### PR TITLE
feat: add illustration and back-to-last button to NotFound

### DIFF
--- a/src/pages/ErrorPage.css
+++ b/src/pages/ErrorPage.css
@@ -106,3 +106,33 @@
     flex: 0 0 auto;
   }
 }
+
+/* Illustration */
+
+.error-illustration {
+  width: 160px;
+  height: auto;
+  margin-bottom: 1.25rem;
+  color: var(--text);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .notfound-stars {
+    animation: notfound-twinkle 3s ease-in-out infinite alternate;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .notfound-stars {
+    animation: none;
+  }
+
+  .error-btn-primary:active {
+    transform: none;
+  }
+}
+
+@keyframes notfound-twinkle {
+  from { opacity: 0.15; }
+  to   { opacity: 0.5; }
+}

--- a/src/pages/NotFound.test.tsx
+++ b/src/pages/NotFound.test.tsx
@@ -1,49 +1,89 @@
 /// <reference types="vitest" />
-import { render, screen } from "@testing-library/react";
-import { BrowserRouter } from "react-router-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom";
 import { NotFound } from "./NotFound";
 
-describe("NotFound", () => {
-  it("renders the 404 page with correct content", () => {
-    render(
-      <BrowserRouter>
-        <NotFound />
-      </BrowserRouter>,
-    );
+function renderNotFound() {
+  return render(
+    <MemoryRouter>
+      <NotFound />
+    </MemoryRouter>
+  );
+}
 
-    expect(screen.getByText("Page not found")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "The page you're looking for doesn't exist or has been moved.",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /go back/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: /dashboard/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: /contact support/i }),
-    ).toBeInTheDocument();
+function setHistoryLength(n: number) {
+  Object.defineProperty(window.history, "length", { configurable: true, value: n });
+}
+
+describe("NotFound", () => {
+  let originalLength: number;
+  let originalGo: typeof window.history.go;
+
+  beforeEach(() => {
+    originalLength = window.history.length;
+    originalGo = window.history.go.bind(window.history);
   });
 
-  it("has accessible elements", () => {
-    render(
-      <BrowserRouter>
-        <NotFound />
-      </BrowserRouter>,
-    );
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setHistoryLength(originalLength);
+    window.history.go = originalGo;
+  });
 
-    expect(
-      screen.getByRole("heading", { name: "Page not found" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByLabelText("Go back to previous page"),
-    ).toBeInTheDocument();
-    expect(screen.getByLabelText("Return to dashboard")).toBeInTheDocument();
-    expect(
-      screen.getByLabelText("Contact support via email"),
-    ).toBeInTheDocument();
+  it("renders a <main> landmark labelled by the h1", () => {
+    renderNotFound();
+    const main = screen.getByRole("main");
+    const id = main.getAttribute("aria-labelledby");
+    expect(document.getElementById(id!)).toHaveTextContent(/page not found/i);
+  });
+
+  it("renders heading and body copy", () => {
+    renderNotFound();
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(/page not found/i);
+    expect(screen.getByText(/doesn't exist or has been moved/i)).toBeInTheDocument();
+  });
+
+  it('shows "Go back" button when history is available', () => {
+    setHistoryLength(3);
+    renderNotFound();
+    expect(screen.getByRole("button", { name: /go back/i })).toBeInTheDocument();
+  });
+
+  it('shows "Go to Dashboard" link when there is no history', () => {
+    setHistoryLength(1);
+    renderNotFound();
+    expect(screen.getByRole("link", { name: /go to dashboard/i })).toBeInTheDocument();
+  });
+
+  it("calls history.go(-1) on Go back click", () => {
+    setHistoryLength(3);
+    const goSpy = vi.fn();
+    window.history.go = goSpy;
+    renderNotFound();
+    fireEvent.click(screen.getByRole("button", { name: /go back/i }));
+    expect(goSpy).toHaveBeenCalledWith(-1);
+  });
+
+  it("Go to Dashboard link points to /", () => {
+    setHistoryLength(1);
+    renderNotFound();
+    expect(screen.getByRole("link", { name: /go to dashboard/i })).toHaveAttribute("href", "/");
+  });
+
+  it("SVG illustration is aria-hidden", () => {
+    renderNotFound();
+    expect(document.querySelector("svg.error-illustration")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("matches snapshot with history", () => {
+    setHistoryLength(3);
+    expect(renderNotFound().asFragment()).toMatchSnapshot();
+  });
+
+  it("matches snapshot without history", () => {
+    setHistoryLength(1);
+    expect(renderNotFound().asFragment()).toMatchSnapshot();
   });
 });

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import "./ErrorPage.css";
 
@@ -10,41 +11,71 @@ import "./ErrorPage.css";
  * the user learns one recovery pattern.
  *
  * Surfaces two affordances:
- * - "Go back" — calls `window.history.back()`
- * - "Go to dashboard" — `Link` to `/`
+ * - "Go back" — calls `window.history.go(-1)` when history is available,
+ *   otherwise falls back to a "Go to Dashboard" `Link` to `/`
+ * - "Contact Support" — mailto link
  *
  * Both keep keyboard semantics native (button + link).
  */
 export function NotFound() {
-  const handleGoBack = () => {
-    window.history.back();
-  };
+  // Checked after mount to avoid SSR mismatch on history.length
+  const [canGoBack, setCanGoBack] = useState(false);
+
+  useEffect(() => {
+    setCanGoBack(window.history.length > 1);
+  }, []);
 
   return (
-    <div className="error-page">
+    <main className="error-page" aria-labelledby="notfound-title">
       <div className="error-content">
-        <div className="error-icon" aria-hidden="true">
-          🔍
-        </div>
-        <h1 className="error-title">Page not found</h1>
+
+        {/* currentColor inherits var(--text), so this works in both themes */}
+        <svg
+          className="error-illustration"
+          aria-hidden="true"
+          focusable="false"
+          viewBox="0 0 200 160"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <ellipse cx="100" cy="148" rx="70" ry="8" fill="currentColor" opacity="0.06" />
+          <line x1="124" y1="114" x2="148" y2="138" stroke="currentColor" strokeWidth="7" strokeLinecap="round" opacity="0.55" />
+          <circle cx="90" cy="82" r="36" fill="none" stroke="currentColor" strokeWidth="7" opacity="0.6" />
+          <circle cx="90" cy="82" r="29" fill="currentColor" opacity="0.04" />
+          <path d="M 82 72 Q 82 62 90 62 Q 98 62 98 70 Q 98 78 90 81" fill="none" stroke="currentColor" strokeWidth="4" strokeLinecap="round" opacity="0.75" />
+          <circle cx="90" cy="92" r="3" fill="currentColor" opacity="0.75" />
+          {/* animation disabled via CSS under prefers-reduced-motion */}
+          <g className="notfound-stars">
+            <circle cx="30"  cy="30"  r="2"   fill="currentColor" opacity="0.3" />
+            <circle cx="165" cy="22"  r="1.5" fill="currentColor" opacity="0.3" />
+            <circle cx="178" cy="70"  r="1"   fill="currentColor" opacity="0.25" />
+            <circle cx="20"  cy="100" r="1.5" fill="currentColor" opacity="0.2" />
+            <circle cx="155" cy="120" r="1"   fill="currentColor" opacity="0.25" />
+          </g>
+        </svg>
+
+        <h1 id="notfound-title" className="error-title">Page not found</h1>
         <p className="error-message">
           The page you're looking for doesn't exist or has been moved.
         </p>
+
         <div className="error-actions">
-          <button
-            className="error-btn error-btn-primary"
-            onClick={handleGoBack}
-            aria-label="Go back to previous page"
-          >
-            Go Back
-          </button>
-          <Link
-            to="/"
-            className="error-btn error-btn-secondary"
-            aria-label="Return to dashboard"
-          >
-            Dashboard
-          </Link>
+          {canGoBack ? (
+            <button
+              className="error-btn error-btn-primary"
+              onClick={() => window.history.go(-1)}
+              aria-label="Go back to previous page"
+            >
+              Go back
+            </button>
+          ) : (
+            <Link
+              to="/"
+              className="error-btn error-btn-primary"
+              aria-label="Go to Dashboard"
+            >
+              Go to Dashboard
+            </Link>
+          )}
           <a
             href="mailto:support@creditra.com"
             className="error-btn error-btn-secondary"
@@ -53,7 +84,8 @@ export function NotFound() {
             Contact Support
           </a>
         </div>
+
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/pages/__snapshots__/NotFound.test.tsx.snap
+++ b/src/pages/__snapshots__/NotFound.test.tsx.snap
@@ -1,0 +1,278 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`NotFound > matches snapshot with history 1`] = `
+<DocumentFragment>
+  <main
+    aria-labelledby="notfound-title"
+    class="error-page"
+  >
+    <div
+      class="error-content"
+    >
+      <svg
+        aria-hidden="true"
+        class="error-illustration"
+        focusable="false"
+        viewBox="0 0 200 160"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <ellipse
+          cx="100"
+          cy="148"
+          fill="currentColor"
+          opacity="0.06"
+          rx="70"
+          ry="8"
+        />
+        <line
+          opacity="0.55"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-width="7"
+          x1="124"
+          x2="148"
+          y1="114"
+          y2="138"
+        />
+        <circle
+          cx="90"
+          cy="82"
+          fill="none"
+          opacity="0.6"
+          r="36"
+          stroke="currentColor"
+          stroke-width="7"
+        />
+        <circle
+          cx="90"
+          cy="82"
+          fill="currentColor"
+          opacity="0.04"
+          r="29"
+        />
+        <path
+          d="M 82 72 Q 82 62 90 62 Q 98 62 98 70 Q 98 78 90 81"
+          fill="none"
+          opacity="0.75"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-width="4"
+        />
+        <circle
+          cx="90"
+          cy="92"
+          fill="currentColor"
+          opacity="0.75"
+          r="3"
+        />
+        <g
+          class="notfound-stars"
+        >
+          <circle
+            cx="30"
+            cy="30"
+            fill="currentColor"
+            opacity="0.3"
+            r="2"
+          />
+          <circle
+            cx="165"
+            cy="22"
+            fill="currentColor"
+            opacity="0.3"
+            r="1.5"
+          />
+          <circle
+            cx="178"
+            cy="70"
+            fill="currentColor"
+            opacity="0.25"
+            r="1"
+          />
+          <circle
+            cx="20"
+            cy="100"
+            fill="currentColor"
+            opacity="0.2"
+            r="1.5"
+          />
+          <circle
+            cx="155"
+            cy="120"
+            fill="currentColor"
+            opacity="0.25"
+            r="1"
+          />
+        </g>
+      </svg>
+      <h1
+        class="error-title"
+        id="notfound-title"
+      >
+        Page not found
+      </h1>
+      <p
+        class="error-message"
+      >
+        The page you're looking for doesn't exist or has been moved.
+      </p>
+      <div
+        class="error-actions"
+      >
+        <button
+          aria-label="Go back to previous page"
+          class="error-btn error-btn-primary"
+        >
+          Go back
+        </button>
+        <a
+          aria-label="Contact support via email"
+          class="error-btn error-btn-secondary"
+          href="mailto:support@creditra.com"
+        >
+          Contact Support
+        </a>
+      </div>
+    </div>
+  </main>
+</DocumentFragment>
+`;
+
+exports[`NotFound > matches snapshot without history 1`] = `
+<DocumentFragment>
+  <main
+    aria-labelledby="notfound-title"
+    class="error-page"
+  >
+    <div
+      class="error-content"
+    >
+      <svg
+        aria-hidden="true"
+        class="error-illustration"
+        focusable="false"
+        viewBox="0 0 200 160"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <ellipse
+          cx="100"
+          cy="148"
+          fill="currentColor"
+          opacity="0.06"
+          rx="70"
+          ry="8"
+        />
+        <line
+          opacity="0.55"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-width="7"
+          x1="124"
+          x2="148"
+          y1="114"
+          y2="138"
+        />
+        <circle
+          cx="90"
+          cy="82"
+          fill="none"
+          opacity="0.6"
+          r="36"
+          stroke="currentColor"
+          stroke-width="7"
+        />
+        <circle
+          cx="90"
+          cy="82"
+          fill="currentColor"
+          opacity="0.04"
+          r="29"
+        />
+        <path
+          d="M 82 72 Q 82 62 90 62 Q 98 62 98 70 Q 98 78 90 81"
+          fill="none"
+          opacity="0.75"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-width="4"
+        />
+        <circle
+          cx="90"
+          cy="92"
+          fill="currentColor"
+          opacity="0.75"
+          r="3"
+        />
+        <g
+          class="notfound-stars"
+        >
+          <circle
+            cx="30"
+            cy="30"
+            fill="currentColor"
+            opacity="0.3"
+            r="2"
+          />
+          <circle
+            cx="165"
+            cy="22"
+            fill="currentColor"
+            opacity="0.3"
+            r="1.5"
+          />
+          <circle
+            cx="178"
+            cy="70"
+            fill="currentColor"
+            opacity="0.25"
+            r="1"
+          />
+          <circle
+            cx="20"
+            cy="100"
+            fill="currentColor"
+            opacity="0.2"
+            r="1.5"
+          />
+          <circle
+            cx="155"
+            cy="120"
+            fill="currentColor"
+            opacity="0.25"
+            r="1"
+          />
+        </g>
+      </svg>
+      <h1
+        class="error-title"
+        id="notfound-title"
+      >
+        Page not found
+      </h1>
+      <p
+        class="error-message"
+      >
+        The page you're looking for doesn't exist or has been moved.
+      </p>
+      <div
+        class="error-actions"
+      >
+        <a
+          aria-label="Go to Dashboard"
+          class="error-btn error-btn-primary"
+          href="/"
+        >
+          Go to Dashboard
+        </a>
+        <a
+          aria-label="Contact support via email"
+          class="error-btn error-btn-secondary"
+          href="mailto:support@creditra.com"
+        >
+          Contact Support
+        </a>
+      </div>
+    </div>
+  </main>
+</DocumentFragment>
+`;


### PR DESCRIPTION
Closes #209 

## Changes
- Replaced emoji icon with a calm inline-SVG illustration using `currentColor` for dark/light parity
- Added smart back button: "Go back" when history is available, "Go to Dashboard" as fallback
- Wrapped content in `<main>` landmark with `aria-labelledby` for screen readers
- Decorative animation gated behind `prefers-reduced-motion`

## Testing
- 9/9 tests passing
- Verified both button states (history available / no history)