### PR TITLE
Replace Request Evaluation help hints with accessible tooltips

### DIFF
--- a/src/components/AccessibleTooltip.css
+++ b/src/components/AccessibleTooltip.css
@@ -1,0 +1,69 @@
+.accessible-tooltip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+.accessible-tooltip__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid rgba(88, 166, 255, 0.5);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.accessible-tooltip__trigger:hover,
+.accessible-tooltip__trigger:focus-visible {
+  background: rgba(88, 166, 255, 0.12);
+  border-color: var(--accent);
+}
+
+.accessible-tooltip__content {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  z-index: 20;
+  width: min(260px, calc(100vw - 2rem));
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  font-size: 0.78rem;
+  font-weight: 400;
+  line-height: var(--lh-small);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 4px);
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.accessible-tooltip__content::after {
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  width: 8px;
+  height: 8px;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  content: "";
+  transform: translate(-50%, -4px) rotate(45deg);
+}
+
+.accessible-tooltip:hover .accessible-tooltip__content,
+.accessible-tooltip:focus-within .accessible-tooltip__content {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}

--- a/src/components/AccessibleTooltip.test.tsx
+++ b/src/components/AccessibleTooltip.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AccessibleTooltip } from './AccessibleTooltip';
+
+describe('AccessibleTooltip', () => {
+  it('connects the focusable help trigger to tooltip content', () => {
+    render(<AccessibleTooltip label="Explain this field." />);
+
+    const trigger = screen.getByLabelText('More information');
+    const tooltip = screen.getByRole('tooltip');
+
+    expect(trigger).toHaveAttribute('aria-describedby', tooltip.id);
+    expect(trigger).toHaveAttribute('tabindex', '0');
+    expect(tooltip).toHaveTextContent('Explain this field.');
+  });
+});

--- a/src/components/AccessibleTooltip.tsx
+++ b/src/components/AccessibleTooltip.tsx
@@ -1,0 +1,26 @@
+import { useId } from 'react';
+import './AccessibleTooltip.css';
+
+interface AccessibleTooltipProps {
+  label: string;
+}
+
+export function AccessibleTooltip({ label }: AccessibleTooltipProps) {
+  const tooltipId = useId();
+
+  return (
+    <span className="accessible-tooltip">
+      <span
+        tabIndex={0}
+        className="accessible-tooltip__trigger"
+        aria-label="More information"
+        aria-describedby={tooltipId}
+      >
+        <span aria-hidden="true">i</span>
+      </span>
+      <span id={tooltipId} role="tooltip" className="accessible-tooltip__content">
+        {label}
+      </span>
+    </span>
+  );
+}

--- a/src/pages/RequestEvaluation.tsx
+++ b/src/pages/RequestEvaluation.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { AccessibleTooltip } from '@/components/AccessibleTooltip';
 import { FormMessage } from '@/components/FormMessage';
 import { PendingButton } from '@/components/PendingButton';
 
@@ -220,7 +221,7 @@ export function RequestEvaluation() {
                 <label style={{ display: 'grid', gap: 6 }}>
                   <span style={{ fontSize: '0.85rem', color: COLOR.muted }}>
                     Revenue attestation (PDF/CSV)
-                    <span title="Upload recent revenue statements or attestations to potentially improve your limit and APR." style={{ marginLeft: 6, color: COLOR.accent, cursor: 'help' }}>ⓘ</span>
+                    <AccessibleTooltip label="Upload recent revenue statements or attestations to potentially improve your limit and APR." />
                   </span>
                   <input
                     type="file"
@@ -238,7 +239,7 @@ export function RequestEvaluation() {
                   />
                   <span style={{ color: COLOR.text }}>
                     Link identity bond
-                    <span title="If you’ve posted an identity bond, linking it may improve your risk profile." style={{ marginLeft: 6, color: COLOR.accent, cursor: 'help' }}>ⓘ</span>
+                    <AccessibleTooltip label="If you’ve posted an identity bond, linking it may improve your risk profile." />
                   </span>
                 </label>
               </div>
@@ -312,7 +313,7 @@ export function RequestEvaluation() {
                 <details style={{ border: `1px solid ${COLOR.border}`, borderRadius: 8, padding: '0.75rem 1rem' }} onToggle={e => setAgreeTermsPreviewed((e.target as HTMLDetailsElement).open)}>
                   <summary style={{ cursor: 'pointer', color: COLOR.text, fontWeight: 600 }}>
                     Preview Terms and Conditions
-                    <span title="Review your proposed terms before accepting." style={{ marginLeft: 8, color: COLOR.accent, cursor: 'help' }}>ⓘ</span>
+                    <AccessibleTooltip label="Review your proposed terms before accepting." />
                   </summary>
                   <ul style={{ margin: '0.5rem 0 0', paddingLeft: '1.2rem', color: COLOR.muted }}>
                     <li>Variable APR based on ongoing risk score updates</li>


### PR DESCRIPTION
## Summary

- Adds a reusable `AccessibleTooltip` component with a focusable trigger, `aria-describedby`, and `role="tooltip"` content.
- Replaces the Request Evaluation native `title` / `cursor: help` / `ⓘ` hints with the accessible tooltip component.
- Adds a component test covering the trigger-to-tooltip ARIA relationship.

## Verification

- `npm.cmd test -- AccessibleTooltip --run`

Notes:

- `.\node_modules\.bin\vite.cmd build` is currently blocked on current `main` by an unrelated syntax error in `src/components/WalletConnectionModal.tsx`.
- `npm.cmd run build` is currently blocked by existing unrelated TypeScript/syntax errors before this change is evaluated.
- `npm.cmd run lint` is currently blocked because `eslint` is not installed in the repo dependencies.

Closes #124