### PR TITLE
Add +/- stepper buttons to AmountInput

### DIFF
--- a/src/components/AmountInput.test.tsx
+++ b/src/components/AmountInput.test.tsx
@@ -179,6 +179,200 @@ describe("AmountInput", () => {
     expect(helperPara).toHaveTextContent("$35,000");
   });
 
+  it("renders decrease stepper button with accessible label", () => {
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={vi.fn()}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const decButton = screen.getByRole("button", {
+      name: /decrease amount/i,
+    });
+    expect(decButton).toBeInTheDocument();
+    expect(decButton).toBeDisabled(); // initially 0, can't go below 0
+  });
+
+  it("renders increase stepper button with accessible label", () => {
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={vi.fn()}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const incButton = screen.getByRole("button", {
+      name: /increase amount/i,
+    });
+    expect(incButton).toBeInTheDocument();
+    expect(incButton).not.toBeDisabled();
+  });
+
+  it("increments amount by step when increase button is clicked", () => {
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={vi.fn()}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const incButton = screen.getByRole("button", {
+      name: /increase amount/i,
+    });
+    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
+
+    fireEvent.click(incButton);
+    expect(input.value).toBe("100");
+  });
+
+  it("decrements amount by step when decrease button is clicked", () => {
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={vi.fn()}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "500" } });
+
+    const decButton = screen.getByRole("button", {
+      name: /decrease amount/i,
+    });
+    fireEvent.click(decButton);
+    expect(input.value).toBe("400");
+  });
+
+  it("disables decrease button when amount is 0", () => {
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={vi.fn()}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const decButton = screen.getByRole("button", {
+      name: /decrease amount/i,
+    });
+    expect(decButton).toBeDisabled();
+  });
+
+  it("disables increase button when amount equals available credit", () => {
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={vi.fn()}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: creditLine.available.toString() } });
+
+    const incButton = screen.getByRole("button", {
+      name: /increase amount/i,
+    });
+    expect(incButton).toBeDisabled();
+  });
+
+  it("does not increment amount beyond available credit", () => {
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={vi.fn()}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "34900" } });
+
+    const incButton = screen.getByRole("button", {
+      name: /increase amount/i,
+    });
+    fireEvent.click(incButton);
+    expect(input.value).toBe(creditLine.available.toString());
+  });
+
+  it("does not decrement amount below 0", () => {
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={vi.fn()}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
+    // A small amount less than STEP_AMOUNT should floor to 0
+    fireEvent.change(input, { target: { value: "50" } });
+    const decButton = screen.getByRole("button", {
+      name: /decrease amount/i,
+    });
+    fireEvent.click(decButton);
+    expect(input.value).toBe("0");
+  });
+
+  it("responds to ArrowUp key to increment amount", () => {
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={vi.fn()}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "500" } });
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(input.value).toBe("600");
+  });
+
+  it("responds to ArrowDown key to decrement amount", () => {
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={vi.fn()}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "500" } });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input.value).toBe("400");
+  });
+
+  it("sets input step attribute", () => {
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={vi.fn()}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
+    expect(input).toHaveAttribute("step", "100");
+  });
+
   it("sets input to invalid state with proper styling when error occurs", () => {
     render(
       <AmountInput

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -1,11 +1,25 @@
 import { CreditLine } from "@/types/draw-credit.types";
-import { AlertCircle, AlertTriangle, CheckCircle, Info } from "lucide-react";
-import { useState, useEffect } from "react";
+import {
+  AlertCircle,
+  AlertTriangle,
+  CheckCircle,
+  ChevronDown,
+  ChevronUp,
+  Info,
+} from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
 import {
   formatMoney,
   getDrawAmountValidation,
 } from "../utils/amountValidation";
 import { FormMessage } from "./FormMessage";
+
+const STEP_AMOUNT = 100;
+
+const stepClasses =
+  "flex items-center justify-center w-10 h-10 rounded-lg border border-border bg-background/60 text-foreground hover:bg-surface hover:border-accent/50 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:opacity-40 disabled:cursor-not-allowed";
+
+const STEP_ICON_CLASS = "h-4 w-4";
 
 interface AmountInputProps {
   creditLine: CreditLine;
@@ -31,6 +45,32 @@ export function AmountInput({
     const numAmount = parseFloat(amount) || 0;
     onAmountChange(numAmount);
   }, [amount, onAmountChange]);
+
+  const handleStep = useCallback(
+    (direction: "up" | "down") => {
+      setAmount((prev) => {
+        const current = parseFloat(prev) || 0;
+        const next = direction === "up"
+          ? Math.min(current + STEP_AMOUNT, creditLine.available)
+          : Math.max(current - STEP_AMOUNT, 0);
+        return next.toString();
+      });
+    },
+    [creditLine.available],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        handleStep("up");
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        handleStep("down");
+      }
+    },
+    [handleStep],
+  );
 
   const handlePreset = (percent: number) => {
     const preset = Math.floor((creditLine.available * percent) / 100);
@@ -108,6 +148,15 @@ export function AmountInput({
         <div
           className={`flex items-center gap-2 bg-surface p-4 rounded-xl border-2 overflow-hidden transition-colors ${inputStateClassName}`}
         >
+          <button
+            onClick={() => handleStep("down")}
+            disabled={numAmount <= 0}
+            className={stepClasses}
+            aria-label="Decrease amount"
+            type="button"
+          >
+            <ChevronDown className={STEP_ICON_CLASS} aria-hidden="true" />
+          </button>
           <span
             className="text-3xl font-bold text-foreground flex-shrink-0"
             aria-hidden="true"
@@ -120,14 +169,25 @@ export function AmountInput({
             placeholder="0"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
+            onKeyDown={handleKeyDown}
             className="text-2xl font-bold bg-transparent outline-none flex-1 text-foreground placeholder:text-muted/50 min-w-0"
             min={validation.minAmount}
             max={creditLine.available}
+            step={STEP_AMOUNT}
             required
             aria-invalid={hasError}
             aria-describedby={describedBy}
             aria-required="true"
           />
+          <button
+            onClick={() => handleStep("up")}
+            disabled={numAmount >= creditLine.available}
+            className={stepClasses}
+            aria-label="Increase amount"
+            type="button"
+          >
+            <ChevronUp className={STEP_ICON_CLASS} aria-hidden="true" />
+          </button>
           {/* Max button for quick-fill with accessible label */}
           <button
             onClick={handleMaxClick}


### PR DESCRIPTION
Adds increment/decrement stepper buttons to the AmountInput component for quicker amount adjustments.

### Changes
- **AmountInput.tsx**: Added − and + stepper buttons with ChevronDown/ChevronUp icons inside the input wrapper. ArrowUp/ArrowDown keyboard support. Clamp amount to [0, creditLine.available]. Disable buttons at range boundaries.
- **AmountInput.test.tsx**: 11 new tests covering stepper button rendering, accessibility labels, increment/decrement logic, boundary clamping, and keyboard interactions. Existing 10 tests all pass unchanged.

### Testing
- `npm test`: 21/21 AmountInput tests pass
- All other pre-existing tests unchanged (FormField, App test failures are pre-existing)

Closes Creditra/Creditra-Frontend#303