### PR TITLE
task: emphasize Defaulted credit line rows with non-color cues

### DIFF
--- a/src/pages/CreditLines.css
+++ b/src/pages/CreditLines.css
@@ -317,6 +317,27 @@
     background: rgba(63, 185, 80, 0.2);
 }
 
+/* ─── Defaulted Row — visual treatment ──────────────────────────────────────── */
+
+/* 3px left-edge error stripe (non-color emphasis) */
+.cl-row--defaulted {
+  border-left: 3px solid rgba(248, 81, 73, 0.8);
+  padding-left: calc(var(--space-md, 1rem) - 3px); /* compensate for border width */
+}
+
+/* Bold the line name in defaulted rows */
+.cl-row--defaulted .cl-name,
+.cl-row--defaulted .cl-col-name {
+  font-weight: 600;
+}
+
+/* Forced-colors mode: use system ButtonText so stripe stays visible */
+@media (forced-colors: active) {
+  .cl-row--defaulted {
+    border-left-color: ButtonText;
+  }
+}
+
 /* ─── Responsive ─────────────────────────────────────────────────────────────── */
 
 @media (max-width: 768px) {

--- a/src/pages/CreditLines.test.tsx
+++ b/src/pages/CreditLines.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+import CreditLines from './CreditLines';
+
+// CL-2023-004 ("Emergency Reserve Line") is the only Defaulted entry in MOCK_CREDIT_LINES
+const DEFAULTED_ID = 'CL-2023-004';
+const DEFAULTED_NAME = 'Emergency Reserve Line';
+
+// All non-defaulted IDs from mock data
+const NON_DEFAULTED_IDS = ['CL-2024-001', 'CL-2024-002', 'CL-2023-003', 'CL-2022-005', 'CL-2025-006'];
+
+function renderCreditLines() {
+  return render(
+    <MemoryRouter>
+      <CreditLines />
+    </MemoryRouter>,
+  );
+}
+
+describe('CreditLines — Defaulted row visual treatment (issue #223)', () => {
+  // ─── Card view ────────────────────────────────────────────────────────────
+
+  describe('card view', () => {
+    it('applies cl-row--defaulted class to the Defaulted card', () => {
+      renderCreditLines();
+
+      // The defaulted card carries aria-label — use it as a stable selector
+      const defaultedCard = screen.getByLabelText(`Credit line ${DEFAULTED_ID} is defaulted`);
+      expect(defaultedCard).toHaveClass('cl-row--defaulted');
+    });
+
+    it('does NOT apply cl-row--defaulted class to non-defaulted cards', () => {
+      renderCreditLines();
+
+      // Find all cards that do NOT have the defaulted aria-label
+      const allHeadings = screen.getAllByRole('heading', { level: 3 });
+
+      allHeadings
+        .filter(h => h.textContent !== DEFAULTED_NAME)
+        .forEach(heading => {
+          // Walk up to the card root (the div with cl-card)
+          const card = heading.closest('.cl-card');
+          expect(card).not.toHaveClass('cl-row--defaulted');
+        });
+    });
+
+    it('sets aria-label on the Defaulted card', () => {
+      renderCreditLines();
+
+      const defaultedCard = screen.getByLabelText(`Credit line ${DEFAULTED_ID} is defaulted`);
+      expect(defaultedCard).toBeInTheDocument();
+      expect(defaultedCard).toHaveAttribute(
+        'aria-label',
+        `Credit line ${DEFAULTED_ID} is defaulted`,
+      );
+    });
+
+    it('does NOT set aria-label on non-defaulted cards', () => {
+      renderCreditLines();
+
+      const allHeadings = screen.getAllByRole('heading', { level: 3 });
+
+      allHeadings
+        .filter(h => h.textContent !== DEFAULTED_NAME)
+        .forEach(heading => {
+          const card = heading.closest('.cl-card');
+          expect(card).not.toHaveAttribute('aria-label');
+        });
+    });
+  });
+
+  // ─── Status-filter sanity check ───────────────────────────────────────────
+
+  describe('only Defaulted status gets the treatment', () => {
+    it('exactly one card has cl-row--defaulted when all statuses are shown', () => {
+      renderCreditLines();
+
+      const defaultedCards = document.querySelectorAll('.cl-row--defaulted');
+      expect(defaultedCards).toHaveLength(1);
+    });
+
+    it('cl-row--defaulted card contains the correct credit line name', () => {
+      renderCreditLines();
+
+      const defaultedCard = document.querySelector('.cl-row--defaulted');
+      expect(defaultedCard).not.toBeNull();
+      expect(within(defaultedCard as HTMLElement).getByRole('heading', { level: 3 }))
+        .toHaveTextContent(DEFAULTED_NAME);
+    });
+  });
+});

--- a/src/pages/CreditLines.tsx
+++ b/src/pages/CreditLines.tsx
@@ -15,8 +15,13 @@ function CreditLineCard({ line }: { line: typeof MOCK_CREDIT_LINES[0] }) {
   const pct = utilizationPct(line.utilized, line.limit);
   const level = getUtilizationLevel(line.utilized, line.limit);
 
+  const isDefaulted = line.status === 'Defaulted';
+
   return (
-    <div className="cl-card">
+    <div
+      className={`cl-card${isDefaulted ? ' cl-row--defaulted' : ''}`}
+      aria-label={isDefaulted ? `Credit line ${line.id} is defaulted` : undefined}
+    >
       <div className="cl-card-header">
         <div>
           <h3 className="cl-name">{line.name}</h3>

--- a/src/pages/DutchAuctions.tsx
+++ b/src/pages/DutchAuctions.tsx
@@ -30,7 +30,7 @@ export const DutchAuctions: React.FC = () => {
       </div>
 
       <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem' }}>
-        {(['all', 'active', 'completed'].map((f) => (
+        {['all', 'active', 'completed'].map((f) => (
           <button
             key={f}
             onClick={() => setFilter(f as any)}


### PR DESCRIPTION
## Summary
Improves visual treatment of `Defaulted` credit line rows with non-color emphasis so the status is distinguishable without relying on color alone (WCAG 1.4.1 compliance).

## Changes

### `src/pages/CreditLines.css`
- Added `.cl-row--defaulted` — 3px left-edge stripe using `rgba(248, 81, 73, 0.8)` matching `STATUS_COLOR.Defaulted`
- Added `.cl-row--defaulted .cl-name` — `font-weight: 600` for bold line name
- Added `@media (forced-colors: active)` — falls back to `ButtonText` for stripe visibility in high-contrast mode

### `src/pages/CreditLines.tsx`
- Added `isDefaulted` derived boolean per card
- Applied `cl-row--defaulted` class to defaulted card root div
- Added `aria-label="Credit line {id} is defaulted"` on defaulted cards for screen readers

### `src/pages/CreditLines.test.tsx` (new)
- Defaulted card has `cl-row--defaulted` class
- Non-defaulted cards do not have the class
- aria-label set correctly on defaulted cards
- aria-label absent on non-defaulted cards

### `src/pages/DutchAuctions.tsx`
- Fixed pre-existing syntax error (stray `(` at line 33) that was blocking the dev server

## Visual Result
- Emergency Reserve Line (Defaulted) shows red left stripe and bold name
- All other cards unchanged

Closes #223