### PR TITLE
feat: add filtered transactions empty state (#298)

### DIFF
--- a/src/pages/TransactionHistory.css
+++ b/src/pages/TransactionHistory.css
@@ -659,7 +659,8 @@
     margin-bottom: 1rem;
 }
 
-.empty-state h2 {
+.empty-state h2,
+.empty-state h3 {
     margin: 0 0 0.5rem;
     font-size: 1.25rem;
     color: var(--text);

--- a/src/pages/TransactionHistory.test.tsx
+++ b/src/pages/TransactionHistory.test.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter, MemoryRouter } from "react-router-dom";
 import { TransactionHistory } from "./TransactionHistory";
 
 const renderTransactionHistory = (initialEntries: string[] = ["/transactions"]) => {
-  render(
+  return render(
     <MemoryRouter initialEntries={initialEntries}>
       <TransactionHistory />
     </MemoryRouter>,
@@ -93,7 +93,7 @@ describe("TransactionHistory", () => {
   });
 
   it("shows a no-results state with a clear filters action", () => {
-    renderTransactionHistory();
+    const { container } = renderTransactionHistory();
 
     fireEvent.click(screen.getByRole("button", { name: "Fee" }));
     fireEvent.click(screen.getByRole("button", { name: "Today" }));
@@ -103,6 +103,12 @@ describe("TransactionHistory", () => {
       name: /no transactions match these filters/i,
     });
     expect(noResultsHeading).toBeTruthy();
+
+    // Check NoDataGraph illustration renders in the empty state
+    const illustration = container.querySelector(
+      ".empty-state .empty-state-illustration",
+    );
+    expect(illustration).toBeInTheDocument();
 
     // Check "no transactions yet" message is NOT present
     const noTransactionsMsg = screen.queryByText(/no transactions yet/i);

--- a/src/pages/TransactionHistory.tsx
+++ b/src/pages/TransactionHistory.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useEffect } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { CopyToClipboard } from "../components/CopyToClipboard";
+import { AmountRangeChips } from "../components/AmountRangeChips";
 import { DateRangeChips, type DatePreset } from "../components/DateRangeChips";
 import { MOCK_CREDIT_LINES } from "../data/mockData";
 import type {
@@ -11,7 +12,7 @@ import type {
 import { startOfDay, startOfMonth, startOfWeek } from "../utils/dates";
 import { COLOR, fmt, fmtDate, fmtDateTime } from "../utils/tokens";
 import "./TransactionHistory.css";
-import { NoActivity, NoLines } from "../components/illustrations";
+import { NoActivity, NoDataGraph, NoLines } from "../components/illustrations";
 
 /**
  * TransactionHistory Page Component
@@ -1136,8 +1137,8 @@ export function TransactionHistory() {
        */}
       <div className="th-table-container">
         {filteredTransactions.length === 0 ? (
-          <div className="th-empty th-empty-no-results">
-            <div className="th-empty-icon">🔍</div>
+          <div className="empty-state">
+            <NoDataGraph className="empty-state-illustration--muted" />
             <h3>No transactions match these filters</h3>
             <p>Try another transaction type, date range, or search term.</p>
             {hasActiveFilters && (


### PR DESCRIPTION
Closes #298

## Summary

Completes the empty-state migration started in PR #344 by replacing
the emoji in the "no filtered results" state with the shared
`NoDataGraph` SVG illustration. All three empty states now use a
consistent design system.

## Changes

- `TransactionHistory.tsx` — import `NoDataGraph`, replace container
  class + emoji with `.empty-state` + SVG
- `TransactionHistory.css` — add `.empty-state h3` for heading
  hierarchy consistency
- `TransactionHistory.test.tsx` — verify illustration renders in DOM

## Verification

- 9/10 tests passing on this branch
- 1 pre-existing failure unrelated to this change (confirmed identical
  on `upstream/main`)


