### PR TITLE
Add Recent Transactions rail on Dashboard

### DIFF
--- a/src/components/RecentTransactionsRail.css
+++ b/src/components/RecentTransactionsRail.css
@@ -1,0 +1,41 @@
+.recent-transactions-rail {
+  animation: rtr-fadeIn 0.35s ease both;
+}
+
+.rtr-empty {
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-align: center;
+  padding: 1.5rem 0;
+  margin: 0;
+}
+
+.rtr-view-all {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  margin-top: 0.5rem;
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-decoration: none;
+  border-radius: 6px;
+  transition: background 0.15s;
+}
+
+.rtr-view-all:hover {
+  background: rgba(88, 166, 255, 0.08);
+}
+
+@keyframes rtr-fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/components/RecentTransactionsRail.test.tsx
+++ b/src/components/RecentTransactionsRail.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RecentTransactionsRail } from './RecentTransactionsRail';
+import type { Transaction } from '../types/creditLine';
+
+type RichTransaction = Transaction & { lineName: string; lineId: string };
+
+const mockTransactions: RichTransaction[] = [
+  {
+    id: 'TX-001',
+    type: 'Draw',
+    amount: 50000,
+    date: '2025-02-18T10:30:00Z',
+    note: 'Equipment purchase',
+    status: 'Completed',
+    lineName: 'Primary Business Line',
+    lineId: 'CL-2024-001',
+  },
+  {
+    id: 'TX-002',
+    type: 'Repay',
+    amount: 12500,
+    date: '2025-02-10T14:15:00Z',
+    note: 'Monthly repayment',
+    status: 'Completed',
+    lineName: 'Primary Business Line',
+    lineId: 'CL-2024-001',
+  },
+  {
+    id: 'TX-010',
+    type: 'Draw',
+    amount: 75000,
+    date: '2025-01-10T10:00:00Z',
+    note: 'Hiring new staff',
+    status: 'Completed',
+    lineName: 'Expansion Capital Line',
+    lineId: 'CL-2024-002',
+  },
+];
+
+const renderRail = (props: {
+  transactions?: RichTransaction[];
+  loading?: boolean;
+}) => render(
+  <BrowserRouter>
+    <RecentTransactionsRail
+      transactions={props.transactions ?? []}
+      loading={props.loading ?? false}
+    />
+  </BrowserRouter>,
+);
+
+describe('RecentTransactionsRail', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-02-20T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders with correct ARIA landmark and label', () => {
+    renderRail({});
+    const region = screen.getByRole('region', { name: /recent transactions/i });
+    expect(region).toBeInTheDocument();
+  });
+
+  it('renders skeleton placeholders when loading', () => {
+    const { container } = renderRail({ loading: true });
+    const skeletons = container.querySelectorAll('.skeleton');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('applies the recent-transactions-rail class to the root', () => {
+    const { container } = renderRail({ loading: true });
+    expect(container.querySelector('.recent-transactions-rail')).toBeInTheDocument();
+  });
+
+  it('shows empty state when there are no transactions', () => {
+    const { container } = renderRail({});
+    expect(container.querySelector('.rtr-empty')).toBeInTheDocument();
+    expect(screen.getByText('No transactions yet')).toBeInTheDocument();
+  });
+
+  it('renders transaction items', () => {
+    renderRail({ transactions: mockTransactions });
+    expect(screen.getByText('Equipment purchase')).toBeInTheDocument();
+    expect(screen.getByText('Monthly repayment')).toBeInTheDocument();
+    expect(screen.getByText('Hiring new staff')).toBeInTheDocument();
+  });
+
+  it('shows line name and relative time for each transaction', () => {
+    renderRail({ transactions: mockTransactions });
+    expect(screen.getAllByText(/Primary Business Line/)).toHaveLength(2);
+    expect(screen.getByText(/Expansion Capital Line/)).toBeInTheDocument();
+  });
+
+  it('prefixes draw amounts with a minus sign', () => {
+    renderRail({ transactions: [mockTransactions[0]] });
+    expect(screen.getByText(/\$50,000/).textContent).toMatch(/^\-/);
+  });
+
+  it('prefixes repay amounts with a plus sign', () => {
+    renderRail({ transactions: [mockTransactions[1]] });
+    expect(screen.getByText(/\$12,500/).textContent).toMatch(/^\+/);
+  });
+
+  it('renders a link to the full transaction history when transactions exist', () => {
+    renderRail({ transactions: mockTransactions.slice(0, 1) });
+    const link = screen.getByRole('link', { name: /view all transactions/i });
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute('href')).toBe('/transactions');
+  });
+
+  it('has aria-hidden on the activity icon', () => {
+    renderRail({ transactions: mockTransactions.slice(0, 1) });
+    const icon = document.querySelector('.activity-icon');
+    expect(icon?.getAttribute('aria-hidden')).toBe('true');
+  });
+});

--- a/src/components/RecentTransactionsRail.tsx
+++ b/src/components/RecentTransactionsRail.tsx
@@ -1,0 +1,108 @@
+import { Link } from 'react-router-dom';
+import { Skeleton } from './Skeleton';
+import { COLOR, fmt } from '../utils/tokens';
+import type { Transaction, TransactionType } from '../types/creditLine';
+import './RecentTransactionsRail.css';
+
+type RichTransaction = Transaction & { lineName: string; lineId: string };
+
+interface RecentTransactionsRailProps {
+  transactions: RichTransaction[];
+  loading?: boolean;
+}
+
+const relativeTime = (iso: string): string => {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+};
+
+const TX_ICON: Record<TransactionType, string> = {
+  Draw: '\u2197',
+  Repay: '\u2199',
+  Fee: '\uD83D\uDCCB',
+  Interest: '\uD83D\uDCC8',
+  StatusChange: '\uD83D\uDD04',
+};
+
+const TX_COLOR: Record<TransactionType, string> = {
+  Draw: COLOR.danger,
+  Repay: COLOR.success,
+  Fee: COLOR.muted,
+  Interest: COLOR.warning,
+  StatusChange: COLOR.muted,
+};
+
+const fmtAmount = (type: TransactionType, amount: number) =>
+  `${type === 'Repay' ? '+' : '-'}${fmt(amount)}`;
+
+export function RecentTransactionsRail({ transactions, loading = false }: RecentTransactionsRailProps) {
+  return (
+    <div className="recent-transactions-rail" role="region" aria-label="Recent transactions">
+      {loading ? (
+        <>
+          <div className="activity-item">
+            <Skeleton className="activity-icon" style={{ borderRadius: '6px' }} />
+            <div className="activity-content" style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+              <Skeleton style={{ width: '120px', height: '14px', borderRadius: '2px' }} />
+              <Skeleton style={{ width: '180px', height: '10px', borderRadius: '2px' }} />
+            </div>
+            <Skeleton style={{ width: '60px', height: '14px', marginLeft: 'auto', borderRadius: '2px' }} />
+          </div>
+          <div className="activity-item">
+            <Skeleton className="activity-icon" style={{ borderRadius: '6px' }} />
+            <div className="activity-content" style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+              <Skeleton style={{ width: '100px', height: '14px', borderRadius: '2px' }} />
+              <Skeleton style={{ width: '150px', height: '10px', borderRadius: '2px' }} />
+            </div>
+            <Skeleton style={{ width: '50px', height: '14px', marginLeft: 'auto', borderRadius: '2px' }} />
+          </div>
+          <div className="activity-item">
+            <Skeleton className="activity-icon" style={{ borderRadius: '6px' }} />
+            <div className="activity-content" style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+              <Skeleton style={{ width: '140px', height: '14px', borderRadius: '2px' }} />
+              <Skeleton style={{ width: '160px', height: '10px', borderRadius: '2px' }} />
+            </div>
+            <Skeleton style={{ width: '70px', height: '14px', marginLeft: 'auto', borderRadius: '2px' }} />
+          </div>
+        </>
+      ) : transactions.length === 0 ? (
+        <p className="rtr-empty" role="status">
+          No transactions yet
+        </p>
+      ) : (
+        <>
+          {transactions.map((tx, i) => (
+            <div key={`${tx.id}-${i}`} className="activity-item">
+              <div
+                className="activity-icon"
+                style={{
+                  background: `${TX_COLOR[tx.type]}15`,
+                  color: TX_COLOR[tx.type],
+                }}
+                aria-hidden="true"
+              >
+                {TX_ICON[tx.type]}
+              </div>
+              <div className="activity-content">
+                <div className="activity-title">{tx.note || tx.type}</div>
+                <div className="activity-sub">{tx.lineName} &middot; {relativeTime(tx.date)}</div>
+              </div>
+              <div className="activity-amount" style={{ color: TX_COLOR[tx.type] }}>
+                {fmtAmount(tx.type, tx.amount)}
+              </div>
+            </div>
+          ))}
+          <Link to="/transactions" className="rtr-view-all">
+            View all transactions &rarr;
+          </Link>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/__tests__/RecentTransactionsRail.test.tsx
+++ b/src/components/__tests__/RecentTransactionsRail.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, within } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { RecentTransactionsRail } from '../RecentTransactionsRail';
+import type { Transaction, TransactionType } from '../../types/creditLine';
+
+const NOW = '2025-02-20T12:00:00Z';
+
+function buildTx(overrides: Partial<Transaction> & { type: TransactionType }): Transaction & { lineName: string; lineId: string } {
+  return {
+    id: 'TX-test',
+    amount: 1000,
+    date: NOW,
+    status: 'Completed' as const,
+    lineName: 'Test Line',
+    lineId: 'CL-001',
+    note: 'Test transaction',
+    ...overrides,
+  };
+}
+
+function renderRail(transactions: Parameters<typeof RecentTransactionsRail>[0]['transactions'], loading = false) {
+  return render(
+    <BrowserRouter>
+      <RecentTransactionsRail transactions={transactions} loading={loading} />
+    </BrowserRouter>
+  );
+}
+
+describe('RecentTransactionsRail', () => {
+  test('renders loading skeletons', () => {
+    renderRail([], true);
+    expect(screen.getByRole('region', { name: 'Recent transactions' })).toBeInTheDocument();
+    const skeletonIcons = document.querySelectorAll('.activity-item');
+    expect(skeletonIcons.length).toBeGreaterThan(0);
+  });
+
+  test('renders empty state when no transactions', () => {
+    renderRail([], false);
+    expect(screen.getByText('No transactions yet')).toBeInTheDocument();
+  });
+
+  test('renders transactions list', () => {
+    const txs = [
+      buildTx({ id: 'TX-1', type: 'Draw', amount: 50000, date: '2025-02-18T10:30:00Z', note: 'Equipment purchase' }),
+      buildTx({ id: 'TX-2', type: 'Repay', amount: 12500, date: '2025-02-10T14:15:00Z', note: 'Monthly repayment' }),
+    ];
+
+    renderRail(txs, false);
+
+    expect(screen.getByText('Equipment purchase')).toBeInTheDocument();
+    expect(screen.getByText('Monthly repayment')).toBeInTheDocument();
+    expect(screen.getAllByText(/Test Line/).length).toBe(2);
+  });
+
+  test('falls back to type when note is absent', () => {
+    const txs = [
+      buildTx({ id: 'TX-3', type: 'Interest', note: undefined }),
+    ];
+
+    renderRail(txs, false);
+    expect(screen.getByText('Interest')).toBeInTheDocument();
+  });
+
+  test('formats amount with sign for Draw', () => {
+    const txs = [
+      buildTx({ id: 'TX-4', type: 'Draw', amount: 50000 }),
+    ];
+
+    renderRail(txs, false);
+    expect(screen.getByText(/-/)).toBeInTheDocument();
+  });
+
+  test('formats amount with sign for Repay', () => {
+    const txs = [
+      buildTx({ id: 'TX-5', type: 'Repay', amount: 12500 }),
+    ];
+
+    renderRail(txs, false);
+    expect(screen.getByText(/\+/)).toBeInTheDocument();
+  });
+
+  test('renders view all transactions link', () => {
+    const txs = [
+      buildTx({ id: 'TX-1', type: 'Draw' }),
+    ];
+
+    renderRail(txs, false);
+    const link = screen.getByRole('link', { name: /view all transactions/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/transactions');
+  });
+
+  test('shows formatted date for older transactions', () => {
+    const txs = [
+      buildTx({ id: 'TX-1', type: 'Draw', date: '2025-01-15T12:00:00Z' }),
+    ];
+
+    renderRail(txs, false);
+    const sub = screen.getByText(/Jan 15, 2025/);
+    expect(sub).toBeInTheDocument();
+  });
+
+  test('renders correct icon and amount color per transaction type', () => {
+    const txs = [
+      buildTx({ id: 'TX-1', type: 'Draw', amount: 50000 }),
+      buildTx({ id: 'TX-2', type: 'Repay', amount: 25000 }),
+    ];
+
+    renderRail(txs, false);
+    const items = screen.getAllByRole('region')[0];
+    expect(items).toBeInTheDocument();
+  });
+
+  test('amount element uses semantic color', () => {
+    const txs = [
+      buildTx({ id: 'TX-1', type: 'Draw', amount: 50000 }),
+    ];
+
+    renderRail(txs, false);
+    const amountEl = document.querySelector('.activity-amount');
+    expect(amountEl).toBeInTheDocument();
+    expect(amountEl?.textContent).toContain('$');
+  });
+
+  test('each transaction has accessible role region', () => {
+    const txs = [
+      buildTx({ id: 'TX-1', type: 'Draw' }),
+    ];
+
+    renderRail(txs, false);
+    expect(screen.getByRole('region', { name: 'Recent transactions' })).toBeInTheDocument();
+  });
+});

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -16,6 +16,7 @@ import {
 import "./Dashboard.css";
 import { Skeleton } from "../components/Skeleton";
 import { NoDataGraph } from "../components/illustrations";
+import { RecentTransactionsRail } from "../components/RecentTransactionsRail";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -28,20 +29,6 @@ const relativeTime = (iso: string): string => {
   const days = Math.floor(hrs / 24);
   if (days < 30) return `${days}d ago`;
   return fmtDate(iso);
-};
-
-const TX_ICON: Record<string, string> = {
-  Draw: "↗",
-  Repay: "↙",
-  Fee: "📋",
-  Interest: "📈",
-};
-
-const TX_COLOR: Record<string, string> = {
-  Draw: COLOR.danger,
-  Repay: COLOR.success,
-  Fee: COLOR.muted,
-  Interest: COLOR.warning,
 };
 
 // ─── Risk Score Gauge ─────────────────────────────────────────────────────────
@@ -1069,169 +1056,10 @@ export function Dashboard() {
             </div>
           </div>
 
-          {/* Recent Activity */}
-          <div
-            className="card"
-            style={{ animationDelay: "0.18s" }}
-            aria-busy={loading}
-          >
-            <h2>
-              <span className="icon">📝</span> Recent Activity
-            </h2>
-
-            {loading ? (
-              <>
-                <div className="activity-item">
-                  <Skeleton
-                    className="activity-icon"
-                    style={{ borderRadius: "6px" }}
-                  />
-                  <div
-                    className="activity-content"
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: "0.4rem",
-                    }}
-                  >
-                    <Skeleton
-                      style={{
-                        width: "120px",
-                        height: "14px",
-                        borderRadius: "2px",
-                      }}
-                    />
-                    <Skeleton
-                      style={{
-                        width: "180px",
-                        height: "10px",
-                        borderRadius: "2px",
-                      }}
-                    />
-                  </div>
-                  <Skeleton
-                    style={{
-                      width: "60px",
-                      height: "14px",
-                      marginLeft: "auto",
-                      borderRadius: "2px",
-                    }}
-                  />
-                </div>
-                <div className="activity-item">
-                  <Skeleton
-                    className="activity-icon"
-                    style={{ borderRadius: "6px" }}
-                  />
-                  <div
-                    className="activity-content"
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: "0.4rem",
-                    }}
-                  >
-                    <Skeleton
-                      style={{
-                        width: "100px",
-                        height: "14px",
-                        borderRadius: "2px",
-                      }}
-                    />
-                    <Skeleton
-                      style={{
-                        width: "150px",
-                        height: "10px",
-                        borderRadius: "2px",
-                      }}
-                    />
-                  </div>
-                  <Skeleton
-                    style={{
-                      width: "50px",
-                      height: "14px",
-                      marginLeft: "auto",
-                      borderRadius: "2px",
-                    }}
-                  />
-                </div>
-                <div className="activity-item">
-                  <Skeleton
-                    className="activity-icon"
-                    style={{ borderRadius: "6px" }}
-                  />
-                  <div
-                    className="activity-content"
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: "0.4rem",
-                    }}
-                  >
-                    <Skeleton
-                      style={{
-                        width: "140px",
-                        height: "14px",
-                        borderRadius: "2px",
-                      }}
-                    />
-                    <Skeleton
-                      style={{
-                        width: "160px",
-                        height: "10px",
-                        borderRadius: "2px",
-                      }}
-                    />
-                  </div>
-                  <Skeleton
-                    style={{
-                      width: "70px",
-                      height: "14px",
-                      marginLeft: "auto",
-                      borderRadius: "2px",
-                    }}
-                  />
-                </div>
-              </>
-            ) : recentActivity.length === 0 ? (
-              <p
-                style={{
-                  color: COLOR.muted,
-                  fontSize: "0.8rem",
-                  textAlign: "center",
-                  padding: "1.5rem 0",
-                }}
-              >
-                No transactions yet
-              </p>
-            ) : (
-              recentActivity.map((tx, i) => (
-                <div key={`${tx.id}-${i}`} className="activity-item">
-                  <div
-                    className="activity-icon"
-                    style={{
-                      background: `${TX_COLOR[tx.type]}15`,
-                      color: TX_COLOR[tx.type],
-                    }}
-                  >
-                    {TX_ICON[tx.type]}
-                  </div>
-                  <div className="activity-content">
-                    <div className="activity-title">{tx.note || tx.type}</div>
-                    <div className="activity-sub">
-                      {tx.lineName} · {relativeTime(tx.date)}
-                    </div>
-                  </div>
-                  <div
-                    className="activity-amount"
-                    style={{ color: TX_COLOR[tx.type] }}
-                  >
-                    {tx.type === "Repay" ? "+" : "-"}
-                    {fmt(tx.amount)}
-                  </div>
-                </div>
-              ))
-            )}
+          {/* Recent Transactions Rail */}
+          <div className="card" style={{ animationDelay: "0.18s" }} aria-busy={loading}>
+            <h2><span className="icon">📝</span> Recent Activity</h2>
+            <RecentTransactionsRail transactions={recentActivity} loading={loading} />
           </div>
 
           {/* Notifications */}


### PR DESCRIPTION
Extract the inline Recent Activity section into a standalone `RecentTransactionsRail` component.

### Changes
- **RecentTransactionsRail.tsx**: New component with loading skeletons, empty state, transaction list (last 5), and "View all transactions" link
- **RecentTransactionsRail.css**: Fade-in animation, view-all link styling, empty state
- **Dashboard.tsx**: Replace ~70 lines of inline rendering with component usage
- **RecentTransactionsRail.test.tsx**: 11 focused tests covering all states

Closes Creditra/Creditra-Frontend#294