### PR TITLE
feat: toast severity icons, role=status per severity, and useToast hook

### DIFF
--- a/src/components/notifications/ToastContainer.test.tsx
+++ b/src/components/notifications/ToastContainer.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { NotificationProvider } from '../../context/NotificationContext';
+import { ToastContainer } from './ToastContainer';
+import { useToast } from '../../hooks/useToast';
+
+// Helper wrapper: mounts ToastContainer inside the provider and exposes
+// the useToast hook so individual tests can fire toasts.
+function TestHarness({
+  onMount,
+}: {
+  onMount?: (toast: ReturnType<typeof useToast>) => void;
+}) {
+  const toast = useToast();
+  if (onMount) onMount(toast);
+  return <ToastContainer />;
+}
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(<NotificationProvider>{ui}</NotificationProvider>);
+}
+
+describe('ToastContainer', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.runAllTimers(); vi.useRealTimers(); });
+
+  // ─── Severity icons ────────────────────────────────────────────────────────
+
+  it('renders an SVG severity icon for each toast', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+
+    act(() => {
+      toastFns.success('S', 'success');
+      toastFns.error('E', 'error');
+      toastFns.warning('W', 'warning');
+      toastFns.info('I', 'info');
+    });
+
+    const icons = document.querySelectorAll('.toast-type-icon svg');
+    expect(icons.length).toBe(4);
+  });
+
+  it('marks the icon badge as aria-hidden so AT uses the title instead', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.success('Done', 'Saved.'); });
+
+    const badge = document.querySelector('.toast-type-icon');
+    expect(badge).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  // ─── role="status" for non-urgent types ───────────────────────────────────
+
+  it('gives success toasts role="status" and aria-live="polite"', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.success('Done', 'All good.'); });
+
+    const toast = document.querySelector('.toast-item');
+    expect(toast).toHaveAttribute('role', 'status');
+    expect(toast).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('gives info toasts role="status"', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.info('FYI', 'Note.'); });
+
+    expect(document.querySelector('.toast-item')).toHaveAttribute('role', 'status');
+  });
+
+  it('gives warning toasts role="status"', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.warning('Caution', 'Low balance.'); });
+
+    expect(document.querySelector('.toast-item')).toHaveAttribute('role', 'status');
+  });
+
+  // ─── role="alert" for urgent types ────────────────────────────────────────
+
+  it('gives error toasts role="alert" and aria-live="assertive"', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.error('Failed', 'Could not connect.'); });
+
+    const toast = document.querySelector('.toast-item');
+    expect(toast).toHaveAttribute('role', 'alert');
+    expect(toast).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  // ─── Theme colors ──────────────────────────────────────────────────────────
+
+  it('applies the success theme color to the icon badge', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.success('OK', 'Saved.'); });
+
+    const badge = document.querySelector('.toast-type-icon') as HTMLElement;
+    // TYPE_COLOR.success.icon = '#3fb950'
+    expect(badge.style.color).toMatch(/3fb950|rgb\(63,\s*185,\s*80\)/i);
+  });
+
+  it('applies the error theme color to the icon badge', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.error('Oops', 'Broke.'); });
+
+    const badge = document.querySelector('.toast-type-icon') as HTMLElement;
+    // TYPE_COLOR.error.icon = '#f85149'
+    expect(badge.style.color).toMatch(/f85149|rgb\(248,\s*81,\s*73\)/i);
+  });
+
+  it('applies a left accent border colored by severity', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.error('Err', 'Bad.'); });
+
+    const item = document.querySelector('.toast-item') as HTMLElement;
+    // Should have a non-transparent left border (error color = #f85149)
+    expect(item.style.borderLeft).toContain('4px solid');
+  });
+
+  // ─── Container role ────────────────────────────────────────────────────────
+
+  it('wraps all toasts in a log region labelled "Notifications"', () => {
+    renderWithProvider(<TestHarness />);
+    const log = screen.getByRole('log', { name: /notifications/i });
+    expect(log).toBeInTheDocument();
+  });
+
+  // ─── Dismiss ───────────────────────────────────────────────────────────────
+
+  it('removes the toast after clicking dismiss', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.info('Hello', 'World.'); });
+
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss notification/i }));
+    act(() => { vi.advanceTimersByTime(400); });
+
+    expect(screen.queryByText('Hello')).not.toBeInTheDocument();
+  });
+
+  // ─── Edge cases ────────────────────────────────────────────────────────────
+
+  it('caps the toast stack at 5 items', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => {
+      for (let i = 0; i < 7; i++) {
+        toastFns.info(`Toast ${i}`, 'msg');
+      }
+    });
+
+    expect(document.querySelectorAll('.toast-item').length).toBeLessThanOrEqual(5);
+  });
+
+  it('renders an action button when an action is provided', () => {
+    const onAction = vi.fn();
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => {
+      toastFns.info('With action', 'Click below.', {
+        action: { label: 'View details', onClick: onAction },
+      });
+    });
+
+    expect(screen.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/notifications/ToastContainer.tsx
+++ b/src/components/notifications/ToastContainer.tsx
@@ -42,21 +42,33 @@ function ToastItem({
     return () => clearInterval(interval);
   }, [toast.persistent, duration]);
 
+  /*
+   * Role semantics:
+   *   role="alert"  (aria-live="assertive") — interrupts the user immediately;
+   *                 reserved for errors and danger states.
+   *   role="status" (aria-live="polite")    — waits for idle; used for success,
+   *                 info, and warning toasts that do not require urgent attention.
+   * WCAG 4.1.3: Status Messages.
+   */
+  const isUrgent = toast.type === "error" || toast.type === "danger";
+
   return (
     <div
       className={`toast-item ${visible ? "toast-enter" : ""} ${leaving ? "toast-leave" : ""}`}
-      style={{ borderColor: colors.border }}
-      role="alert"
-      aria-live={
-        toast.type === "error" || toast.type === "danger"
-          ? "assertive"
-          : "polite"
-      }
+      style={{
+        borderColor: colors.border,
+        /* Left accent bar communicates severity via color in addition to the icon. */
+        borderLeft: `4px solid ${colors.icon}`,
+      }}
+      role={isUrgent ? "alert" : "status"}
+      aria-live={isUrgent ? "assertive" : "polite"}
     >
       <div className="toast-header">
+        {/* Icon is decorative alongside the title; suppress it for AT. */}
         <span
           className="toast-type-icon"
           style={{ background: colors.bg, color: colors.icon }}
+          aria-hidden="true"
         >
           {TYPE_ICON[toast.type]}
         </span>
@@ -98,7 +110,9 @@ export function ToastContainer() {
   const { toasts, dismissToast } = useNotifications();
 
   return (
-    <div className="toast-container" aria-label="Notifications">
+    /* role="log" marks this region as an ordered sequence of status messages
+       so AT users can revisit the list without losing their reading position. */
+    <div className="toast-container" role="log" aria-label="Notifications" aria-live="polite">
       {toasts.map((toast) => (
         <ToastItem key={toast.id} toast={toast} onDismiss={dismissToast} />
       ))}

--- a/src/components/notifications/notificationIcons.tsx
+++ b/src/components/notifications/notificationIcons.tsx
@@ -1,11 +1,14 @@
+import type { ReactNode } from 'react';
+import { AlertTriangle, CheckCircle2, Info, XCircle } from 'lucide-react';
 import type { NotificationCategory, NotificationType } from '../../types/notification';
 
-export const TYPE_ICON: Record<NotificationType, string> = {
-  success: '✓',
-  error: '✕',
-  danger: '✕',
-  warning: '⚠',
-  info: 'ℹ',
+/** Lucide SVG icon for each notification severity. Set aria-hidden on the wrapping element. */
+export const TYPE_ICON: Record<NotificationType, ReactNode> = {
+  success: <CheckCircle2 size={14} strokeWidth={2.5} aria-hidden="true" />,
+  info:    <Info         size={14} strokeWidth={2.5} aria-hidden="true" />,
+  warning: <AlertTriangle size={14} strokeWidth={2.5} aria-hidden="true" />,
+  error:   <XCircle     size={14} strokeWidth={2.5} aria-hidden="true" />,
+  danger:  <XCircle     size={14} strokeWidth={2.5} aria-hidden="true" />,
 };
 
 export const CATEGORY_ICON: Record<NotificationCategory, string> = {

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,63 @@
+import { useCallback } from 'react';
+import { useNotifications } from '../context/NotificationContext';
+import type { NotificationCategory } from '../types/notification';
+
+interface ToastOptions {
+  /** Category controls per-preference muting. Defaults to 'system'. */
+  category?: NotificationCategory;
+  /** Auto-dismiss delay in ms. Defaults to 5 500. */
+  duration?: number;
+  /** When true the toast stays until manually dismissed. */
+  persistent?: boolean;
+  /** Optional inline call-to-action rendered inside the toast. */
+  action?: { label: string; onClick: () => void };
+}
+
+/**
+ * Convenience wrapper around `useNotifications().addToast`.
+ *
+ * Usage:
+ * ```ts
+ * const toast = useToast();
+ * toast.success('Repayment sent', 'Your payment is being processed.');
+ * toast.error('Connection failed', 'Could not reach the Stellar network.');
+ * ```
+ *
+ * Returns the toast id from each helper so callers can dismiss programmatically
+ * via `toast.dismiss(id)` when needed.
+ */
+export function useToast() {
+  const { addToast, dismissToast } = useNotifications();
+
+  const success = useCallback(
+    (title: string, message: string, opts?: ToastOptions) =>
+      addToast({ type: 'success', title, message, ...opts }),
+    [addToast],
+  );
+
+  const error = useCallback(
+    (title: string, message: string, opts?: ToastOptions) =>
+      addToast({ type: 'error', title, message, ...opts }),
+    [addToast],
+  );
+
+  const warning = useCallback(
+    (title: string, message: string, opts?: ToastOptions) =>
+      addToast({ type: 'warning', title, message, ...opts }),
+    [addToast],
+  );
+
+  const info = useCallback(
+    (title: string, message: string, opts?: ToastOptions) =>
+      addToast({ type: 'info', title, message, ...opts }),
+    [addToast],
+  );
+
+  return {
+    success,
+    error,
+    warning,
+    info,
+    dismiss: dismissToast,
+  };
+}


### PR DESCRIPTION
Closes #277

## Summary

- **SVG severity icons** — Replaced the unicode glyphs in `TYPE_ICON` (`✓ ✕ ⚠ ℹ`) with lucide-react SVG components (`CheckCircle2`, `Info`, `AlertTriangle`, `XCircle`). The export type changed from `string` to `ReactNode`; all three consumers (`ToastContainer`, `NotificationCenter`, `BannerAlert`) render them inside a `<span>` so the change is backward-compatible.
- **`role="status"` for polite toasts** — `ToastItem` previously used `role="alert"` for every severity, which interrupts screen readers immediately. Non-urgent toasts (success/info/warning) now receive `role="status"` + `aria-live="polite"`; error/danger toasts keep `role="alert"` + `aria-live="assertive"`. This satisfies WCAG 4.1.3 Status Messages.
- **`aria-hidden` on icon badge** — The `.toast-type-icon` span now carries `aria-hidden="true"` so AT skips the SVG and reads the title text directly.
- **Left accent border** — Each toast gains a 4 px left border in its severity color (token from `TYPE_COLOR`), ensuring severity is not communicated by color alone (WCAG 1.4.1 Use of Color).
- **Container `role="log"`** — The `.toast-container` div now has `role="log"` + `aria-live="polite"` so AT users can revisit the notification list chronologically.
- **`useToast` hook** — New `src/hooks/useToast.ts` wraps `useNotifications().addToast` with typed `success / error / warning / info` helpers and a `dismiss` function.
- **13 new tests** — Cover SVG icon presence, `aria-hidden` on badge, `role`/`aria-live` per severity, theme colors, left-accent border, `role="log"` container, dismiss, stack cap (≤ 5), and action button rendering.

## Files changed

| File | Change |
|---|---|
| `src/components/notifications/notificationIcons.tsx` | `TYPE_ICON` upgraded to lucide-react SVG `ReactNode`s |
| `src/components/notifications/ToastContainer.tsx` | `role` / `aria-live` per severity; `aria-hidden` on icon; left accent border; container `role="log"` |
| `src/hooks/useToast.ts` | New convenience hook |
| `src/components/notifications/ToastContainer.test.tsx` | 13 new tests |

## Test plan

- [ ] Fire a success toast → green check icon, `role="status"`, green left border
- [ ] Fire an error toast → red ✕ icon, `role="alert"`, red left border
- [ ] Fire info and warning toasts → correct icons and `role="status"`
- [ ] Tab through the toast dismiss button to confirm focus ring
- [ ] Screen reader (VoiceOver / NVDA) announces success without interrupting current speech; error interrupts immediately
- [ ] `npm test -- --run` → 108 tests pass, same 3 pre-existing failures, no regressions