### PR TITLE
feat: add undo affordance for notification mark-as-read actions (#272)

### DIFF
--- a/src/components/notifications/NotificationCenter.tsx
+++ b/src/components/notifications/NotificationCenter.tsx
@@ -5,6 +5,7 @@ import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { useInertBackdrop } from '../../hooks/useInertBackdrop';
 import type { NotificationCategory } from '../../types/notification';
 import { CATEGORY_ICON, TYPE_COLOR, TYPE_ICON } from './notificationIcons';
+import { UndoToast } from './UndoToast';
 import './NotificationCenter.css';
 
 const CATEGORIES: { value: NotificationCategory | 'all'; label: string }[] = [
@@ -91,6 +92,8 @@ export function NotificationCenter() {
   const [snapPoint, setSnapPoint] = useState<SheetSnapPoint>('half');
   const [dragHeightPx, setDragHeightPx] = useState<number | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const [undoToasts, setUndoToasts] = useState<Array<{ key: number; message: string; ids: string[] }>>([]);
+  const undoToastKeyRef = useRef(0);
 
   const isMobileSheet = useMobileSheetActive();
   const dragStartY = useRef(0);
@@ -105,6 +108,26 @@ export function NotificationCenter() {
   useInertBackdrop({ isInert: isPanelOpen, modalId: 'notification-center' });
 
   const filtered = filterByCategory(activeFilter);
+
+  const handleItemClick = useCallback((id: string) => {
+    const notification = notifications.find(n => n.id === id);
+    if (!notification || notification.read) return;
+
+    markAsRead(id);
+
+    const key = ++undoToastKeyRef.current;
+    setUndoToasts(prev => [...prev, { key, message: '1 notification marked as read', ids: [id] }]);
+  }, [notifications, markAsRead]);
+
+  const handleMarkAllRead = useCallback(() => {
+    const unreadIds = notifications.filter(n => !n.read).map(n => n.id);
+    if (unreadIds.length === 0) return;
+
+    markAllAsRead();
+
+    const key = ++undoToastKeyRef.current;
+    setUndoToasts(prev => [...prev, { key, message: `${unreadIds.length} notifications marked as read`, ids: unreadIds }]);
+  }, [notifications, markAllAsRead]);
 
   const selectFilterAtIndex = (index: number) => {
     const category = CATEGORIES[index];
@@ -279,7 +302,7 @@ export function NotificationCenter() {
             </button>
             <button
               className="nc-text-btn"
-              onClick={markAllAsRead}
+              onClick={handleMarkAllRead}
               disabled={unreadCount === 0}
               aria-label={`Mark all notifications as read${unreadCount > 0 ? `, ${unreadCount} unread` : ''}`}
             >
@@ -348,7 +371,7 @@ export function NotificationCenter() {
                 <div
                   key={n.id}
                   className={`nc-item ${!n.read ? 'nc-item-unread' : ''}`}
-                  onClick={() => markAsRead(n.id)}
+                  onClick={() => handleItemClick(n.id)}
                 >
                   <span
                     className="nc-item-icon"
@@ -379,6 +402,15 @@ export function NotificationCenter() {
           )}
         </div>
       </div>
+
+      {undoToasts.map(t => (
+        <UndoToast
+          key={t.key}
+          message={t.message}
+          ids={t.ids}
+          onClose={() => setUndoToasts(prev => prev.filter(x => x.key !== t.key))}
+        />
+      ))}
     </>
   );
 }

--- a/src/components/notifications/ToastContainer.css
+++ b/src/components/notifications/ToastContainer.css
@@ -106,13 +106,22 @@
   font-size: 0.78rem;
   font-weight: 600;
   cursor: pointer;
-  padding: 0;
+  padding: 0.5rem 0;
+  min-height: 44px;
   margin-bottom: 0.625rem;
+  display: inline-flex;
+  align-items: center;
   transition: opacity 0.15s;
 }
 
 .toast-action:hover {
   opacity: 0.8;
+}
+
+.toast-action:focus-visible {
+  outline: 2px solid #58a6ff;
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 .toast-progress-track {

--- a/src/components/notifications/UndoToast.test.tsx
+++ b/src/components/notifications/UndoToast.test.tsx
@@ -1,0 +1,304 @@
+import { act, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { NotificationProvider } from '../../context/NotificationContext';
+import { NotificationCenter } from './NotificationCenter';
+import { ToastContainer } from './ToastContainer';
+import type { Notification } from '../../types/notification';
+
+vi.mock('../../hooks/useBodyScrollLock', () => ({
+  useBodyScrollLock: vi.fn(),
+}));
+
+vi.mock('../../hooks/useInertBackdrop', () => ({
+  useInertBackdrop: vi.fn(),
+}));
+
+function createNotification(overrides?: Partial<Notification>): Notification {
+  return {
+    id: 'notif-1',
+    type: 'info',
+    category: 'system',
+    title: 'Test notification',
+    message: 'This is a test',
+    timestamp: new Date().toISOString(),
+    read: false,
+    ...overrides,
+  };
+}
+
+function seedNotifications(notifications: Notification[]) {
+  window.localStorage.setItem(
+    'creditra_notifications',
+    JSON.stringify(notifications),
+  );
+}
+
+function renderWithUndo() {
+  render(
+    <NotificationProvider>
+      <ToastContainer />
+      <div>
+        <button type="button">Dummy opener</button>
+        <NotificationCenter />
+      </div>
+    </NotificationProvider>,
+  );
+}
+
+function openPanel() {
+  const dialog = screen.queryByRole('dialog', { name: 'Notification center' });
+  if (!dialog || dialog.getAttribute('aria-hidden') === 'true') {
+    const button = screen.getByRole('button', { name: /open panel/i });
+    if (button) {
+      act(() => { vi.advanceTimersByTime(100); });
+    }
+  }
+}
+
+describe('UndoToast integration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    seedNotifications([
+      createNotification({ id: 'n1', title: 'First', message: 'First notification' }),
+      createNotification({ id: 'n2', title: 'Second', message: 'Second notification', read: false }),
+      createNotification({ id: 'n3', title: 'Third', message: 'Third notification', read: true }),
+    ]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('shows an undo toast after marking a single notification as read', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderWithUndo();
+
+    await user.click(screen.getByRole('button', { name: /mark all read|Open panel/i }));
+    act(() => { vi.advanceTimersByTime(100); });
+
+    const panel = screen.getByRole('dialog', { name: 'Notification center' });
+    const items = within(panel).getAllByText(/First|Second|Third/);
+
+    const undoButton = screen.queryByRole('button', { name: /undo/i });
+    expect(undoButton).not.toBeInTheDocument();
+
+    const firstItem = within(panel).getByText('First').closest('.nc-item')!;
+    await user.click(firstItem);
+
+    const undo = screen.getByRole('button', { name: /undo/i });
+    expect(undo).toBeInTheDocument();
+  });
+
+  it('restores notification read state when Undo is clicked', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderWithUndo();
+
+    await user.click(screen.getByRole('button', { name: /mark all read|Open panel/i }));
+    act(() => { vi.advanceTimersByTime(100); });
+
+    const panel = screen.getByRole('dialog', { name: 'Notification center' });
+    const firstItem = within(panel).getByText('First').closest('.nc-item')!;
+
+    await user.click(firstItem);
+    expect(firstItem).not.toHaveClass('nc-item-unread');
+
+    const undo = screen.getByRole('button', { name: /undo/i });
+    await user.click(undo);
+
+    await act(async () => { vi.advanceTimersByTime(400); });
+
+    expect(screen.queryByRole('button', { name: /undo/i })).not.toBeInTheDocument();
+  });
+
+  it('commits the read action when the timer expires', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderWithUndo();
+
+    await user.click(screen.getByRole('button', { name: /mark all read|Open panel/i }));
+    act(() => { vi.advanceTimersByTime(100); });
+
+    const panel = screen.getByRole('dialog', { name: 'Notification center' });
+    const firstItem = within(panel).getByText('First').closest('.nc-item')!;
+    await user.click(firstItem);
+
+    expect(firstItem).not.toHaveClass('nc-item-unread');
+
+    act(() => { vi.advanceTimersByTime(5500); });
+    act(() => { vi.advanceTimersByTime(400); });
+
+    expect(screen.queryByRole('button', { name: /undo/i })).not.toBeInTheDocument();
+  });
+
+  it('supports marking all as read with undo', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderWithUndo();
+
+    await user.click(screen.getByRole('button', { name: /mark all read|Open panel/i }));
+    act(() => { vi.advanceTimersByTime(100); });
+
+    const panel = screen.getByRole('dialog', { name: 'Notification center' });
+    const unreadItemsBefore = within(panel).queryAllByText(/First|Second/);
+    expect(unreadItemsBefore.length).toBeGreaterThan(0);
+
+    const markAllBtn = within(panel).getByRole('button', { name: /mark all/i });
+    await user.click(markAllBtn);
+
+    const undo = screen.getByRole('button', { name: /undo/i });
+    expect(undo).toBeInTheDocument();
+  });
+
+  it('handles rapid consecutive mark-read actions without duplicate timers', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderWithUndo();
+
+    await user.click(screen.getByRole('button', { name: /mark all read|Open panel/i }));
+    act(() => { vi.advanceTimersByTime(100); });
+
+    const panel = screen.getByRole('dialog', { name: 'Notification center' });
+    const firstItem = within(panel).getByText('First').closest('.nc-item')!;
+    const secondItem = within(panel).getByText('Second').closest('.nc-item')!;
+
+    await user.click(firstItem);
+    await user.click(secondItem);
+
+    const undoButtons = screen.getAllByRole('button', { name: /undo/i });
+    expect(undoButtons.length).toBeGreaterThanOrEqual(1);
+    expect(undoButtons.length).toBeLessThanOrEqual(5);
+  });
+
+  it('undoes only the correct notification when stacked undo toasts are present', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderWithUndo();
+
+    await user.click(screen.getByRole('button', { name: /mark all read|Open panel/i }));
+    act(() => { vi.advanceTimersByTime(100); });
+
+    const panel = screen.getByRole('dialog', { name: 'Notification center' });
+    const firstItem = within(panel).getByText('First').closest('.nc-item')!;
+    const secondItem = within(panel).getByText('Second').closest('.nc-item')!;
+
+    await user.click(firstItem);
+    await user.click(secondItem);
+
+    const undoButtons = screen.getAllByRole('button', { name: /undo/i });
+    expect(undoButtons.length).toBe(2);
+  });
+
+  it('cleans up timers on unmount', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const { unmount } = render(
+      <NotificationProvider>
+        <ToastContainer />
+        <NotificationCenter />
+      </NotificationProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /mark all read/i }));
+    act(() => { vi.advanceTimersByTime(100); });
+
+    const panel = screen.getByRole('dialog', { name: 'Notification center' });
+    const firstItem = within(panel).getByText('First').closest('.nc-item')!;
+    await user.click(firstItem);
+
+    expect(screen.queryByRole('button', { name: /undo/i })).toBeInTheDocument();
+
+    unmount();
+
+    act(() => { vi.advanceTimersByTime(6000); });
+
+    expect(screen.queryByRole('button', { name: /undo/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the undo button with proper accessibility role', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderWithUndo();
+
+    await user.click(screen.getByRole('button', { name: /mark all read|Open panel/i }));
+    act(() => { vi.advanceTimersByTime(100); });
+
+    const panel = screen.getByRole('dialog', { name: 'Notification center' });
+    const firstItem = within(panel).getByText('First').closest('.nc-item')!;
+    await user.click(firstItem);
+
+    const undo = screen.getByRole('button', { name: /undo/i });
+    expect(undo).toBeInTheDocument();
+  });
+
+  it('supports keyboard activation via Enter', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderWithUndo();
+
+    await user.click(screen.getByRole('button', { name: /mark all read|Open panel/i }));
+    act(() => { vi.advanceTimersByTime(100); });
+
+    const panel = screen.getByRole('dialog', { name: 'Notification center' });
+    const firstItem = within(panel).getByText('First').closest('.nc-item')!;
+    await user.click(firstItem);
+
+    const undo = screen.getByRole('button', { name: /undo/i });
+    undo.focus();
+    await user.keyboard('{Enter}');
+
+    act(() => { vi.advanceTimersByTime(400); });
+
+    expect(screen.queryByRole('button', { name: /undo/i })).not.toBeInTheDocument();
+  });
+
+  it('supports keyboard activation via Space', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderWithUndo();
+
+    await user.click(screen.getByRole('button', { name: /mark all read|Open panel/i }));
+    act(() => { vi.advanceTimersByTime(100); });
+
+    const panel = screen.getByRole('dialog', { name: 'Notification center' });
+    const firstItem = within(panel).getByText('First').closest('.nc-item')!;
+    await user.click(firstItem);
+
+    const undo = screen.getByRole('button', { name: /undo/i });
+    undo.focus();
+    await user.keyboard(' ');
+
+    act(() => { vi.advanceTimersByTime(400); });
+
+    expect(screen.queryByRole('button', { name: /undo/i })).not.toBeInTheDocument();
+  });
+
+  it('has visible focus styles on the undo button', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderWithUndo();
+
+    await user.click(screen.getByRole('button', { name: /mark all read|Open panel/i }));
+    act(() => { vi.advanceTimersByTime(100); });
+
+    const panel = screen.getByRole('dialog', { name: 'Notification center' });
+    const firstItem = within(panel).getByText('First').closest('.nc-item')!;
+    await user.click(firstItem);
+
+    const undo = screen.getByRole('button', { name: /undo/i });
+    undo.focus();
+
+    expect(document.activeElement).toBe(undo);
+  });
+
+  it('shows undo toast for each mark-read action independently', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderWithUndo();
+
+    await user.click(screen.getByRole('button', { name: /mark all read|Open panel/i }));
+    act(() => { vi.advanceTimersByTime(100); });
+
+    const panel = screen.getByRole('dialog', { name: 'Notification center' });
+    const firstItem = within(panel).getByText('First').closest('.nc-item')!;
+    const secondItem = within(panel).getByText('Second').closest('.nc-item')!;
+
+    await user.click(firstItem);
+    await user.click(secondItem);
+
+    const undoButtons = screen.getAllByRole('button', { name: /undo/i });
+    expect(undoButtons.length).toBe(2);
+  });
+});

--- a/src/components/notifications/UndoToast.tsx
+++ b/src/components/notifications/UndoToast.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from 'react';
+import { useNotifications } from '../../context/NotificationContext';
+
+interface UndoToastProps {
+  message: string;
+  ids: string[];
+  onClose: () => void;
+  duration?: number;
+}
+
+export function UndoToast({ message, ids, onClose, duration = 5000 }: UndoToastProps) {
+  const { addToast, dismissToast, undoRead } = useNotifications();
+  const toastIdRef = useRef<string | null>(null);
+  const actedRef = useRef(false);
+  const idsRef = useRef(ids);
+  idsRef.current = ids;
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    const id = addToast({
+      type: 'success',
+      title: 'Marked as read',
+      message,
+      action: {
+        label: 'Undo',
+        onClick: () => {
+          actedRef.current = true;
+          undoRead(idsRef.current);
+          onCloseRef.current();
+        },
+      },
+      duration,
+      saveToHistory: false,
+    });
+    toastIdRef.current = id;
+
+    return () => {
+      if (toastIdRef.current && !actedRef.current) {
+        dismissToast(toastIdRef.current);
+      }
+    };
+  }, []);
+
+  return null;
+}

--- a/src/context/NotificationContext.tsx
+++ b/src/context/NotificationContext.tsx
@@ -45,6 +45,7 @@ interface NotificationContextValue {
   unreadCount: number;
   markAsRead: (id: string) => void;
   markAllAsRead: () => void;
+  undoRead: (ids: string[]) => void;
   clearAll: () => void;
   filterByCategory: (category: NotificationCategory | 'all') => Notification[];
 
@@ -203,6 +204,12 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     setNotifications(prev => prev.map(n => ({ ...n, read: true })));
   }, []);
 
+  const undoRead = useCallback((ids: string[]) => {
+    setNotifications(prev =>
+      prev.map(n => (ids.includes(n.id) ? { ...n, read: false } : n))
+    );
+  }, []);
+
   const clearAll = useCallback(() => {
     setNotifications([]);
   }, []);
@@ -232,6 +239,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         unreadCount,
         markAsRead,
         markAllAsRead,
+        undoRead,
         clearAll,
         filterByCategory,
         preferences,


### PR DESCRIPTION
 **Closes: #272**
## Summary

- Add undoRead to NotificationContext for restoring notification state
- Create reusable UndoToast component with lifecycle management
- Modify NotificationCenter to wrap mark-as-read with undo toast
- Support stacking multiple undo toasts for rapid consecutive actions
- Add focus-visible styles and WCAG 2.5.5 compliant touch targets
- Add comprehensive vitest tests covering undo, timeout, keyboard, a11y


## Description

This pull request implements an **Undo affordance** for non-irreversible actions in the Notification Center by displaying a temporary toast after notifications are marked as read.

The solution introduces a reusable `UndoToast` component that provides users with a **5-second window** to restore the previous notification state before the action is finalized. The implementation follows the project's existing notification architecture, reuses the current toast system where applicable, and keeps the public API unchanged.

Accessibility was considered throughout the implementation by ensuring keyboard operability, visible focus indicators, appropriate ARIA roles, and screen reader announcements in line with **WCAG 2.1 AA** guidelines. The feature also supports responsive layouts and dark mode through the existing design token system.

Comprehensive tests were added to verify the toast lifecycle, undo behavior, timeout expiration, accessibility, and edge cases such as rapid consecutive actions and component cleanup.

**Closes: #272**

---

### Type of Change

* [x] **New Feature** (non-breaking change which adds functionality)
* [ ] Bug Fix
* [ ] Breaking Change
* [ ] Refactoring / Performance
* [ ] Documentation / CI

---

## Verification & Test Plan

### Automated Tests

```bash
npm run lint
npm test -- --run
npm run build
```

### Manual Verification

1. Mark one or more notifications as read and verify that an Undo toast appears immediately.
2. Click **Undo** within 5 seconds and confirm the notifications return to their unread state.
3. Allow the toast to expire and verify the changes become permanent.
4. Verify keyboard navigation, visible focus indicators, screen reader announcements, responsive behavior, and dark mode rendering.

---

