### PR TITLE
feat: default-risk education before first borrow

### DIFF
--- a/.kiro/specs/default-risk-education-flow/.config.kiro
+++ b/.kiro/specs/default-risk-education-flow/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "393b14e9-59e5-4746-b2f4-8e8b8efcf19a", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/default-risk-education-flow/requirements.md
+++ b/.kiro/specs/default-risk-education-flow/requirements.md
@@ -1,0 +1,149 @@
+# Requirements Document
+
+## Introduction
+
+The default-risk education flow is a pre-borrow gate for the GrantFox campaign. Before a first-time borrower can complete a draw on the `/draw-credit` page, they must read and acknowledge a 3-step modal that explains the consequences of defaulting on a credit line. The modal blocks the draw flow until explicitly dismissed. It re-surfaces whenever the page is loaded with the `?learn=1` query parameter, allowing support links, help center articles, and campaign materials to force the education flow for any returning user who needs a refresher.
+
+The feature must integrate cleanly with the existing `useFocusTrap`, `useBodyScrollLock`, and `useInertBackdrop` hooks already present in the codebase, follow the Creditra design token system, and ship with full test coverage.
+
+## Glossary
+
+- **Risk_Education_Modal**: The 3-step modal dialog that explains default consequences to a borrower before their first draw.
+- **Draw_Flow**: The multi-step credit draw sequence on `/draw-credit`, implemented in `DrawCreditPage`.
+- **First-Time_Borrower**: A user for whom the key `grantfox_risk_education_acknowledged` is absent or set to `false` in `localStorage`.
+- **Acknowledged_State**: The state recorded in `localStorage` under `grantfox_risk_education_acknowledged` after a borrower completes all three steps and confirms.
+- **Learn_Param**: The URL query parameter `?learn=1` that forces the Risk_Education_Modal to open regardless of the Acknowledged_State.
+- **Step_Indicator**: The visual progress dots shown inside the modal representing the three content steps.
+- **Focus_Trap**: The keyboard-focus containment mechanism provided by `useFocusTrap` that keeps Tab and Shift+Tab cycling within the modal while it is open.
+- **GrantFox_Campaign**: The credit campaign context within which this education flow is required.
+- **Storage_Util**: The `readJson` / `writeJson` helpers in `src/utils/storage.ts` used for all `localStorage` access.
+
+## Requirements
+
+### Requirement 1: Gate the Draw Flow for First-Time Borrowers
+
+**User Story:** As a first-time GrantFox borrower, I want to see a clear explanation of default consequences before I borrow, so that I can make an informed decision about taking on credit.
+
+#### Acceptance Criteria
+
+1. WHEN a user navigates to `/draw-credit` and the Acknowledged_State is absent or `false`, THE Risk_Education_Modal SHALL render before any Draw_Flow step is visible.
+2. WHEN the Risk_Education_Modal is open, THE Draw_Flow SHALL be non-interactive and hidden from assistive technology until the modal is dismissed.
+3. WHEN a user navigates to `/draw-credit` and the Acknowledged_State is `true` and the URL does not contain `?learn=1`, THE Risk_Education_Modal SHALL NOT render, and the Draw_Flow SHALL be immediately accessible.
+
+---
+
+### Requirement 2: Three-Step Educational Content
+
+**User Story:** As a first-time borrower, I want to read through three focused screens of default-risk information, so that I understand the full picture before proceeding.
+
+#### Acceptance Criteria
+
+1. THE Risk_Education_Modal SHALL contain exactly three sequential steps: (1) What is a Default, (2) Consequences of Default, (3) How to Avoid Default.
+2. WHEN the modal is on step 1 or step 2, THE Risk_Education_Modal SHALL display a "Next" button that advances to the following step.
+3. WHEN the modal is on step 2 or step 3, THE Risk_Education_Modal SHALL display a "Back" button that returns to the previous step.
+4. WHEN the modal is on step 1, THE Risk_Education_Modal SHALL render the "Back" button in a disabled state.
+5. WHEN the modal is on step 3, THE Risk_Education_Modal SHALL replace the "Next" button label with "I Understand – Proceed".
+6. THE Risk_Education_Modal SHALL display a Step_Indicator showing the current step position and total step count at all times.
+7. THE Risk_Education_Modal SHALL announce the current step to assistive technology via an `aria-live="polite"` region.
+
+---
+
+### Requirement 3: Block Completion Until All Steps Are Acknowledged
+
+**User Story:** As a product owner, I want borrowers to read through all three steps before proceeding, so that no user can skip the educational content.
+
+#### Acceptance Criteria
+
+1. WHEN the modal is on step 1 or step 2, THE Risk_Education_Modal SHALL NOT render a final confirmation action that closes the modal and unblocks the Draw_Flow.
+2. WHEN the user activates "I Understand – Proceed" on step 3, THE Risk_Education_Modal SHALL write `true` to `localStorage` under the key `grantfox_risk_education_acknowledged` using the Storage_Util `writeJson` helper.
+3. WHEN the user activates "I Understand – Proceed" on step 3, THE Risk_Education_Modal SHALL close and the Draw_Flow SHALL become interactive.
+4. IF the Storage_Util `writeJson` call fails silently (quota exceeded, private mode), THEN THE Risk_Education_Modal SHALL still close and the Draw_Flow SHALL still unblock, accepting that the acknowledgement will not persist.
+
+---
+
+### Requirement 4: Re-Show on `?learn=1` Query Parameter
+
+**User Story:** As a support agent, I want to link borrowers back to the education flow using `?learn=1`, so that I can give returning users a refresher without requiring them to clear their browser data.
+
+#### Acceptance Criteria
+
+1. WHEN a user navigates to `/draw-credit?learn=1` and the Acknowledged_State is `true`, THE Risk_Education_Modal SHALL open and display from step 1.
+2. WHEN a user navigates to `/draw-credit?learn=1` and the Acknowledged_State is `false` or absent, THE Risk_Education_Modal SHALL open and display from step 1.
+3. WHEN the modal opened via `?learn=1` is completed, THE Draw_Flow page SHALL update the URL by removing the `?learn=1` parameter without adding a browser history entry.
+4. WHEN the modal opened via `?learn=1` is completed, THE Risk_Education_Modal SHALL write `true` to `localStorage` under `grantfox_risk_education_acknowledged`.
+
+---
+
+### Requirement 5: Keyboard Accessibility and Focus Trap
+
+**User Story:** As a keyboard-only user, I want focus to be contained within the modal while it is open, so that I cannot accidentally interact with background content.
+
+#### Acceptance Criteria
+
+1. WHEN the Risk_Education_Modal opens, THE Risk_Education_Modal SHALL move keyboard focus to the first focusable element inside the dialog using the `useFocusTrap` hook.
+2. WHILE the Risk_Education_Modal is open, THE Risk_Education_Modal SHALL cycle keyboard focus between interactive elements inside the dialog when the user presses Tab or Shift+Tab, preventing focus from leaving the modal.
+3. WHILE the Risk_Education_Modal is open, THE Risk_Education_Modal SHALL lock body scroll using the `useBodyScrollLock` hook.
+4. WHILE the Risk_Education_Modal is open, THE Risk_Education_Modal SHALL mark background content as inert using the `useInertBackdrop` hook with the modal element's id.
+5. WHEN the Risk_Education_Modal closes, THE Risk_Education_Modal SHALL return keyboard focus to the element that had focus before the modal opened.
+6. THE Risk_Education_Modal SHALL NOT close on Escape key press, because acknowledgement of all three steps is required before the Draw_Flow is unblocked.
+
+---
+
+### Requirement 6: Visible Focus Ring
+
+**User Story:** As a keyboard or switch-access user, I want a clearly visible focus indicator on all interactive elements inside the modal, so that I always know which element I am about to activate.
+
+#### Acceptance Criteria
+
+1. WHEN a button inside the Risk_Education_Modal receives keyboard focus, THE Risk_Education_Modal SHALL display a `2px solid` focus ring using the `--accent` CSS custom property (`#58a6ff`) with `outline-offset: 2px`, matching the global `:focus-visible` rule in `src/index.css`.
+2. THE Risk_Education_Modal SHALL use the `:focus-visible` pseudo-class so that the focus ring does not appear for mouse or touch interactions.
+3. WHEN the "Back" button is in a disabled state on step 1, THE Risk_Education_Modal SHALL suppress the focus ring on that element and set `tabindex="-1"` to remove it from the tab order entirely.
+
+---
+
+### Requirement 7: ARIA Semantics and Screen Reader Support
+
+**User Story:** As a screen reader user, I want the modal to be correctly identified as a dialog with a labelled title, so that my assistive technology announces the correct context when the modal opens.
+
+#### Acceptance Criteria
+
+1. THE Risk_Education_Modal SHALL render the dialog container with `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` pointing to the modal's visible title element.
+2. THE Risk_Education_Modal SHALL include an `aria-describedby` attribute on the dialog container pointing to the step description paragraph for the current step.
+3. WHEN the step content changes, THE Risk_Education_Modal SHALL update the `aria-describedby` reference to reflect the new step's description.
+4. THE Step_Indicator SHALL include an `aria-label` on each dot indicating its step number and whether it is complete, current, or upcoming (e.g., "Step 2 of 3 – current").
+5. THE Risk_Education_Modal SHALL set `aria-disabled="true"` and `tabindex="-1"` on the "Back" button when it is in the disabled state on step 1.
+
+---
+
+### Requirement 8: Persistence via localStorage
+
+**User Story:** As a returning borrower, I want the modal to be skipped on subsequent visits once I have completed it, so that I am not interrupted every time I draw credit.
+
+#### Acceptance Criteria
+
+1. THE Risk_Education_Modal SHALL read the Acknowledged_State from `localStorage` key `grantfox_risk_education_acknowledged` using the Storage_Util `readJson` helper with a fallback of `false`.
+2. WHEN the Acknowledged_State is `true` and the Learn_Param is absent, THE Risk_Education_Modal SHALL not mount, keeping the component tree lightweight.
+3. THE Risk_Education_Modal SHALL write the Acknowledged_State through the Storage_Util `writeJson` helper only after the user activates the final confirmation action on step 3.
+4. FOR ALL storage read calls, THE Risk_Education_Modal SHALL handle storage unavailability (private browsing, quota exceeded) by treating the result as if the acknowledgement has not been given, showing the modal.
+
+---
+
+### Requirement 9: Animation and Motion Sensitivity
+
+**User Story:** As a user with vestibular disorders, I want the modal to respect my operating system's reduced-motion preference, so that step transitions do not cause discomfort.
+
+#### Acceptance Criteria
+
+1. THE Risk_Education_Modal SHALL animate step transitions using `framer-motion`'s `AnimatePresence` and `motion.div`, matching the existing pattern in `OnboardingFlow.tsx`.
+2. WHERE the user has enabled `prefers-reduced-motion: reduce`, THE Risk_Education_Modal SHALL suppress slide and fade animations on step transitions, matching the `@media (prefers-reduced-motion: reduce)` block in `OnboardingFlow.css`.
+
+---
+
+### Requirement 10: Round-Trip Persistence Integrity
+
+**User Story:** As a QA engineer, I want to verify that the acknowledgement flag written to localStorage is readable back as the same value, so that I can confirm the gate logic is reliable across page loads.
+
+#### Acceptance Criteria
+
+1. FOR ALL valid acknowledgement writes, reading `grantfox_risk_education_acknowledged` from `localStorage` using the Storage_Util `readJson` helper SHALL return `true` immediately after the write.
+2. FOR ALL valid acknowledgement writes, reloading the page at `/draw-credit` with no `?learn=1` param SHALL result in the Risk_Education_Modal not rendering (round-trip gate test).

--- a/.kiro/specs/default-risk-education-modal/requirements.md
+++ b/.kiro/specs/default-risk-education-modal/requirements.md
@@ -1,0 +1,145 @@
+# Requirements Document
+
+## Introduction
+
+**Feature:** Default-Risk Education Modal  
+**Campaign:** GrantFox  
+**Type:** UI/UX feature — first-time borrower gate
+
+First-time borrowers must see a 3-step modal that explains default consequences before they can complete a draw. The modal blocks the draw flow until the user explicitly acknowledges all three steps. It can also be re-triggered at any time via the `?learn=1` URL query parameter.
+
+First-time borrowers must see a 3-step modal that explains default consequences before they can complete a draw. The modal blocks the draw flow until the user explicitly acknowledges all three steps. It can also be re-triggered at any time via the `?learn=1` URL query parameter.
+
+---
+
+## Requirements
+
+### 1 — 3-Step Modal Content
+
+**REQ-1.1** The modal must contain exactly three steps presented in fixed order:
+
+| Step | Title | Purpose |
+|------|-------|---------|
+| 1 | What is a Default? | Define default in plain language |
+| 2 | Consequences of Default | Enumerate specific consequences (score impact, line suspension, collections) |
+| 3 | How to Avoid Default | Actionable guidance (repay on time, monitor utilization, contact support) |
+
+**REQ-1.2** Each step must display: a step title, a body paragraph, and a contextual icon.
+
+**REQ-1.3** A step-indicator strip (1 / 2 / 3) must be visible at all times showing the current position, completed steps (checkmark), and upcoming steps. The strip must be announced to screen readers via `aria-current="step"`.
+
+**REQ-1.4** Navigation must support Back (disabled on step 1) and Next (labeled "I Understand" on step 3). There must be no Skip affordance — the user must read through all steps.
+
+**REQ-1.5** Animated step transitions must use `framer-motion` `AnimatePresence` (slide left/right), consistent with `OnboardingFlow.tsx`. Motion must be suppressed under `prefers-reduced-motion: reduce`.
+
+---
+
+### 2 — Flow Blocking
+
+**REQ-2.1** The modal must render at the very beginning of `DrawCreditPage` — before step `"select"` is displayed — when either of the trigger conditions in REQ-3 is true.
+
+**REQ-2.2** While the modal is open the underlying draw-wizard content must not be reachable by pointer, keyboard, or assistive technology. Specifically:
+- `useInertBackdrop` must mark all non-modal DOM nodes as `inert`.
+- `useBodyScrollLock` must prevent body scroll.
+- Backdrop click must NOT close the modal (acknowledgement is mandatory).
+- Escape key must NOT close the modal.
+
+**REQ-2.3** The "I Understand" button on step 3 is the only affordance that closes the modal and advances the user into the draw flow.
+
+---
+
+### 3 — Trigger Conditions
+
+**REQ-3.1 — First-time gate:** The modal must be shown when the localStorage key `creditra.default_risk_ack` is absent or falsy. After the user completes step 3 and clicks "I Understand", `creditra.default_risk_ack` must be written via `writeJson` (from `src/utils/storage.ts`) so the modal is not shown again on subsequent visits.
+
+**REQ-3.2 — Learn mode:** The modal must also be shown when the URL contains the query parameter `?learn=1`, regardless of the localStorage value. Use `useSearchParams` from `react-router-dom` to read this param. When the modal is dismissed in learn mode, the `?learn=1` param must be removed from the URL (replace, no history entry) but the localStorage key must NOT be overwritten.
+
+**REQ-3.3** Both trigger conditions are evaluated on mount; if neither applies the modal must not render.
+
+---
+
+### 4 — Accessibility
+
+**REQ-4.1 — Dialog role:** The modal container must have `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing to the current step title, and `aria-describedby` pointing to the current step body.
+
+**REQ-4.2 — Focus trap:** `useFocusTrap` (from `src/hooks/useFocusTrap.ts`) must be active while the modal is open. On open, focus must move to the first focusable element (Back or Next button). On close, focus must return to the element that triggered the draw flow (triggerRef pattern).
+
+**REQ-4.3 — Visible focus ring:** All interactive elements (Back, Next/I Understand, step indicators if interactive) must display a `2px solid var(--accent)` outline on `:focus-visible`, inherited from the global rule in `src/index.css`. No custom override may suppress this.
+
+**REQ-4.4 — Live region:** Step transitions must announce the new step title to screen readers via an `aria-live="polite"` region.
+
+**REQ-4.5 — Keyboard navigation:** Tab and Shift+Tab must cycle only within the modal. Escape must produce no action (modal is mandatory — see REQ-2.2).
+
+---
+
+### 5 — Implementation Constraints
+
+**REQ-5.1** The component must be implemented as `src/components/DefaultRiskModal.tsx` with a companion `DefaultRiskModal.css`. Inline styles are permitted only for dynamic values (token-derived colors); all structural styles must live in the CSS file.
+
+**REQ-5.2** The component must accept these props:
+```ts
+interface DefaultRiskModalProps {
+  isOpen: boolean;
+  onAcknowledge: () => void;
+  triggerRef?: React.RefObject<HTMLElement | null>;
+}
+```
+
+**REQ-5.3** Trigger logic (localStorage check + `?learn=1` detection) must live in `DrawCreditPage`, not inside the modal component itself. The modal is a pure presentational/interaction component.
+
+**REQ-5.4** The `writeJson` / `readJson` utilities from `src/utils/storage.ts` must be used for all localStorage access — no raw `localStorage.setItem` / `getItem` calls.
+
+**REQ-5.5** The localStorage key must be the string constant `'creditra.default_risk_ack'` defined as a named export from a new file `src/constants/storageKeys.ts`.
+
+---
+
+### 6 — Testing
+
+**REQ-6.1** A test file `src/components/DefaultRiskModal.test.tsx` must cover:
+- Modal renders when `isOpen` is true.
+- Modal does not render when `isOpen` is false.
+- Back button is disabled on step 1.
+- Clicking Next advances from step 1 → 2 → 3.
+- "I Understand" button appears only on step 3.
+- `onAcknowledge` is called when "I Understand" is clicked.
+- Escape key press does not call `onAcknowledge` and does not close the modal.
+- Backdrop click does not call `onAcknowledge`.
+- `aria-current="step"` is set on the active step indicator.
+- Focus is present within the modal when open.
+
+**REQ-6.2** A test file `src/pages/DrawCreditPage.test.tsx` (or augment existing) must cover:
+- Modal is shown when `creditra.default_risk_ack` is absent from localStorage.
+- Modal is NOT shown when `creditra.default_risk_ack` is `true` in localStorage.
+- Modal IS shown when URL contains `?learn=1` even if localStorage key is set.
+- Acknowledging the modal sets `creditra.default_risk_ack` in localStorage.
+- Acknowledging in `?learn=1` mode removes the query param but does not re-write localStorage.
+
+---
+
+### 7 — Documentation
+
+**REQ-7.1** A JSDoc block at the top of `DefaultRiskModal.tsx` must document: purpose, props, trigger conditions, WCAG 2.1 AA criteria satisfied (2.1.2, 2.4.3, 4.1.2, 1.4.1).
+
+**REQ-7.2** `docs/UX_RATIONALE.md` must be updated with a section explaining why the modal is non-dismissible (user protection / GrantFox campaign requirement) and the `?learn=1` re-trigger mechanism.
+
+---
+
+## Out of Scope
+
+- Backend persistence of acknowledgement (localStorage only for now).
+- Multi-language / i18n support.
+- Analytics/event tracking for modal completion.
+- Any change to the draw wizard steps themselves.
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| Default | Failure to repay a drawn credit line per the agreed terms, resulting in account suspension and credit score impact. |
+| Draw | A borrowing action — withdrawing funds from an approved credit line. |
+| First-time borrower | A user who has never completed a draw on the Creditra platform (no prior `creditra.default_risk_ack` localStorage key). |
+| Learn mode | A mode triggered by the `?learn=1` URL query parameter that re-shows the education modal regardless of prior acknowledgement. |
+| Focus trap | A keyboard interaction pattern that constrains Tab/Shift+Tab focus cycling to within a modal dialog. |
+| `creditra.default_risk_ack` | The localStorage key written after a user completes the education modal. |


### PR DESCRIPTION
CLose: #230
What's captured:

3-step modal content (REQ-1) Steps are fixed: "What is a Default?" → "Consequences of Default" → "How to Avoid Default". Step indicator strip with aria-current="step", no skip button, animated transitions via framer-motion matching the existing OnboardingFlow pattern.

Flow blocking (REQ-2) Modal mounts before the draw wizard's "select" step. Backdrop click and Escape are both inert — acknowledgement is mandatory. Uses all three existing accessibility hooks: useFocusTrap, useBodyScrollLock, useInertBackdrop.

Trigger conditions (REQ-3)

First visit: creditra.default_risk_ack absent in localStorage → show modal, write key on acknowledge.
?learn=1 in URL → always show, strip the param on dismiss but don't re-write the key.
Trigger logic lives in DrawCreditPage, not in the modal itself.
Accessibility (REQ-4) role="dialog", aria-modal, focus trap, visible var(--accent) focus ring, aria-live="polite" step announcer, Escape suppressed.

Implementation constraints (REQ-5) New files: 
DefaultRiskModal.tsx
, DefaultRiskModal.css, 
storageKeys.ts
. Props interface defined. readJson/writeJson from 
storage.ts
 for all storage access.

Testing (REQ-6) 10 test cases for the modal component, 5 for the DrawCreditPage trigger logic.

Documentation (REQ-7) JSDoc block with WCAG criteria, 
UX_RATIONALE.md
 update explaining the non-dismissible design.
