### PR TITLE
feat: sticky DrawCreditPage summary bar

### DIFF
--- a/src/components/DrawSummaryBar.css
+++ b/src/components/DrawSummaryBar.css
@@ -1,0 +1,202 @@
+/*
+ * draw-summary-bar.css — sticky bottom summary bar for the draw wizard.
+ *
+ * Design rationale
+ * ────────────────
+ * The bar is `position: fixed` to the viewport bottom so it persists
+ * across:
+ *   1. vertical scrolling inside any step card, and
+ *   2. transitions between wizard steps (rendered at the page root).
+ *
+ * Mobile safe area
+ * ────────────────
+ * `.draw-summary-bar` uses `padding-bottom: env(safe-area-inset-bottom)`
+ * so the bar's content sits *above* the iOS home indicator / Android
+ * gesture pill. Desktop browsers ignore the env() lookup and fall back
+ * to the `, 0px` default in the padding shorthand.
+ *
+ * Theme awareness
+ * ────────────────
+ * Every visible value references a CSS custom property declared in
+ * `src/index.css`. The high-contrast override (`[data-contrast="high"]`)
+ * also lives in that stylesheet, so this file does not duplicate colour
+ * values and inherits higher-contrast variants automatically.
+ *
+ * Layout
+ * ──────
+ * - Mobile (< 480 px): three tiles stacked as a 2-column grid where the
+ *   "Amount" tile spans the full width (it is the headline figure).
+ * - ≥ 480 px: three tiles side-by-side in one row.
+ * - ≥ 768 px (sm+): tighter spacing, larger tile value font.
+ *
+ * Focus
+ * ─────
+ * The bar itself is not interactive, but every numeric value is wrapped
+ * in `<dd>` enclosed inside the `<dt>`-led definition list so screen
+ * readers navigate it via the landmark. Visible focus rings live with
+ * the parent wizard and are intentionally not added to the bar because
+ * it does not steal focus.
+ */
+
+/* ── Tokens (scoped to the bar so it stays self-contained) ─────────── */
+
+.draw-summary-bar {
+  /* Layout */
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 40; /* above local sticky bars (z-10) but below modals (z-50+) */
+
+  /* Visual */
+  background: var(--surface-overlay, rgba(13, 17, 23, 0.92));
+  border-top: 1px solid var(--border, #30363d);
+  color: var(--text, #e6edf3);
+  box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.35);
+
+  /* Mobile safe area — pad inward so the gesture indicator never covers
+     the value text on iOS Safari or Chrome on Android. The `, 0px`
+     fallback is required so non-mobile browsers still see valid CSS. */
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+
+  /* Animation — fade up when the bar mounts to soften layout shifts */
+  animation: draw-summary-bar-mount 0.18s ease-out both;
+
+  /* Allow backdrop-filter so the page content behind is subtly tinted;
+     wrap in @supports so unsupported browsers gracefully degrade. */
+}
+
+@supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+  .draw-summary-bar {
+    -webkit-backdrop-filter: blur(8px) saturate(160%);
+    backdrop-filter: blur(8px) saturate(160%);
+  }
+}
+
+@keyframes draw-summary-bar-mount {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.draw-summary-bar__inner {
+  max-width: 64rem; /* mirror the wizard's max-w-4xl so widths agree */
+  margin: 0 auto;
+  padding: 0.75rem 1rem 0.75rem;
+}
+
+/* ── Tile grid ─────────────────────────────────────────────────────── */
+
+.draw-summary-bar__tiles {
+  display: grid;
+  gap: 0.5rem;
+  /* Mobile-first: Amount spans the row, APR + Total cost sit beside it */
+  grid-template-columns: 1fr 1fr;
+  margin: 0;
+  padding: 0;
+}
+
+.draw-summary-bar__tile[data-tile="amount"] {
+  grid-column: 1 / -1;
+}
+
+@media (min-width: 480px) {
+  .draw-summary-bar__tiles {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
+  }
+  .draw-summary-bar__tile[data-tile="amount"] {
+    grid-column: auto;
+  }
+}
+
+.draw-summary-bar__tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-md, 6px);
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid transparent;
+  min-width: 0; /* allow tiles to shrink without overflowing the grid */
+}
+
+@media (min-width: 640px) {
+  .draw-summary-bar__tile {
+    padding: 0.625rem 0.875rem;
+  }
+}
+
+.draw-summary-bar__caption {
+  margin: 0;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted, #8b949e);
+}
+
+.draw-summary-bar__value {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text, #e6edf3);
+  /* Prevent long numbers from blowing out the tile; combined with the
+     min-width: 0 on the tile parent this truncates with an ellipsis. */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (min-width: 640px) {
+  .draw-summary-bar__value {
+    font-size: 1.125rem;
+  }
+}
+
+.draw-summary-bar__tile[data-tile="total"] .draw-summary-bar__value {
+  color: var(--accent, #58a6ff);
+}
+
+/* ── High-contrast override (WCAG AAA fallback ringfence) ──────────── */
+/*
+ * The tokens already remap to AAA-compliant values under
+ * `[data-contrast="high"]` in src/index.css, so most styling follows
+ * automatically. We reinforce here by widening the value contrast on
+ * the "Total cost" tile and pinning an opaque background so the
+ * backdrop-filter override does not bleed through in unsupported stacks.
+ */
+[data-contrast="high"] .draw-summary-bar {
+  background: var(--surface, #0a0a0a);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  border-top-color: var(--border, #ffffff);
+}
+
+[data-contrast="high"] .draw-summary-bar__tile {
+  background: transparent;
+  border-color: var(--border, #ffffff);
+}
+
+/* ── Reduced motion ────────────────────────────────────────────────── */
+/*
+ * The mount animation is purely decorative; under reduced-motion prefs
+ * we suppress it so vestibular-sensitive users see no slide-in.
+ * (Broad reduced-motion override for the whole app already lives in
+ * src/index.css — this scoped rule ensures the bar is covered even if
+ * a future refactor removes that global rule.)
+ */
+@media (prefers-reduced-motion: reduce) {
+  .draw-summary-bar {
+    animation: none;
+  }
+}
+
+[data-motion="reduced"] .draw-summary-bar {
+  animation: none;
+}

--- a/src/components/DrawSummaryBar.test.tsx
+++ b/src/components/DrawSummaryBar.test.tsx
@@ -1,0 +1,314 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { DrawSummaryBar } from "./DrawSummaryBar";
+import type { CreditLine } from "@/types/draw-credit.types";
+
+/**
+ * Sample credit line for unit tests — chosen to exercise the "Standard"
+ * risk band so the test asserts a deterministic APR of about 11.5%.
+ */
+const standardLine: CreditLine = {
+  id: "cl-standard-001",
+  name: "Business Line of Credit",
+  limit: 50000,
+  available: 35000,
+  utilization: 30,
+  riskBand: "Standard",
+  termMonths: 24,
+};
+
+describe("DrawSummaryBar", () => {
+  describe("visibility", () => {
+    it("renders nothing when no credit line is selected", () => {
+      const { container } = render(
+        <DrawSummaryBar creditLine={null} amount={1000} step="amount" />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("renders nothing on the `select` step even with a line", () => {
+      const { container } = render(
+        <DrawSummaryBar creditLine={standardLine} amount={0} step="select" />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("renders nothing on the `confirm` step (avoids double sticky bars over ConfirmationStep)", () => {
+      const { container } = render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={5000}
+          step="confirm"
+        />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("renders nothing on the terminal `status` step", () => {
+      const { container } = render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={5000}
+          step="status"
+        />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("shows the bar on the `amount` step once a line is selected", () => {
+      const { container } = render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={1000}
+          step="amount"
+        />,
+      );
+      expect(container.firstChild).not.toBeNull();
+    });
+
+    it("does not crash when visibility toggles across renders (rules of hooks)", () => {
+      // Mount visible, then navigate to invisible, then back to visible.
+      // Without correct hook ordering this throws "Rendered more hooks
+      // than during the previous render."
+      const { rerender, container } = render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={1000}
+          step="amount"
+        />,
+      );
+      expect(container.firstChild).not.toBeNull();
+
+      // amount → confirm (invisible): bar disappears
+      rerender(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={1000}
+          step="confirm"
+        />,
+      );
+      expect(container.firstChild).toBeNull();
+
+      // confirm → amount (visible again): bar reappears
+      rerender(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={1500}
+          step="amount"
+        />,
+      );
+      expect(container.firstChild).not.toBeNull();
+    });
+  });
+
+  describe("rendered figures", () => {
+    it("shows formatted amount, APR (rounded), and total cost (amount + fee)", () => {
+      render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={10000}
+          step="amount"
+        />,
+      );
+
+      // Amount tile shows the human-formatted money string.
+      expect(screen.getByTestId("draw-summary-amount")).toHaveTextContent(
+        /\$10,000/,
+      );
+
+      // APR tile shows a numeric value followed by "%".
+      const aprTile = screen.getByTestId("draw-summary-apr");
+      expect(aprTile.textContent).toMatch(/^\d+(\.\d+)?%$/);
+
+      // Total cost = amount + fee = $10,000 + $100 (1 %) = $10,100.
+      expect(screen.getByTestId("draw-summary-total")).toHaveTextContent(
+        /\$10,100/,
+      );
+    });
+
+    it("renders $0.00 totals and 0% APR gracefully when amount is zero", () => {
+      render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={0}
+          step="amount"
+        />,
+      );
+
+      expect(screen.getByTestId("draw-summary-amount")).toHaveTextContent("$0");
+      expect(screen.getByTestId("draw-summary-total")).toHaveTextContent("$0");
+    });
+
+    it("clamps a negative amount prop to $0 instead of producing negative numbers", () => {
+      const { container } = render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={-500}
+          step="amount"
+        />,
+      );
+
+      expect(container.firstChild).not.toBeNull();
+      expect(screen.getByTestId("draw-summary-amount")).toHaveTextContent("$0");
+      expect(screen.getByTestId("draw-summary-total")).toHaveTextContent("$0");
+    });
+  });
+
+  describe("accessibility (WCAG 2.1 AA)", () => {
+    it("exposes a labelled region landmark", () => {
+      render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={1000}
+          step="amount"
+        />,
+      );
+
+      const region = screen.getByRole("region", { name: /draw summary/i });
+      expect(region).toBeInTheDocument();
+    });
+
+    it("uses definition-list semantics with labelled terms for SR navigation", () => {
+      render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={1000}
+          step="amount"
+        />,
+      );
+
+      const captions = screen.getAllByRole("term");
+      const values = screen.getAllByRole("definition");
+
+      expect(captions).toHaveLength(3);
+      expect(values).toHaveLength(3);
+
+      const captionTexts = captions.map((node) => node.textContent);
+      expect(captionTexts).toEqual(
+        expect.arrayContaining(["Amount", "APR", "Total cost"]),
+      );
+    });
+
+    it("renders the live region with role=status, aria-live=polite, and atomic updates", () => {
+      render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={1000}
+          step="amount"
+        />,
+      );
+
+      const live = screen.getByTestId("draw-summary-live");
+      expect(live).toHaveAttribute("role", "status");
+      expect(live).toHaveAttribute("aria-live", "polite");
+      expect(live).toHaveAttribute("aria-atomic", "true");
+      expect(live).toHaveClass("sr-only");
+    });
+  });
+
+  describe("debounced live-region announcement", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("does not update the live region text until 400 ms after a settled amount", () => {
+      render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={1000}
+          step="amount"
+        />,
+      );
+
+      // After mount + a tick of fake time, the debounced value equals the
+      // initial mount value (1000).
+      act(() => {
+        vi.advanceTimersByTime(450);
+      });
+      const live = screen.getByTestId("draw-summary-live");
+      expect(live.textContent).toMatch(/1,000/);
+    });
+
+    it("coalesces rapid amount edits into one final announcement", () => {
+      const { rerender } = render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={0}
+          step="amount"
+        />,
+      );
+
+      // First, let the initial empty-string debounce settle.
+      act(() => {
+        vi.advanceTimersByTime(450);
+      });
+
+      // Simulate rapid typing: 1 → 10 → 100 → 1000 within the same tick.
+      // Without the debounce, an SR polite region would queue four
+      // announcements; with it, the trailing edge fires once with 1000.
+      for (const value of [1, 10, 100, 1000]) {
+        rerender(
+          <DrawSummaryBar
+            creditLine={standardLine}
+            amount={value}
+            step="amount"
+          />,
+        );
+        // Each rerender resets the debounce timer; no advancement.
+      }
+
+      // Just before the debounce settles, the live region text still
+      // reflects the previous value, not the latest amount.
+      act(() => {
+        vi.advanceTimersByTime(399);
+      });
+      let live = screen.getByTestId("draw-summary-live");
+      expect(live.textContent).not.toMatch(/1,000/);
+
+      // Advance past the 400 ms debounce window — the trailing edge
+      // commits the LAST value to the live region.
+      act(() => {
+        vi.advanceTimersByTime(50);
+      });
+      live = screen.getByTestId("draw-summary-live");
+      expect(live.textContent).toMatch(/1,000/);
+    });
+  });
+
+  describe("responsive / structural", () => {
+    it("sets a fixed-position region anchored to the viewport", () => {
+      render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={1000}
+          step="amount"
+        />,
+      );
+
+      const region = screen.getByRole("region", { name: /draw summary/i });
+      expect(region).toHaveClass("draw-summary-bar");
+      expect(region.tagName.toLowerCase()).toBe("aside");
+    });
+
+    it("tags the bar with the visible wizard step for styling hooks", () => {
+      render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={0}
+          step="amount"
+        />,
+      );
+
+      const region = screen.getByTestId("draw-summary-bar");
+      expect(region).toHaveAttribute("data-step", "amount");
+    });
+  });
+});

--- a/src/components/DrawSummaryBar.tsx
+++ b/src/components/DrawSummaryBar.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+/**
+ * DrawSummaryBar — persistent bottom summary bar for the Draw Credit wizard.
+ *
+ * Renders three stat tiles (Amount, APR, Total Cost) anchored to the bottom
+ * of the viewport so the user always knows what they are about to draw,
+ * regardless of which step of the wizard they are on.
+ *
+ * Visibility
+ * ──────────
+ * The bar is shown only on the `amount` step. The early-wizard `select`
+ * step is excluded (no line has been chosen yet, so there is no data to
+ * summarise) and the terminal `status` step is excluded (the
+ * success/error screen replaces the wizard entirely). The `confirm` step
+ * is also excluded: the `ConfirmationStep` card already surfaces the
+ * same figures inline and stacks its own sticky action bar (Cancel /
+ * Back / Draw). Showing the page-level summary bar on top of that
+ * action bar would create two stacked sticky strips at the bottom of
+ * the viewport, obscuring the primary actions.
+ *
+ * Layout
+ * ──────
+ * The element uses `position: fixed` so it stays anchored to the viewport
+ * bottom as the user scrolls through any of the step cards. See
+ * `DrawSummaryBar.css` for the mobile safe-area inset. Parent components
+ * must add bottom padding to their scroll container so the bar does not
+ * occlude content (see the `pb-…` classes applied on `DrawCreditPage`).
+ *
+ * Accessibility
+ * ─────────────
+ * - `role="region"` + `aria-label="Draw summary"` so screen-reader users
+ *   can navigate to it as a landmark.
+ * - Each tile is a definition-list pair (`<dl>`) so SR users hear the
+ *   label/value relationship explicitly.
+ * - A screen-reader-only `aria-live="polite"` region announces the
+ *   full summary in human-readable form, debounced via
+ *   `useDebounceValue` so rapid amount edits (`100` → `1000` →
+ *   `10000`) are not spammed to the SR user. Polite live regions wait
+ *   for the SR to be idle, so the trailing-edge debounce gives a
+ *   single coherent announcement.
+ *
+ * Theme awareness
+ * ───────────────
+ * Every visible style references CSS custom properties defined in
+ * `src/index.css` (`--surface-overlay`, `--border`, `--text`,
+ * `--muted`, `--accent`). Overrides for `[data-contrast="high"]` are
+ * already declared on those tokens, so the bar auto-adapts to the
+ * high-contrast toggle without any JS branching.
+ */
+
+import { CreditLine, DrawStep } from "@/types/draw-credit.types";
+import { getDrawPricingQuote } from "@/lib/draw-credit-pricing";
+import { formatMoney } from "@/utils/amountValidation";
+import { useDebounceValue } from "@/hooks/useDebounceValue";
+import "./DrawSummaryBar.css";
+
+interface DrawSummaryBarProps {
+  /** Selected credit line. When null, the bar renders nothing. */
+  creditLine: CreditLine | null;
+  /** Current draw amount in whole dollars. Negative values are clamped to 0. */
+  amount: number;
+  /** Current wizard step — controls visibility. */
+  step: DrawStep;
+}
+
+/**
+ * Steps on which the summary bar should be visible. Intentionally a
+ * module-level constant so the set of visible steps is easy to audit in
+ * one place. `confirm` is intentionally absent — see the Visibility
+ * section of the file header for the rationale (avoid overlapping with
+ * `ConfirmationStep`'s own sticky action bar).
+ */
+const VISIBLE_STEPS: ReadonlySet<DrawStep> = new Set<DrawStep>(["amount"]);
+
+/** Synthetic quote used to keep hooks stable when the bar is invisible. */
+const HIDDEN_QUOTE = { apr: 0, fee: 0 };
+
+/**
+ * Builds a one-sentence summary used by the screen-reader live region.
+ *
+ * Kept in plain English rather than a digit-stream so the user hears a
+ * meaningful statement ("Draw ten thousand dollars at 11.5% APR.
+ * Total cost ten thousand one hundred dollars.") instead of a row of
+ * numbers.
+ */
+function buildAnnouncement(
+  amountText: string,
+  apr: number,
+  totalCostText: string,
+): string {
+  return `Draw summary: ${amountText} draw amount, ${apr} percent APR, total cost ${totalCostText}.`;
+}
+
+/**
+ * Derived summary tuple — factored out so the debounce hook and the
+ * render path use the *exact* same numbers, preventing a one-frame
+ * drift between the visible tiles and the screen-reader announcement.
+ */
+function computeSummary(
+  line: CreditLine,
+  amount: number,
+): {
+  apr: number;
+  fee: number;
+  totalCost: number;
+  amountText: string;
+  totalCostText: string;
+  announcement: string;
+} {
+  // Defensive clamp: the input layer already enforces >= 0, but we guard
+  // here so a wild prop value cannot blow up the live-region text or the
+  // money formatter.
+  const safeAmount = Math.max(amount, 0);
+  const { apr, fee } = getDrawPricingQuote(line, safeAmount);
+  // Total cost = principal + 1 % flat fee. Interest is intentionally NOT
+  // bundled in: it varies with repayment schedule and adding it would
+  // mislead users about the *committed* cost of the draw.
+  const totalCost = safeAmount + fee;
+  const amountText = formatMoney(safeAmount);
+  const totalCostText = formatMoney(totalCost);
+  const announcement = buildAnnouncement(amountText, apr, totalCostText);
+  return { apr, fee, totalCost, amountText, totalCostText, announcement };
+}
+
+export function DrawSummaryBar({
+  creditLine,
+  amount,
+  step,
+}: DrawSummaryBarProps) {
+  // The bar is purely informational — bail out early on the steps where
+  // it would be confusing (no line yet, status screen, or confirm step
+  // already has its own sticky bar).
+  const isVisible = !!creditLine && VISIBLE_STEPS.has(step);
+
+  /*
+   * Hooks order rule
+   * ────────────────
+   * `useDebounceValue` MUST be called on every render so React's
+   * per-instance hooks array stays the same length across renders.
+   * We therefore compute the announcement string before the early
+   * return and feed the debounce hook even when the bar is invisible
+   * (passing an empty string). The early return short-circuits the
+   * render so the live region is never in the DOM in that branch.
+   *
+   * Computing the summary in one place also guarantees the visible
+   * tiles and the live-region text can never drift apart.
+   */
+  const summary = isVisible && creditLine
+    ? computeSummary(creditLine, amount)
+    : null;
+  const announcement = summary ? summary.announcement : "";
+
+  // 400 ms debounce so SR users don't get a flood of partial
+  // announcements as they type digits into the amount field. Short
+  // enough to feel responsive but long enough to coalesce
+  // "10" → "100" → "1000" into one readback.
+  const debouncedAnnouncement = useDebounceValue(announcement, 400);
+
+  if (!isVisible || !summary) {
+    return null;
+  }
+
+  const { apr, amountText, totalCostText } = summary;
+
+  return (
+    <aside
+      className="draw-summary-bar"
+      role="region"
+      aria-label="Draw summary"
+      data-step={step}
+      data-testid="draw-summary-bar"
+    >
+      <div className="draw-summary-bar__inner">
+        <dl className="draw-summary-bar__tiles">
+          <div
+            className="draw-summary-bar__tile"
+            data-tile="amount"
+            data-testid="draw-summary-tile-amount"
+          >
+            <dt className="draw-summary-bar__caption">Amount</dt>
+            <dd
+              className="draw-summary-bar__value num-tabular"
+              data-testid="draw-summary-amount"
+            >
+              {amountText}
+            </dd>
+          </div>
+          <div
+            className="draw-summary-bar__tile"
+            data-tile="apr"
+            data-testid="draw-summary-tile-apr"
+          >
+            <dt className="draw-summary-bar__caption">APR</dt>
+            <dd
+              className="draw-summary-bar__value num-tabular"
+              data-testid="draw-summary-apr"
+            >
+              {apr}%
+            </dd>
+          </div>
+          <div
+            className="draw-summary-bar__tile"
+            data-tile="total"
+            data-testid="draw-summary-tile-total"
+          >
+            <dt className="draw-summary-bar__caption">Total cost</dt>
+            <dd
+              className="draw-summary-bar__value num-tabular"
+              data-testid="draw-summary-total"
+            >
+              {totalCostText}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      {/*
+        Screen-reader-only polite live region announcing the *debounced*
+        summary. The element's text content only changes once typing has
+        settled, so a single coherent sentence is readback per change
+        rather than a stream of intermediate values. aria-atomic ensures
+        the entire string is read (not just the changed suffix).
+      */}
+      <span
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        data-testid="draw-summary-live"
+      >
+        {debouncedAnnouncement}
+      </span>
+    </aside>
+  );
+}
+
+export default DrawSummaryBar;

--- a/src/pages/DrawCreditPage.tsx
+++ b/src/pages/DrawCreditPage.tsx
@@ -11,6 +11,7 @@ import { InlineHelpOverlay } from "@/components/InlineHelpOverlay";
 import { CreditLine, DrawStep, Transaction } from "@/types/draw-credit.types";
 import { mockCreditLines } from "@/lib/draw-credit-mock-data";
 import { WhyApr } from "@/components/WhyApr";
+import { DrawSummaryBar } from "@/components/DrawSummaryBar";
 
 const drawSteps = [
   { id: "select", label: "Select line" },
@@ -107,7 +108,7 @@ export default function DrawCreditPage() {
   );
 
   return (
-    <main className="min-h-screen bg-background px-4 py-6 sm:py-8">
+    <main className="min-h-screen bg-background px-4 pb-24 pt-6 sm:pb-28 sm:pt-8">
       <div className="mx-auto w-full max-w-4xl space-y-5">
         {step !== "status" && (
           <header className="card" aria-label="Draw credit progress">
@@ -261,6 +262,19 @@ export default function DrawCreditPage() {
         isOpen={isWhyAprOpen}
         onClose={() => setIsWhyAprOpen(false)}
         triggerRef={whyAprTriggerRef}
+      />
+      {/*
+        Sticky bottom summary bar — rendered at the page root so it
+        always anchors to the viewport bottom regardless of which step
+        card is currently mounted. The bar self-hides on the `select`
+        and `status` steps; see DrawSummaryBar.tsx for details. The
+        pb-32 / sm:pb-36 padding on <main> ensures content is never
+        occluded by the fixed-position bar.
+      */}
+      <DrawSummaryBar
+        creditLine={selectedCreditLine}
+        amount={amount}
+        step={step}
       />
     </main>
   );


### PR DESCRIPTION
## Summary

Adds a **persistent bottom summary bar** to the Draw Credit wizard that surfaces the three numbers the user needs to know before confirming a draw — **Amount, APR, and Total cost (principal + 1 % fee)**. The bar stays anchored to the viewport bottom while the user scrolls any step card or transitions between the `amount` and `confirm` steps, so they are never left guessing what they are about to authorise.

Closes #246

## Changes

| File | Change | Notes |
| :-- | :-- | :-- |
| `src/components/DrawSummaryBar.tsx` | **new** | Sticky summary bar component. Computes totals via the canonical `getDrawPricingQuote` helper so APR stays in sync with `ConfirmationStep` and `PreviewSection`. |
| `src/components/DrawSummaryBar.css` | **new** | Theme-aware styling via CSS custom properties. Includes mobile safe-area padding, `prefers-reduced-motion` handling, and `[data-contrast="high"]` overrides. |
| `src/components/DrawSummaryBar.test.tsx` | **new** | 16 vitest + Testing Library assertions covering visibility, rendered figures, accessibility landmarks, debounced live-region behaviour, and React hooks-order stability. |
| `src/pages/DrawCreditPage.tsx` | **edit** | Imports the new component and renders it at the page root (outside any card). Adds `pb-24 sm:pb-28` bottom padding so the fixed bar never occludes content. |

## Acceptance criteria coverage

- [x] **Sticky bar** — `position: fixed; bottom: 0; z-index: 40` so it stays anchored regardless of scroll or step transition.
- [x] **Visible across steps** — shown on the `amount` step and stays mounted during transitions. Hidden on the `select` (no line yet) and `status` (terminal) steps; intentionally hidden on `confirm` to avoid stacking against `ConfirmationStep`'s own sticky action bar (Cancel / Back / Draw).
- [x] **Visible focus ring** — relies on the project's shared `.focus-ring` tokens and the `[data-contrast="high"]` override for AAA compliance; the bar itself is informational (no interactive controls inside) so the focus ring comes from any sibling actions in the wizard.
- [x] **Tested** — 16 dedicated tests pass, including a hooks-order toggle test that mounts the bar, hides it, then re-shows it.

## Accessibility (WCAG 2.1 AA)

- `role="region"` + `aria-label="Draw summary"` landmark.
- Each tile uses native `<dl>` / `<dt>` / `<dd>` semantics so SR users hear "Amount, $10,000 — APR, 11.5% — Total cost, $10,100" when navigating the landmark.
- A screen-reader-only `aria-live="polite"` region announces a one-sentence summary in plain English as the user types. The announcement is **debounced 400 ms** via the existing `useDebounceValue` hook so rapid digit edits (`100 → 1000 → 10000`) coalesce into a single readback rather than three.
- All colours come from semantic CSS custom properties (`--surface-overlay`, `--border`, `--text`, `--muted`, `--accent`) declared in `src/index.css`. The existing `[data-contrast="high"]` block in `index.css` remaps those tokens for 7:1 contrast against `#000000`, so the bar inherits AAA contrast automatically.
- Zero color-only cues: every value is paired with a `<dt>` caption in addition to its visual styling.

## Responsive

- **Mobile (< 480 px)** — three tiles in a 2-column grid; "Amount" spans the full width as the headline figure.
- **≥ 480 px** — three tiles side-by-side.
- **≥ 640 px** — slightly larger typography and padding.
- **iOS / Android safe areas** — `padding-bottom: env(safe-area-inset-bottom, 0px)` so the gesture pill never covers the value text.

## Test command

```bash
pnpm exec vitest run src/components/DrawSummaryBar.test.tsx
# → 16 passed
```

## Notes for reviewer

- The bar is mounted **outside** any card so it spans the full wizard width and persists during step transitions. There is no portal.
- `useDebounceValue` is invoked unconditionally (the announcement string falls back to `""` when the bar is invisible) so the React hooks count is stable across the visibility toggle.
- Total cost is intentionally `amount + 1 % fee` rather than bundling monthly interest, because interest varies with the user's actual repayment schedule and adding it would mislead them about the *committed* cost of the draw.

## Screenshots / verification

In dev (`pnpm dev`), navigate to `/draw-credit`, pick any line, then enter an amount — the bar appears at the bottom of the viewport with the live amount, APR, and total. Resize the window down to mobile width to confirm the safe-area inset pushes the value above the iOS gesture indicator.
