### PR TITLE
feat: add arrow-key step navigation to OnboardingFlow

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -135,7 +135,7 @@ The table below is updated on every accessibility-impacting PR. Status legend:
 | `WalletButton` | Tab/Enter/Esc; trigger has `aria-haspopup`/`aria-expanded` | `aria-label` on icon-only states | AA | n/a | OK |
 | `WalletConnectionModal` | Focus trap + return; Escape closes | `role="dialog"`, `aria-modal`, `aria-labelledby` | AA | reduced-motion gated | OK |
 | `ShortcutHelpOverlay` | Global `?` trigger outside text inputs; Escape closes; focus returns | `role="dialog"`, `aria-modal`, grouped shortcut lists | AA | reduced-motion gated | OK |
-| `OnboardingFlow` | Arrow keys advance steps (planned), Esc skips | Stepper labelled via `aria-label` | AA | `useReducedMotion()` | OK |
+| `OnboardingFlow` | Arrow keys advance/back; Esc skips | Stepper labelled via `aria-label` | AA | `useReducedMotion()` | OK |
 | `FormField` | Native input semantics | Auto `htmlFor`, `aria-describedby`, `aria-invalid`, `aria-required` | AA | n/a | OK |
 | `FormMessage` | n/a (text only) | `role="alert"` on error | AA | reduced-motion gated | OK |
 | `AmountInput` | Native input + preset buttons; Tab in order | `aria-describedby` aggregates helper/constraint/status/error | AA | n/a | OK |

--- a/src/components/OnboardingFlow.css
+++ b/src/components/OnboardingFlow.css
@@ -212,6 +212,7 @@
 @media (prefers-reduced-motion: reduce) {
   .onboarding-overlay,
   .onboarding-content,
+  .onboarding-step,
   .step-icon,
   .indicator,
   .primary-btn,
@@ -225,6 +226,7 @@
 /* Reduced Motion Override */
 [data-motion="reduced"] .onboarding-overlay,
 [data-motion="reduced"] .onboarding-content,
+[data-motion="reduced"] .onboarding-step,
 [data-motion="reduced"] .step-icon,
 [data-motion="reduced"] .indicator,
 [data-motion="reduced"] .primary-btn,

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useReducedMotion } from '../context/ReducedMotionContext';
 import './OnboardingFlow.css';
 
 interface Props {
@@ -41,32 +42,66 @@ const steps = [
 
 export const OnboardingFlow = ({ isOpen, onComplete, onSkip }: Props) => {
   const [currentStep, setCurrentStep] = useState(0);
+  const [direction, setDirection] = useState<'forward' | 'backward'>('forward');
+  const { isReducedMotionActive } = useReducedMotion();
 
-  if (!isOpen) return null;
+  useEffect(() => {
+    if (isOpen) {
+      setCurrentStep(0);
+      setDirection('forward');
+    }
+  }, [isOpen]);
 
   const isLastStep = currentStep === steps.length - 1;
   const isFirstStep = currentStep === 0;
   const step = steps[currentStep];
 
-  const handleNext = () => {
-    if (isLastStep) {
-      localStorage.setItem('onboarding_completed', 'true');
-      onComplete();
-    } else {
-      setCurrentStep(currentStep + 1);
-    }
-  };
+  const handleNext = useCallback(() => {
+    setDirection('forward');
+    setCurrentStep((current) => {
+      if (current === steps.length - 1) {
+        localStorage.setItem('onboarding_completed', 'true');
+        onComplete();
+        return current;
+      }
 
-  const handleBack = () => {
-    if (!isFirstStep) {
-      setCurrentStep(currentStep - 1);
-    }
-  };
+      return current + 1;
+    });
+  }, [onComplete]);
 
-  const handleSkip = () => {
+  const handleBack = useCallback(() => {
+    setDirection('backward');
+    setCurrentStep((current) => Math.max(0, current - 1));
+  }, []);
+
+  const handleSkip = useCallback(() => {
     localStorage.setItem('onboarding_completed', 'true');
     onSkip();
-  };
+  }, [onSkip]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleSkip();
+      }
+
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        handleNext();
+      }
+
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        handleBack();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleBack, handleNext, handleSkip, isOpen]);
 
   return (
     <div className="onboarding-overlay" role="dialog" aria-modal="true" aria-label="Onboarding">
@@ -84,10 +119,10 @@ export const OnboardingFlow = ({ isOpen, onComplete, onSkip }: Props) => {
             <motion.div
               key={currentStep}
               className="onboarding-step"
-              initial={{ opacity: 0, x: 20 }}
+              initial={{ opacity: 0, x: isReducedMotionActive ? 0 : direction === 'forward' ? 20 : -20 }}
               animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: -20 }}
-              transition={{ duration: 0.3 }}
+              exit={{ opacity: 0, x: isReducedMotionActive ? 0 : direction === 'forward' ? -20 : 20 }}
+              transition={{ duration: isReducedMotionActive ? 0 : 0.3 }}
             >
               <div className="step-icon">{step.icon}</div>
               <h2>{step.title}</h2>

--- a/src/components/__tests__/OnboardingFlow.test.tsx
+++ b/src/components/__tests__/OnboardingFlow.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('../../context/ReducedMotionContext', () => ({
+  useReducedMotion: () => ({ isReducedMotionActive: false }),
+}));
+
+import { OnboardingFlow } from '../OnboardingFlow';
+
+describe('OnboardingFlow', () => {
+  const onComplete = vi.fn();
+  const onSkip = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('advances and retreats steps with arrow keys', () => {
+    render(<OnboardingFlow isOpen onComplete={onComplete} onSkip={onSkip} />);
+
+    expect(screen.getByText('Step 1 of 3')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+    expect(screen.getByText('Step 2 of 3')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'ArrowLeft' });
+    expect(screen.getByText('Step 1 of 3')).toBeInTheDocument();
+  });
+
+  it('calls onComplete when advancing from the last step', () => {
+    render(<OnboardingFlow isOpen onComplete={onComplete} onSkip={onSkip} />);
+
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+
+    expect(screen.getByText('Step 3 of 3')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips onboarding when Escape is pressed', () => {
+    render(<OnboardingFlow isOpen onComplete={onComplete} onSkip={onSkip} />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #197 


This PR implements keyboard navigation for the onboarding modal so users can move between steps with the Left/Right arrow keys while preserving the existing Escape behavior to skip the flow.

### What changed

- Added Left arrow to go back and Right arrow to advance steps in OnboardingFlow.tsx
- Kept Escape behavior intact for skipping onboarding
- Added reduced-motion-aware slide transitions during step changes
- Ensured step state resets when onboarding reopens
- Updated ACCESSIBILITY.md audit entry for OnboardingFlow
- Added focused unit tests covering arrow navigation and Escape skip

### Testing

- pnpm exec vitest run OnboardingFlow.test.tsx --reporter=verbose
- Result: 1 passed, 3 tests passed


<img width="461" height="232" alt="image" src="https://github.com/user-attachments/assets/d779e070-b4b3-4d48-adc8-4e23973ca33d" />

