### PR TITLE
feat: animate RiskGauge arc sweep with reduced-motion fallback

### DIFF
--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -244,7 +244,17 @@
     fill: none;
     stroke-width: 10;
     stroke-linecap: round;
-    transition: stroke-dashoffset 1s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    transition: stroke-dashoffset 280ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .risk-gauge-fill {
+        transition: stroke-dashoffset 0ms !important;
+    }
+}
+
+[data-motion="reduced"] .risk-gauge-fill {
+    transition: stroke-dashoffset 0ms !important;
 }
 
 .risk-gauge-score {

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, act, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
-import { Dashboard } from './Dashboard';
+import { Dashboard, RiskGauge } from './Dashboard';
+import { ReducedMotionProvider } from '../context/ReducedMotionContext';
 
 // Mock modules before imports
 vi.mock('../context/WalletContext', () => ({
@@ -34,6 +35,26 @@ vi.mock('../utils/storage', () => ({
 }));
 
 const WALLET_KEY = 'risk-explainer-dismissed-0x1234567890abcdef1234567890abcdef12345678';
+
+function stubMatchMedia(matches: boolean) {
+  const original = window.matchMedia;
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)' ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+  return () => {
+    Object.defineProperty(window, 'matchMedia', { writable: true, value: original });
+  };
+}
 
 describe('Dashboard component skeletons', () => {
   beforeEach(() => {
@@ -169,6 +190,107 @@ describe('RiskExplainer', () => {
     const explainer = container.querySelector('.risk-explainer');
     expect(explainer).toBeInTheDocument();
     expect(explainer?.getAttribute('role')).toBe('status');
+    vi.useRealTimers();
+  });
+});
+
+describe('RiskGauge inline component from Dashboard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('matches snapshot at score 580', () => {
+    const { container } = render(
+      <ReducedMotionProvider>
+        <RiskGauge score={580} trend="stable" lastUpdated="2025-01-01T00:00:00Z" />
+      </ReducedMotionProvider>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot at score 660', () => {
+    const { container } = render(
+      <ReducedMotionProvider>
+        <RiskGauge score={660} trend="stable" lastUpdated="2025-01-01T00:00:00Z" />
+      </ReducedMotionProvider>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot at score 740', () => {
+    const { container } = render(
+      <ReducedMotionProvider>
+        <RiskGauge score={740} trend="stable" lastUpdated="2025-01-01T00:00:00Z" />
+      </ReducedMotionProvider>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('tweens score value when normal-motion is active', () => {
+    vi.useFakeTimers();
+    const restore = stubMatchMedia(false);
+
+    const { rerender } = render(
+      <ReducedMotionProvider>
+        <RiskGauge score={580} trend="stable" lastUpdated="2025-01-01T00:00:00Z" />
+      </ReducedMotionProvider>
+    );
+
+    // Initial render shows 580
+    expect(screen.getByText('580')).toBeInTheDocument();
+
+    // Rerender with new score 740
+    rerender(
+      <ReducedMotionProvider>
+        <RiskGauge score={740} trend="stable" lastUpdated="2025-01-01T00:00:00Z" />
+      </ReducedMotionProvider>
+    );
+
+    // Score does not snap immediately to 740 because it's tweening
+    expect(screen.queryByText('740')).not.toBeInTheDocument();
+
+    // Advance halfway (140ms)
+    act(() => {
+      vi.advanceTimersByTime(140);
+    });
+    // Check that it's tweening (not 580 and not 740)
+    const scoreText = document.querySelector('.risk-gauge-score');
+    const midVal = parseInt(scoreText?.textContent || '0', 10);
+    expect(midVal).toBeGreaterThan(580);
+    expect(midVal).toBeLessThan(740);
+
+    // Advance to completion (another 140ms)
+    act(() => {
+      vi.advanceTimersByTime(140);
+    });
+    expect(screen.getByText('740')).toBeInTheDocument();
+
+    restore();
+    vi.useRealTimers();
+  });
+
+  it('updates score instantly without tweening when reduced-motion is active', () => {
+    vi.useFakeTimers();
+    const restore = stubMatchMedia(true);
+
+    const { rerender } = render(
+      <ReducedMotionProvider>
+        <RiskGauge score={580} trend="stable" lastUpdated="2025-01-01T00:00:00Z" />
+      </ReducedMotionProvider>
+    );
+
+    expect(screen.getByText('580')).toBeInTheDocument();
+
+    rerender(
+      <ReducedMotionProvider>
+        <RiskGauge score={740} trend="stable" lastUpdated="2025-01-01T00:00:00Z" />
+      </ReducedMotionProvider>
+    );
+
+    // Snaps instantly to 740
+    expect(screen.getByText('740')).toBeInTheDocument();
+
+    restore();
     vi.useRealTimers();
   });
 });

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { CopyToClipboard } from "../components/CopyToClipboard";
 import { StatusBadge } from "../components/StatusBadge";
 import { useWallet } from "../context/WalletContext";
+import { useReducedMotion } from "../context/ReducedMotionContext";
 import { RiskBandsPanel } from "../components/RiskBandsPanel";
 import { MOCK_CREDIT_LINES } from "../data/mockData";
 import type { Transaction } from "../types/creditLine";
@@ -17,9 +18,10 @@ import {
 } from "../utils/tokens";
 import { readJson, writeJson } from "../utils/storage";
 import "./Dashboard.css";
-import {T Skeleton} from "../components/Skeleton";
+import { Skeleton } from "../components/Skeleton";
 import { NoDataGraph } from "../components/illustrations";
 import CompareLinesPanel from "../components/CompareLinesPanel";
+import { WhatsChangedPanel } from "../components/WhatsChangedPanel";
 import { useFocusTrap } from "../hooks/useFocusTrap";
 import { useInertBackdrop } from "../hooks/useInertBackdrop";
 import { useBodyScrollLock } from "../hooks/useBodyScrollLock";
@@ -54,7 +56,23 @@ const TX_COLOR: Record<string, string> = {
 
 // ─── Risk Score Gauge ─────────────────────────────────────────────────────────
 
-function RiskGauge({
+const easeCubicBezier = (x: number): number => {
+  if (x <= 0) return 0;
+  if (x >= 1) return 1;
+  const x1 = 0.16;
+  const x2 = 0.3;
+  let t = x;
+  for (let i = 0; i < 8; i++) {
+    const currentX = 3 * (1 - t) * (1 - t) * t * x1 + 3 * (1 - t) * t * t * x2 + t * t * t;
+    const diff = currentX - x;
+    if (Math.abs(diff) < 1e-6) break;
+    const dXdt = 3 * (1 - t) * (1 - t) * x1 + 6 * (1 - t) * t * (x2 - x1) + 3 * t * t * (1 - x2);
+    t -= diff / (dXdt || 1);
+  }
+  return 3 * t * (1 - t) + t * t * t;
+};
+
+export function RiskGauge({
   score,
   trend,
   lastUpdated,
@@ -67,11 +85,10 @@ function RiskGauge({
   const cx = 80;
   const cy = 75;
   const circumference = Math.PI * radius;
-  const normalizedScore = Math.min(100, Math.max(0, score));
-  const offset = circumference - (normalizedScore / 100) * circumference;
+  const normalizedScore = Math.min(850, Math.max(0, score));
+  const offset = circumference - (normalizedScore / 850) * circumference;
 
-  const gaugeColor =
-    score >= 70 ? COLOR.success : score >= 50 ? COLOR.warning : COLOR.danger;
+  const gaugeColor = RISK_COLOR(normalizedScore);
   const trendArrow =
     trend === "improving" ? "▲" : trend === "declining" ? "▼" : "─";
   const trendColor =
@@ -80,6 +97,49 @@ function RiskGauge({
       : trend === "declining"
         ? COLOR.danger
         : COLOR.muted;
+
+  const { isReducedMotionActive } = useReducedMotion();
+  const [displayedScore, setDisplayedScore] = useState(normalizedScore);
+  const prevScoreRef = useRef(normalizedScore);
+
+  useEffect(() => {
+    if (isReducedMotionActive) {
+      setDisplayedScore(normalizedScore);
+      prevScoreRef.current = normalizedScore;
+      return;
+    }
+
+    const startScore = prevScoreRef.current;
+    const endScore = normalizedScore;
+    if (startScore === endScore) return;
+
+    const duration = 280;
+    const startTime = Date.now();
+    let animationFrameId: number;
+
+    const animate = () => {
+      const elapsed = Date.now() - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const easedProgress = easeCubicBezier(progress);
+
+      const currentVal = startScore + (endScore - startScore) * easedProgress;
+      setDisplayedScore(currentVal);
+
+      if (progress < 1) {
+        animationFrameId = requestAnimationFrame(animate);
+      } else {
+        prevScoreRef.current = endScore;
+      }
+    };
+
+    animationFrameId = requestAnimationFrame(animate);
+
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, [normalizedScore, isReducedMotionActive]);
+
+  const scoreFormatter = useMemo(() => new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }), []);
 
   return (
     <div className="risk-gauge-container">
@@ -96,7 +156,7 @@ function RiskGauge({
           strokeDashoffset={offset}
         />
         <text x={cx} y={cy - 12} className="risk-gauge-score">
-          {normalizedScore}
+          {scoreFormatter.format(Math.round(displayedScore))}
         </text>
         <text x={cx} y={cy - 38} className="risk-gauge-label">
           Risk Score

--- a/src/pages/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/pages/__snapshots__/Dashboard.test.tsx.snap
@@ -1,0 +1,220 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`RiskGauge inline component from Dashboard > matches snapshot at score 580 1`] = `
+<div
+  class="risk-gauge-container"
+>
+  <svg
+    class="risk-gauge-svg"
+    viewBox="0 0 160 100"
+  >
+    <path
+      class="risk-gauge-bg"
+      d="M 25 75 A 55 55 0 0 1 135 75"
+    />
+    <path
+      class="risk-gauge-fill"
+      d="M 25 75 A 55 55 0 0 1 135 75"
+      stroke="#f85149"
+      stroke-dasharray="172.78759594743863"
+      stroke-dashoffset="54.88547165389227"
+    />
+    <text
+      class="risk-gauge-score"
+      x="80"
+      y="63"
+    >
+      580
+    </text>
+    <text
+      class="risk-gauge-label"
+      x="80"
+      y="37"
+    >
+      Risk Score
+    </text>
+  </svg>
+  <div
+    class="risk-meta"
+  >
+    <div
+      class="risk-meta-item"
+    >
+      <span
+        class="rm-label"
+      >
+        Trend
+      </span>
+      <span
+        class="rm-value"
+        style="color: rgb(139, 148, 158);"
+      >
+        ─
+         
+        Stable
+      </span>
+    </div>
+    <div
+      class="risk-meta-item"
+    >
+      <span
+        class="rm-label"
+      >
+        Last Updated
+      </span>
+      <span
+        class="rm-value"
+        style="color: rgb(139, 148, 158);"
+      >
+        Jan 1, 2025
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RiskGauge inline component from Dashboard > matches snapshot at score 660 1`] = `
+<div
+  class="risk-gauge-container"
+>
+  <svg
+    class="risk-gauge-svg"
+    viewBox="0 0 160 100"
+  >
+    <path
+      class="risk-gauge-bg"
+      d="M 25 75 A 55 55 0 0 1 135 75"
+    />
+    <path
+      class="risk-gauge-fill"
+      d="M 25 75 A 55 55 0 0 1 135 75"
+      stroke="#d29922"
+      stroke-dasharray="172.78759594743863"
+      stroke-dashoffset="38.623109682368636"
+    />
+    <text
+      class="risk-gauge-score"
+      x="80"
+      y="63"
+    >
+      660
+    </text>
+    <text
+      class="risk-gauge-label"
+      x="80"
+      y="37"
+    >
+      Risk Score
+    </text>
+  </svg>
+  <div
+    class="risk-meta"
+  >
+    <div
+      class="risk-meta-item"
+    >
+      <span
+        class="rm-label"
+      >
+        Trend
+      </span>
+      <span
+        class="rm-value"
+        style="color: rgb(139, 148, 158);"
+      >
+        ─
+         
+        Stable
+      </span>
+    </div>
+    <div
+      class="risk-meta-item"
+    >
+      <span
+        class="rm-label"
+      >
+        Last Updated
+      </span>
+      <span
+        class="rm-value"
+        style="color: rgb(139, 148, 158);"
+      >
+        Jan 1, 2025
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RiskGauge inline component from Dashboard > matches snapshot at score 740 1`] = `
+<div
+  class="risk-gauge-container"
+>
+  <svg
+    class="risk-gauge-svg"
+    viewBox="0 0 160 100"
+  >
+    <path
+      class="risk-gauge-bg"
+      d="M 25 75 A 55 55 0 0 1 135 75"
+    />
+    <path
+      class="risk-gauge-fill"
+      d="M 25 75 A 55 55 0 0 1 135 75"
+      stroke="#3fb950"
+      stroke-dasharray="172.78759594743863"
+      stroke-dashoffset="22.360747710845004"
+    />
+    <text
+      class="risk-gauge-score"
+      x="80"
+      y="63"
+    >
+      740
+    </text>
+    <text
+      class="risk-gauge-label"
+      x="80"
+      y="37"
+    >
+      Risk Score
+    </text>
+  </svg>
+  <div
+    class="risk-meta"
+  >
+    <div
+      class="risk-meta-item"
+    >
+      <span
+        class="rm-label"
+      >
+        Trend
+      </span>
+      <span
+        class="rm-value"
+        style="color: rgb(139, 148, 158);"
+      >
+        ─
+         
+        Stable
+      </span>
+    </div>
+    <div
+      class="risk-meta-item"
+    >
+      <span
+        class="rm-label"
+      >
+        Last Updated
+      </span>
+      <span
+        class="rm-value"
+        style="color: rgb(139, 148, 158);"
+      >
+        Jan 1, 2025
+      </span>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Closes #171

---

This PR resolves issue #171, animating the arc sweep of the semicircular RiskGauge inline component on the Dashboard on score changes. A smooth 280 ms eased transition highlights credit activity, while a strict prefers-reduced-motion fallback preserves accessibility requirements by resolving transitions instantly.