### PR TITLE
feat(uiux): consistent pending button states across forms

### DIFF
--- a/PENDING_BUTTON_STATES.md
+++ b/PENDING_BUTTON_STATES.md
@@ -1,0 +1,48 @@
+# Pending Button States
+
+Standardized rules for submit/async action buttons across all forms.
+
+## Component
+
+`src/components/PendingButton.tsx` — use this instead of a raw `<button>` for any form submission or async action.
+
+```tsx
+<PendingButton
+  type="submit"
+  pending={loading}
+  pendingLabel="Saving..."
+  className="..."
+>
+  Save
+</PendingButton>
+```
+
+### Props
+
+| Prop | Type | Description |
+|---|---|---|
+| `pending` | `boolean` | Whether the async action is in progress |
+| `pendingLabel` | `string` | Label shown while pending (e.g. "Signing in...") |
+| `children` | `ReactNode` | Idle label |
+| `disabled` | `boolean` | Additional disabled condition (e.g. form invalid) |
+| `...rest` | `ButtonHTMLAttributes` | All standard button attributes |
+
+## Rules
+
+1. **Spinner placement** — inline, left of label. SVG-based, sized `1em` so it scales with font size.
+2. **No layout shift** — `min-width: max-content` on `.pending-btn` keeps the button width stable between idle and pending states.
+3. **Disabled while pending** — `disabled` and `aria-busy="true"` are set automatically when `pending={true}`. This prevents double-submission.
+4. **Label change** — the visible label changes to `pendingLabel` during submission. Screen readers announce the change via the button's accessible name.
+5. **Reduced motion** — the spinner animation is disabled via `@media (prefers-reduced-motion: reduce)`.
+
+## Covered flows
+
+| Flow | File | Pending label |
+|---|---|---|
+| Login | `LoginPage.tsx` | "Signing in..." |
+| Register | `RegisterPage.tsx` | "Creating Account..." |
+| Forgot password | `ForgotPasswordPage.tsx` | "Sending..." |
+| Reset password | `ResetPasswordPage.tsx` | "Resetting..." |
+| Draw credit confirm | `ConfirmationStep.tsx` | "Processing..." |
+| Repay confirm | `RepayModal.tsx` | "Processing..." |
+| Request evaluation | `RequestEvaluation.tsx` | "Starting..." |

--- a/src/components/ConfirmationStep.tsx
+++ b/src/components/ConfirmationStep.tsx
@@ -2,6 +2,7 @@ import { CreditLine } from "@/types/draw-credit.types";
 import { AlertCircle } from "lucide-react";
 import { useState } from "react";
 import { CreditLineSummaryBlock } from "@/components/CreditLineSummaryBlock";
+import { PendingButton } from "@/components/PendingButton";
 
 interface ConfirmationStepProps {
   creditLine: CreditLine;
@@ -96,13 +97,15 @@ export function ConfirmationStep({
           Back
         </button>
         <div className="sm:flex-1 space-y-2">
-          <button
+          <PendingButton
             onClick={onConfirm}
-            disabled={!agreedToTerms || isLoading}
+            pending={isLoading}
+            pendingLabel="Processing..."
+            disabled={!agreedToTerms}
             className="w-full py-3 px-4 bg-blue-600 text-white rounded-lg hover:bg-blue-500 hover:shadow-lg hover:shadow-blue-500/40 transition-all font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {isLoading ? "Processing..." : "Confirm draw"}
-          </button>
+            Confirm draw
+          </PendingButton>
           {!agreedToTerms && !isLoading && (
             <p className="text-xs text-muted text-center sm:text-right">
               Accept terms to enable confirmation.

--- a/src/components/PendingButton.tsx
+++ b/src/components/PendingButton.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+interface PendingButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  pending: boolean;
+  pendingLabel: string;
+  children: React.ReactNode;
+}
+
+/**
+ * PendingButton — standardized submit/async action button.
+ *
+ * Rules:
+ * - Shows an inline spinner (left of label) while pending; no layout shift.
+ * - Sets disabled + aria-busy=true while pending to prevent double-submission.
+ * - Spinner is aria-hidden; the visible label change communicates state to screen readers.
+ * - Caller controls all styling via className; this component adds no visual opinions.
+ */
+export function PendingButton({
+  pending,
+  pendingLabel,
+  children,
+  disabled,
+  className = '',
+  ...rest
+}: PendingButtonProps) {
+  return (
+    <button
+      {...rest}
+      disabled={pending || disabled}
+      aria-busy={pending}
+      className={`pending-btn ${className}`}
+    >
+      {pending && (
+        <svg
+          className="pending-btn__spinner"
+          aria-hidden="true"
+          viewBox="0 0 16 16"
+          fill="none"
+        >
+          <circle
+            cx="8"
+            cy="8"
+            r="6"
+            stroke="currentColor"
+            strokeOpacity="0.3"
+            strokeWidth="2"
+          />
+          <path
+            d="M14 8a6 6 0 0 0-6-6"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      )}
+      {pending ? pendingLabel : children}
+    </button>
+  );
+}

--- a/src/components/RepayModal.tsx
+++ b/src/components/RepayModal.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useId } from 'react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import { PendingButton } from './PendingButton';
 
 interface RepaymentCreditLine {
   id: string;
@@ -390,9 +391,14 @@ export function RepayModal({
               <button onClick={() => setStep('input')} style={{ ...btn.outline, flex: 1 }}>
                 Back
               </button>
-              <button onClick={handleConfirm} style={{ ...btn.primary, flex: 2 }}>
+              <PendingButton
+                onClick={handleConfirm}
+                pending={false}
+                pendingLabel="Processing..."
+                style={{ ...btn.primary, flex: 2 }}
+              >
                 Confirm Repayment
-              </button>
+              </PendingButton>
             </div>
           </div>
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -285,3 +285,36 @@ body {
   font-size: 0.875rem;
   line-height: 1.45;
 }
+
+/* ── Pending Button ─────────────────────────────────────────────────────── */
+/*
+ * .pending-btn wraps any submit/async button.
+ * The spinner is inline-flex so it sits left of the label without shifting width.
+ * min-width is set on the element so the button doesn't resize between states.
+ */
+.pending-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  /* Prevent width change between idle and pending labels */
+  min-width: max-content;
+}
+
+.pending-btn__spinner {
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+  animation: pending-btn-spin 0.75s linear infinite;
+}
+
+@keyframes pending-btn-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pending-btn__spinner {
+    animation: none;
+    opacity: 0.6;
+  }
+}

--- a/src/pages/ForgotPasswordPage.tsx
+++ b/src/pages/ForgotPasswordPage.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { PasswordResetRequestData, AuthError } from "../types/auth.types";
+import { PendingButton } from "../components/PendingButton";
 
 export function ForgotPasswordPage() {
   const [formData, setFormData] = useState<PasswordResetRequestData>({
@@ -126,13 +127,14 @@ export function ForgotPasswordPage() {
               />
             </div>
 
-            <button
+            <PendingButton
               type="submit"
-              disabled={loading}
+              pending={loading}
+              pendingLabel="Sending..."
               className="w-full bg-[#58a6ff] hover:bg-blue-700 disabled:bg-blue-400 text-white font-medium py-3 rounded-lg transition-colors"
             >
-              {loading ? "Sending..." : "Send Reset Link"}
-            </button>
+              Send Reset Link
+            </PendingButton>
           </form>
 
           <div className="mt-6 text-center">

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { LoginFormData, AuthError } from "../types/auth.types";
+import { PendingButton } from "../components/PendingButton";
 
 export function LoginPage() {
   const navigate = useNavigate();
@@ -125,13 +126,14 @@ export function LoginPage() {
               </Link>
             </div>
 
-            <button
+            <PendingButton
               type="submit"
-              disabled={loading}
+              pending={loading}
+              pendingLabel="Signing in..."
               className="w-full bg-[#58a6ff] hover:bg-blue-700 disabled:bg-blue-400 text-white font-medium py-3 rounded-lg transition-colors"
             >
-              {loading ? "Signing in..." : "Login"}
-            </button>
+              Login
+            </PendingButton>
           </form>
 
           <div className="mt-6 text-center">

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -11,6 +11,7 @@ import {
   getPasswordStrengthColor,
   getPasswordStrengthText,
 } from "../utils/password-strength";
+import { PendingButton } from "../components/PendingButton";
 
 export function RegisterPage() {
   const navigate = useNavigate();
@@ -219,13 +220,14 @@ export function RegisterPage() {
               </label>
             </div>
 
-            <button
+            <PendingButton
               type="submit"
-              disabled={loading}
+              pending={loading}
+              pendingLabel="Creating Account..."
               className="w-full bg-[#58a6ff] hover:bg-blue-700 disabled:bg-blue-400 text-white font-medium py-3 rounded-lg transition-colors"
             >
-              {loading ? "Creating Account..." : "Create Account"}
-            </button>
+              Create Account
+            </PendingButton>
           </form>
 
           <div className="mt-6 text-center">

--- a/src/pages/RequestEvaluation.tsx
+++ b/src/pages/RequestEvaluation.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { FormMessage } from '@/components/FormMessage';
+import { PendingButton } from '@/components/PendingButton';
 
 type Step = 1 | 2 | 3 | 4 | 5;
 type EvalState = 'idle' | 'running' | 'success' | 'rejected' | 'error';
@@ -246,7 +247,14 @@ export function RequestEvaluation() {
               <button style={btn.ghost} onClick={() => { setRevenueFile(null); setHasIdentityBond(false); }}>Clear</button>
               <div style={{ display: 'flex', gap: '0.5rem' }}>
                 <button style={btn.secondary} onClick={() => setStep(1)}>Back</button>
-                <button style={btn.primary} onClick={startEvaluation}>Begin Evaluation</button>
+                <PendingButton
+                  pending={evalState === 'running'}
+                  pendingLabel="Starting..."
+                  onClick={startEvaluation}
+                  style={btn.primary}
+                >
+                  Begin Evaluation
+                </PendingButton>
               </div>
             </div>
           </div>
@@ -332,12 +340,18 @@ export function RequestEvaluation() {
               <button style={btn.secondary} onClick={restartEvaluation}>Try Again</button>
               <div style={{ display: 'flex', gap: '0.5rem' }}>
                 <button style={btn.ghost} onClick={() => navigate('/credit-lines')}>Contact Support</button>
-                <button
-                  style={{ ...btn.primary, opacity: evalState === 'success' && result?.approved && agreeTermsPreviewed ? 1 : 0.5, pointerEvents: evalState === 'success' && result?.approved && agreeTermsPreviewed ? 'auto' as const : 'none' }}
+                <PendingButton
+                  pending={false}
+                  pendingLabel="Accepting..."
+                  disabled={!(evalState === 'success' && result?.approved && agreeTermsPreviewed)}
                   onClick={acceptCreditLine}
+                  style={{
+                    ...btn.primary,
+                    opacity: evalState === 'success' && result?.approved && agreeTermsPreviewed ? 1 : 0.5,
+                  }}
                 >
                   Accept Credit Line
-                </button>
+                </PendingButton>
               </div>
             </div>
           </div>

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -7,6 +7,7 @@ import {
   getPasswordStrengthColor,
   getPasswordStrengthText,
 } from "../utils/password-strength";
+import { PendingButton } from "../components/PendingButton";
 
 export function ResetPasswordPage() {
   const navigate = useNavigate();
@@ -200,13 +201,15 @@ export function ResetPasswordPage() {
               />
             </div>
 
-            <button
+            <PendingButton
               type="submit"
-              disabled={loading || !token}
+              pending={loading}
+              pendingLabel="Resetting..."
+              disabled={!token}
               className="w-full bg-[#58a6ff] hover:bg-blue-700 disabled:bg-blue-400 text-white font-medium py-3 rounded-lg transition-colors"
             >
-              {loading ? "Resetting..." : "Reset Password"}
-            </button>
+              Reset Password
+            </PendingButton>
           </form>
 
           <div className="mt-6 text-center">


### PR DESCRIPTION
- Add PendingButton component: inline spinner, aria-busy, prevents double-submit
- Apply to all form flows: login, register, forgot/reset password, draw, repay, evaluation
- Add spinner CSS to index.css with prefers-reduced-motion support
- Add PENDING_BUTTON_STATES.md documenting the pattern and rules

Closes #87