### PR TITLE
feat: env-var threshold and focus ring for large-repayment guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,14 @@ npm run lint       # eslint .
 ### Environment
 
 ```env
-VITE_API_URL=http://localhost:3000     # backend base URL, read via import.meta.env
+VITE_API_URL=http://localhost:3000          # backend base URL, read via import.meta.env
+VITE_REPAY_CONFIRM_THRESHOLD=5000           # USD amount above which repayments require typed confirmation (default: 5000)
 ```
+
+`VITE_REPAY_CONFIRM_THRESHOLD` controls the typed-amount guard in the repayment flow.
+When a repayment amount meets or exceeds this value, the review step shows a confirmation
+input where the user must type the exact amount before the "Confirm Repayment" button
+enables. Set to `0` to disable the guard entirely (not recommended for production).
 
 ---
 

--- a/src/components/RepayModal.tsx
+++ b/src/components/RepayModal.tsx
@@ -246,6 +246,7 @@ export function RepayModal({
                   placeholder="0.00"
                   aria-invalid={validation.feedback.severity === 'danger'}
                   aria-describedby={describedBy}
+                  className="repay-modal-input"
                   style={{
                     width: '100%',
                     background: COLOR.bg,
@@ -255,7 +256,6 @@ export function RepayModal({
                     color: COLOR.text,
                     fontSize: '1.25rem',
                     fontWeight: 500,
-                    outline: 'none',
                     boxShadow: amount > 0 && validation.feedback.severity !== 'danger' ? '0 0 0 2px rgba(88,166,255,0.1)' : 'none',
                     transition: 'all 0.2s',
                   }}
@@ -468,7 +468,9 @@ export function RepayModal({
                     onChange={(e) => setConfirmAmountStr(e.target.value)}
                     placeholder={fmt(amount)}
                     aria-describedby="confirm-repay-description"
+                    aria-label="Type the repayment amount to confirm"
                     autoComplete="off"
+                    className="repay-modal-input"
                     style={{
                       width: '100%',
                       background: COLOR.bg,
@@ -478,7 +480,6 @@ export function RepayModal({
                       color: COLOR.text,
                       fontSize: '1.25rem',
                       fontWeight: 500,
-                      outline: 'none',
                       transition: 'all 0.2s',
                     }}
                   />
@@ -630,6 +631,9 @@ export function RepayModal({
         @keyframes slideUp { from { opacity: 0; transform: translateY(20px); } to { opacity: 1; transform: translateY(0); } }
         @keyframes spin { to { transform: rotate(360deg); } }
         @keyframes scaleIn { 0% { transform: scale(0); } 60% { transform: scale(1.1); } 100% { transform: scale(1); } }
+        /* Suppress default outline for pointer users; show a visible ring for keyboard users (WCAG 2.4.7). */
+        .repay-modal-input { outline: none; }
+        .repay-modal-input:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; }
       `}</style>
       <InlineHelpOverlay
         isOpen={isHelpOpen}

--- a/src/utils/amountValidation.test.ts
+++ b/src/utils/amountValidation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   getDrawAmountValidation,
   getRepayAmountValidation,
@@ -45,8 +45,38 @@ describe('getRepayAmountValidation', () => {
 });
 
 describe('REPAY_CONFIRM_THRESHOLD', () => {
-  it('defaults to 5000', () => {
+  it('defaults to 5000 when VITE_REPAY_CONFIRM_THRESHOLD is not set', () => {
     expect(REPAY_CONFIRM_THRESHOLD).toBe(5000);
+  });
+
+  it('reads a custom value from VITE_REPAY_CONFIRM_THRESHOLD', async () => {
+    vi.stubEnv('VITE_REPAY_CONFIRM_THRESHOLD', '1000');
+    vi.resetModules();
+    const { REPAY_CONFIRM_THRESHOLD: threshold } = await import('./amountValidation');
+    expect(threshold).toBe(1000);
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('falls back to 5000 when VITE_REPAY_CONFIRM_THRESHOLD is not a valid number', async () => {
+    vi.stubEnv('VITE_REPAY_CONFIRM_THRESHOLD', 'not-a-number');
+    vi.resetModules();
+    const { REPAY_CONFIRM_THRESHOLD: threshold } = await import('./amountValidation');
+    expect(threshold).toBe(5000);
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('accepts 0 to disable the guard', async () => {
+    vi.stubEnv('VITE_REPAY_CONFIRM_THRESHOLD', '0');
+    vi.resetModules();
+    const { REPAY_CONFIRM_THRESHOLD: threshold, requiresRepayConfirmation: requires } =
+      await import('./amountValidation');
+    expect(threshold).toBe(0);
+    // When threshold is 0 the guard is disabled; no amount triggers confirmation.
+    expect(requires(10000)).toBe(false);
+    vi.unstubAllEnvs();
+    vi.resetModules();
   });
 });
 

--- a/src/utils/amountValidation.ts
+++ b/src/utils/amountValidation.ts
@@ -52,12 +52,15 @@ const MIN_AMOUNT = 1;
  * Threshold above which repayments require the user to type the exact amount
  * in a confirmation field before the "Confirm Repayment" button enables.
  *
- * Set to `0` or a negative value to disable the confirm-by-typing guard
- * entirely across the entire application.
- *
- * Configurable — update this value to change the threshold globally.
+ * Driven by the VITE_REPAY_CONFIRM_THRESHOLD environment variable (a plain
+ * non-negative number). Falls back to 5 000 when the variable is absent or
+ * cannot be parsed. Set the variable to "0" to disable the guard entirely.
  */
-export const REPAY_CONFIRM_THRESHOLD = 5000;
+export const REPAY_CONFIRM_THRESHOLD = (() => {
+  const raw = import.meta.env.VITE_REPAY_CONFIRM_THRESHOLD;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 5000;
+})();
 
 /**
  * Returns `true` when `amount` meets or exceeds `REPAY_CONFIRM_THRESHOLD`,


### PR DESCRIPTION
Closes #271

## Summary

- **Env-var threshold** — `REPAY_CONFIRM_THRESHOLD` in `src/utils/amountValidation.ts` now reads from `VITE_REPAY_CONFIRM_THRESHOLD` (falls back to 5 000). Set to `0` to disable the guard entirely. Previously it was hardcoded, preventing operators from tuning the value without a code change.
- **Visible focus ring** — Removed `outline: none` from both the amount input and the confirmation input in `RepayModal.tsx`. Replaced with a `.repay-modal-input` CSS class and `:focus-visible` ring (`2px solid #58a6ff`, 2 px offset), satisfying WCAG 2.1 AA Success Criterion 2.4.7 (Focus Visible). Pointer users are unaffected; keyboard and assistive-technology users get a clear indicator.
- **Screen-reader label** — Added `aria-label="Type the repayment amount to confirm"` to the confirmation input so screen readers announce its purpose unambiguously.
- **Tests** — Extended `amountValidation.test.ts` with three new cases (custom env value, invalid env value, `0` to disable) using `vi.stubEnv` + `vi.resetModules` for clean isolation.
- **README** — Documented `VITE_REPAY_CONFIRM_THRESHOLD` in the Environment section.

## Files changed

| File | Change |
|---|---|
| `src/utils/amountValidation.ts` | Threshold now driven by `VITE_REPAY_CONFIRM_THRESHOLD` env var |
| `src/components/RepayModal.tsx` | Focus ring via `.repay-modal-input:focus-visible`; `aria-label` on confirm input |
| `src/utils/amountValidation.test.ts` | 3 new env-var threshold tests |
| `README.md` | Env var documented |

## Test plan

- [ ] Repayment below threshold (e.g. $4 999) → proceeds to review without typed-confirmation field
- [ ] Repayment at or above threshold (e.g. $5 000) → review step shows "Type the amount to confirm" input; Confirm button disabled until exact amount typed
- [ ] Tab into either input and confirm a blue focus ring appears
- [ ] Set `VITE_REPAY_CONFIRM_THRESHOLD=1000` in `.env.local` → guard triggers at $1 000+
- [ ] Set `VITE_REPAY_CONFIRM_THRESHOLD=0` → guard never appears
- [ ] `npm test -- --run` → 98 tests pass, same 3 pre-existing failures, no regressions