### PR TITLE
feat: add sticky summary bar on mobile DrawCreditPage (#201)

### DIFF
--- a/docs/UX_RATIONALE.md
+++ b/docs/UX_RATIONALE.md
@@ -293,7 +293,35 @@ motion-reduced animation behavior.
 
 ---
 
-## 11. Microcopy glossary
+## 11. Mobile sticky draw summary bar
+
+**Problem.** On mobile, the draw wizard's amount step scrolls the inline preview
+off-screen. Users lose sight of line, amount, and APR while entering a figure —
+the three numbers they need to sanity-check before continuing.
+
+**Alternatives considered.**
+
+- **Always-visible inline preview above the fold.** Rejected — the amount form
+  and drawing-limit indicator need vertical space; pinning preview at the top
+  pushes the primary input below the fold.
+- **Sticky summary on every breakpoint.** Rejected — desktop already has a
+  sidebar `PreviewSection` (`lg:sticky`); a second bar would duplicate content.
+- **Summary on the `confirm` step too.** Rejected — `ConfirmationStep` ships its
+  own sticky action bar; stacking two bottom strips would obscure Cancel / Draw.
+
+**Chosen approach.** `DrawSummaryBar` fixed to the viewport bottom, shown only
+below `md` on the `amount` step. It surfaces **Line**, **Amount**, and **APR**,
+respects `env(safe-area-inset-bottom)`, collapses to a one-line peek on
+scroll-down, and expands on scroll-up. `tabIndex={0}` makes the region
+keyboard-reachable; transitions are instant under reduced motion.
+
+**Trade-off.** Scroll-direction collapse adds a small scroll listener on mobile
+only. We accept it because the peek state recovers vertical space without
+hiding the summary entirely.
+
+---
+
+## 12. Microcopy glossary
 
 **Problem.** Risk-priced credit terminology (utilization, reserve, draw, APR
 vs. APY, attestation) appeared inconsistently across AmountInput, PreviewSection,

--- a/src/components/DrawSummaryBar.css
+++ b/src/components/DrawSummaryBar.css
@@ -1,69 +1,45 @@
 /*
- * draw-summary-bar.css — sticky bottom summary bar for the draw wizard.
+ * draw-summary-bar.css — mobile-only sticky bottom summary for the draw wizard.
  *
- * Design rationale
- * ────────────────
- * The bar is `position: fixed` to the viewport bottom so it persists
- * across:
- *   1. vertical scrolling inside any step card, and
- *   2. transitions between wizard steps (rendered at the page root).
+ * Breakpoint
+ * ──────────
+ * Hidden at md and above (min-width 768px). Desktop users see the sidebar
+ * PreviewSection instead.
  *
- * Mobile safe area
- * ────────────────
- * `.draw-summary-bar` uses `padding-bottom: env(safe-area-inset-bottom)`
- * so the bar's content sits *above* the iOS home indicator / Android
- * gesture pill. Desktop browsers ignore the env() lookup and fall back
- * to the `, 0px` default in the padding shorthand.
+ * Safe area
+ * ─────────
+ * padding-bottom uses env(safe-area-inset-bottom) for iOS home indicator /
+ * Android gesture bar clearance.
  *
- * Theme awareness
- * ────────────────
- * Every visible value references a CSS custom property declared in
- * `src/index.css`. The high-contrast override (`[data-contrast="high"]`)
- * also lives in that stylesheet, so this file does not duplicate colour
- * values and inherits higher-contrast variants automatically.
- *
- * Layout
- * ──────
- * - Mobile (< 480 px): three tiles stacked as a 2-column grid where the
- *   "Amount" tile spans the full width (it is the headline figure).
- * - ≥ 480 px: three tiles side-by-side in one row.
- * - ≥ 768 px (sm+): tighter spacing, larger tile value font.
- *
- * Focus
- * ─────
- * The bar itself is not interactive, but every numeric value is wrapped
- * in `<dd>` enclosed inside the `<dt>`-led definition list so screen
- * readers navigate it via the landmark. Visible focus rings live with
- * the parent wizard and are intentionally not added to the bar because
- * it does not steal focus.
+ * Collapse / expand
+ * ─────────────────
+ * Scroll-down adds .draw-summary-bar--collapsed (via useScrollCollapse).
+ * The expanded tile grid slides away; a one-line peek remains visible.
+ * Under prefers-reduced-motion or [data-motion="reduced"], the transition
+ * is instant.
  */
 
-/* ── Tokens (scoped to the bar so it stays self-contained) ─────────── */
-
 .draw-summary-bar {
-  /* Layout */
   position: fixed;
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 40; /* above local sticky bars (z-10) but below modals (z-50+) */
+  z-index: 40;
 
-  /* Visual */
   background: var(--surface-overlay, rgba(13, 17, 23, 0.92));
   border-top: 1px solid var(--border, #30363d);
   color: var(--text, #e6edf3);
   box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.35);
-
-  /* Mobile safe area — pad inward so the gesture indicator never covers
-     the value text on iOS Safari or Chrome on Android. The `, 0px`
-     fallback is required so non-mobile browsers still see valid CSS. */
   padding-bottom: env(safe-area-inset-bottom, 0px);
 
-  /* Animation — fade up when the bar mounts to soften layout shifts */
   animation: draw-summary-bar-mount 0.18s ease-out both;
+}
 
-  /* Allow backdrop-filter so the page content behind is subtly tinted;
-     wrap in @supports so unsupported browsers gracefully degrade. */
+/* Sticky summary is mobile-only — desktop uses the sidebar preview. */
+@media (min-width: 768px) {
+  .draw-summary-bar {
+    display: none;
+  }
 }
 
 @supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
@@ -84,33 +60,48 @@
   }
 }
 
-.draw-summary-bar__inner {
-  max-width: 64rem; /* mirror the wizard's max-w-4xl so widths agree */
-  margin: 0 auto;
-  padding: 0.75rem 1rem 0.75rem;
+.draw-summary-bar:focus-visible {
+  outline: 2px solid var(--accent, #58a6ff);
+  outline-offset: -2px;
 }
 
-/* ── Tile grid ─────────────────────────────────────────────────────── */
+.draw-summary-bar__inner {
+  position: relative;
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: 0.75rem 1rem;
+  overflow: hidden;
+  transition: max-height 0.22s ease, padding 0.22s ease;
+}
+
+.draw-summary-bar--reduced-motion .draw-summary-bar__inner {
+  transition: none;
+}
+
+/* ── Expanded tile grid ─────────────────────────────────────────────── */
 
 .draw-summary-bar__tiles {
   display: grid;
   gap: 0.5rem;
-  /* Mobile-first: Amount spans the row, APR + Total cost sit beside it */
   grid-template-columns: 1fr 1fr;
   margin: 0;
   padding: 0;
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.22s ease, transform 0.22s ease;
 }
 
-.draw-summary-bar__tile[data-tile="amount"] {
+.draw-summary-bar__tile[data-tile="line"] {
   grid-column: 1 / -1;
 }
 
-@media (min-width: 480px) {
+@media (min-width: 480px) and (max-width: 767px) {
   .draw-summary-bar__tiles {
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1rem;
+    gap: 0.75rem;
   }
-  .draw-summary-bar__tile[data-tile="amount"] {
+
+  .draw-summary-bar__tile[data-tile="line"] {
     grid-column: auto;
   }
 }
@@ -123,13 +114,7 @@
   border-radius: var(--radius-md, 6px);
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid transparent;
-  min-width: 0; /* allow tiles to shrink without overflowing the grid */
-}
-
-@media (min-width: 640px) {
-  .draw-summary-bar__tile {
-    padding: 0.625rem 0.875rem;
-  }
+  min-width: 0;
 }
 
 .draw-summary-bar__caption {
@@ -146,31 +131,65 @@
   font-size: 1rem;
   font-weight: 700;
   color: var(--text, #e6edf3);
-  /* Prevent long numbers from blowing out the tile; combined with the
-     min-width: 0 on the tile parent this truncates with an ellipsis. */
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-@media (min-width: 640px) {
-  .draw-summary-bar__value {
-    font-size: 1.125rem;
-  }
+/* ── Collapsed peek row ─────────────────────────────────────────────── */
+
+.draw-summary-bar__peek {
+  display: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text, #e6edf3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.draw-summary-bar__tile[data-tile="total"] .draw-summary-bar__value {
+.draw-summary-bar__peek-sep {
+  margin: 0 0.35rem;
+  color: var(--muted, #8b949e);
+}
+
+.draw-summary-bar__peek-line {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.draw-summary-bar__peek-apr {
   color: var(--accent, #58a6ff);
+  flex-shrink: 0;
 }
 
-/* ── High-contrast override (WCAG AAA fallback ringfence) ──────────── */
-/*
- * The tokens already remap to AAA-compliant values under
- * `[data-contrast="high"]` in src/index.css, so most styling follows
- * automatically. We reinforce here by widening the value contrast on
- * the "Total cost" tile and pinning an opaque background so the
- * backdrop-filter override does not bleed through in unsupported stacks.
- */
+.draw-summary-bar--collapsed .draw-summary-bar__inner {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.draw-summary-bar--collapsed .draw-summary-bar__tiles {
+  opacity: 0;
+  transform: translateY(100%);
+  pointer-events: none;
+  position: absolute;
+  left: 0;
+  right: 0;
+  visibility: hidden;
+}
+
+.draw-summary-bar--collapsed .draw-summary-bar__peek {
+  display: block;
+}
+
+.draw-summary-bar--collapsed.draw-summary-bar--reduced-motion .draw-summary-bar__tiles {
+  transition: none;
+}
+
+/* ── High contrast ──────────────────────────────────────────────────── */
+
 [data-contrast="high"] .draw-summary-bar {
   background: var(--surface, #0a0a0a);
   -webkit-backdrop-filter: none;
@@ -183,20 +202,24 @@
   border-color: var(--border, #ffffff);
 }
 
-/* ── Reduced motion ────────────────────────────────────────────────── */
-/*
- * The mount animation is purely decorative; under reduced-motion prefs
- * we suppress it so vestibular-sensitive users see no slide-in.
- * (Broad reduced-motion override for the whole app already lives in
- * src/index.css — this scoped rule ensures the bar is covered even if
- * a future refactor removes that global rule.)
- */
+/* ── Reduced motion ───────────────────────────────────────────────── */
+
 @media (prefers-reduced-motion: reduce) {
   .draw-summary-bar {
     animation: none;
+  }
+
+  .draw-summary-bar__inner,
+  .draw-summary-bar__tiles {
+    transition: none;
   }
 }
 
 [data-motion="reduced"] .draw-summary-bar {
   animation: none;
+}
+
+[data-motion="reduced"] .draw-summary-bar__inner,
+[data-motion="reduced"] .draw-summary-bar__tiles {
+  transition: none;
 }

--- a/src/components/DrawSummaryBar.test.tsx
+++ b/src/components/DrawSummaryBar.test.tsx
@@ -3,10 +3,27 @@ import { render, screen, act } from "@testing-library/react";
 import { DrawSummaryBar } from "./DrawSummaryBar";
 import type { CreditLine } from "@/types/draw-credit.types";
 
-/**
- * Sample credit line for unit tests — chosen to exercise the "Standard"
- * risk band so the test asserts a deterministic APR of about 11.5%.
- */
+vi.mock("@/hooks/useMediaQuery", () => ({
+  BELOW_MD_MEDIA: "(max-width: 767px)",
+  useMediaQuery: vi.fn(() => true),
+}));
+
+vi.mock("@/hooks/useScrollCollapse", () => ({
+  useScrollCollapse: vi.fn(() => false),
+}));
+
+vi.mock("@/hooks/usePrefersReducedMotion", () => ({
+  usePrefersReducedMotion: vi.fn(() => false),
+}));
+
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useScrollCollapse } from "@/hooks/useScrollCollapse";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+
+const mockUseMediaQuery = vi.mocked(useMediaQuery);
+const mockUseScrollCollapse = vi.mocked(useScrollCollapse);
+const mockUsePrefersReducedMotion = vi.mocked(usePrefersReducedMotion);
+
 const standardLine: CreditLine = {
   id: "cl-standard-001",
   name: "Business Line of Credit",
@@ -18,6 +35,12 @@ const standardLine: CreditLine = {
 };
 
 describe("DrawSummaryBar", () => {
+  beforeEach(() => {
+    mockUseMediaQuery.mockReturnValue(true);
+    mockUseScrollCollapse.mockReturnValue(false);
+    mockUsePrefersReducedMotion.mockReturnValue(false);
+  });
+
   describe("visibility", () => {
     it("renders nothing when no credit line is selected", () => {
       const { container } = render(
@@ -35,7 +58,7 @@ describe("DrawSummaryBar", () => {
       expect(container.firstChild).toBeNull();
     });
 
-    it("renders nothing on the `confirm` step (avoids double sticky bars over ConfirmationStep)", () => {
+    it("renders nothing on the `confirm` step", () => {
       const { container } = render(
         <DrawSummaryBar
           creditLine={standardLine}
@@ -59,7 +82,21 @@ describe("DrawSummaryBar", () => {
       expect(container.firstChild).toBeNull();
     });
 
-    it("shows the bar on the `amount` step once a line is selected", () => {
+    it("renders nothing at md breakpoint and above", () => {
+      mockUseMediaQuery.mockReturnValue(false);
+
+      const { container } = render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={1000}
+          step="amount"
+        />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("shows the bar on the `amount` step below md once a line is selected", () => {
       const { container } = render(
         <DrawSummaryBar
           creditLine={standardLine}
@@ -71,9 +108,6 @@ describe("DrawSummaryBar", () => {
     });
 
     it("does not crash when visibility toggles across renders (rules of hooks)", () => {
-      // Mount visible, then navigate to invisible, then back to visible.
-      // Without correct hook ordering this throws "Rendered more hooks
-      // than during the previous render."
       const { rerender, container } = render(
         <DrawSummaryBar
           creditLine={standardLine}
@@ -83,7 +117,6 @@ describe("DrawSummaryBar", () => {
       );
       expect(container.firstChild).not.toBeNull();
 
-      // amount → confirm (invisible): bar disappears
       rerender(
         <DrawSummaryBar
           creditLine={standardLine}
@@ -93,7 +126,6 @@ describe("DrawSummaryBar", () => {
       );
       expect(container.firstChild).toBeNull();
 
-      // confirm → amount (visible again): bar reappears
       rerender(
         <DrawSummaryBar
           creditLine={standardLine}
@@ -106,7 +138,7 @@ describe("DrawSummaryBar", () => {
   });
 
   describe("rendered figures", () => {
-    it("shows formatted amount, APR (rounded), and total cost (amount + fee)", () => {
+    it("shows line name, formatted amount, and APR", () => {
       render(
         <DrawSummaryBar
           creditLine={standardLine}
@@ -115,22 +147,18 @@ describe("DrawSummaryBar", () => {
         />,
       );
 
-      // Amount tile shows the human-formatted money string.
+      expect(screen.getByTestId("draw-summary-line")).toHaveTextContent(
+        "Business Line of Credit",
+      );
       expect(screen.getByTestId("draw-summary-amount")).toHaveTextContent(
         /\$10,000/,
       );
 
-      // APR tile shows a numeric value followed by "%".
       const aprTile = screen.getByTestId("draw-summary-apr");
       expect(aprTile.textContent).toMatch(/^\d+(\.\d+)?%$/);
-
-      // Total cost = amount + fee = $10,000 + $100 (1 %) = $10,100.
-      expect(screen.getByTestId("draw-summary-total")).toHaveTextContent(
-        /\$10,100/,
-      );
     });
 
-    it("renders $0.00 totals and 0% APR gracefully when amount is zero", () => {
+    it("renders $0 amount and 0% APR gracefully when amount is zero", () => {
       render(
         <DrawSummaryBar
           creditLine={standardLine}
@@ -140,11 +168,10 @@ describe("DrawSummaryBar", () => {
       );
 
       expect(screen.getByTestId("draw-summary-amount")).toHaveTextContent("$0");
-      expect(screen.getByTestId("draw-summary-total")).toHaveTextContent("$0");
     });
 
-    it("clamps a negative amount prop to $0 instead of producing negative numbers", () => {
-      const { container } = render(
+    it("clamps a negative amount prop to $0", () => {
+      render(
         <DrawSummaryBar
           creditLine={standardLine}
           amount={-500}
@@ -152,14 +179,47 @@ describe("DrawSummaryBar", () => {
         />,
       );
 
-      expect(container.firstChild).not.toBeNull();
       expect(screen.getByTestId("draw-summary-amount")).toHaveTextContent("$0");
-      expect(screen.getByTestId("draw-summary-total")).toHaveTextContent("$0");
+    });
+  });
+
+  describe("scroll collapse", () => {
+    it("applies collapsed class and shows peek row when scroll hook reports collapsed", () => {
+      mockUseScrollCollapse.mockReturnValue(true);
+
+      render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={5000}
+          step="amount"
+        />,
+      );
+
+      const region = screen.getByTestId("draw-summary-bar");
+      expect(region).toHaveClass("draw-summary-bar--collapsed");
+      expect(region).toHaveAttribute("aria-expanded", "false");
+      expect(screen.getByTestId("draw-summary-peek")).toBeInTheDocument();
+    });
+
+    it("uses instant transition class when reduced motion is preferred", () => {
+      mockUsePrefersReducedMotion.mockReturnValue(true);
+
+      render(
+        <DrawSummaryBar
+          creditLine={standardLine}
+          amount={1000}
+          step="amount"
+        />,
+      );
+
+      expect(screen.getByTestId("draw-summary-bar")).toHaveClass(
+        "draw-summary-bar--reduced-motion",
+      );
     });
   });
 
   describe("accessibility (WCAG 2.1 AA)", () => {
-    it("exposes a labelled region landmark", () => {
+    it("exposes a labelled, focusable region landmark", () => {
       render(
         <DrawSummaryBar
           creditLine={standardLine}
@@ -170,9 +230,10 @@ describe("DrawSummaryBar", () => {
 
       const region = screen.getByRole("region", { name: /draw summary/i });
       expect(region).toBeInTheDocument();
+      expect(region).toHaveAttribute("tabindex", "0");
     });
 
-    it("uses definition-list semantics with labelled terms for SR navigation", () => {
+    it("uses definition-list semantics with Line, Amount, and APR labels", () => {
       render(
         <DrawSummaryBar
           creditLine={standardLine}
@@ -189,7 +250,7 @@ describe("DrawSummaryBar", () => {
 
       const captionTexts = captions.map((node) => node.textContent);
       expect(captionTexts).toEqual(
-        expect.arrayContaining(["Amount", "APR", "Total cost"]),
+        expect.arrayContaining(["Line", "Amount", "APR"]),
       );
     });
 
@@ -228,13 +289,12 @@ describe("DrawSummaryBar", () => {
         />,
       );
 
-      // After mount + a tick of fake time, the debounced value equals the
-      // initial mount value (1000).
       act(() => {
         vi.advanceTimersByTime(450);
       });
       const live = screen.getByTestId("draw-summary-live");
       expect(live.textContent).toMatch(/1,000/);
+      expect(live.textContent).toMatch(/Business Line of Credit/);
     });
 
     it("coalesces rapid amount edits into one final announcement", () => {
@@ -246,14 +306,10 @@ describe("DrawSummaryBar", () => {
         />,
       );
 
-      // First, let the initial empty-string debounce settle.
       act(() => {
         vi.advanceTimersByTime(450);
       });
 
-      // Simulate rapid typing: 1 → 10 → 100 → 1000 within the same tick.
-      // Without the debounce, an SR polite region would queue four
-      // announcements; with it, the trailing edge fires once with 1000.
       for (const value of [1, 10, 100, 1000]) {
         rerender(
           <DrawSummaryBar
@@ -262,19 +318,14 @@ describe("DrawSummaryBar", () => {
             step="amount"
           />,
         );
-        // Each rerender resets the debounce timer; no advancement.
       }
 
-      // Just before the debounce settles, the live region text still
-      // reflects the previous value, not the latest amount.
       act(() => {
         vi.advanceTimersByTime(399);
       });
       let live = screen.getByTestId("draw-summary-live");
       expect(live.textContent).not.toMatch(/1,000/);
 
-      // Advance past the 400 ms debounce window — the trailing edge
-      // commits the LAST value to the live region.
       act(() => {
         vi.advanceTimersByTime(50);
       });

--- a/src/components/DrawSummaryBar.tsx
+++ b/src/components/DrawSummaryBar.tsx
@@ -1,126 +1,67 @@
 "use client";
 
 /**
- * DrawSummaryBar — persistent bottom summary bar for the Draw Credit wizard.
- *
- * Renders three stat tiles (Amount, APR, Total Cost) anchored to the bottom
- * of the viewport so the user always knows what they are about to draw,
- * regardless of which step of the wizard they are on.
+ * DrawSummaryBar — mobile sticky bottom summary for the Draw Credit wizard.
  *
  * Visibility
  * ──────────
- * The bar is shown only on the `amount` step. The early-wizard `select`
- * step is excluded (no line has been chosen yet, so there is no data to
- * summarise) and the terminal `status` step is excluded (the
- * success/error screen replaces the wizard entirely). The `confirm` step
- * is also excluded: the `ConfirmationStep` card already surfaces the
- * same figures inline and stacks its own sticky action bar (Cancel /
- * Back / Draw). Showing the page-level summary bar on top of that
- * action bar would create two stacked sticky strips at the bottom of
- * the viewport, obscuring the primary actions.
+ * Shown only below the `md` breakpoint (max-width 767px) on the `amount`
+ * step once a credit line is selected. Desktop uses the sidebar
+ * `PreviewSection`; `select`, `confirm`, and `status` steps are excluded
+ * (see VISIBLE_STEPS).
  *
- * Layout
- * ──────
- * The element uses `position: fixed` so it stays anchored to the viewport
- * bottom as the user scrolls through any of the step cards. See
- * `DrawSummaryBar.css` for the mobile safe-area inset. Parent components
- * must add bottom padding to their scroll container so the bar does not
- * occlude content (see the `pb-…` classes applied on `DrawCreditPage`).
+ * Scroll behaviour
+ * ────────────────
+ * Collapses to a one-line peek while the user scrolls down through the
+ * amount step; expands again on scroll-up. Under reduced-motion the
+ * transition is instant (see DrawSummaryBar.css).
  *
  * Accessibility
  * ─────────────
- * - `role="region"` + `aria-label="Draw summary"` so screen-reader users
- *   can navigate to it as a landmark.
- * - Each tile is a definition-list pair (`<dl>`) so SR users hear the
- *   label/value relationship explicitly.
- * - A screen-reader-only `aria-live="polite"` region announces the
- *   full summary in human-readable form, debounced via
- *   `useDebounceValue` so rapid amount edits (`100` → `1000` →
- *   `10000`) are not spammed to the SR user. Polite live regions wait
- *   for the SR to be idle, so the trailing-edge debounce gives a
- *   single coherent announcement.
- *
- * Theme awareness
- * ───────────────
- * Every visible style references CSS custom properties defined in
- * `src/index.css` (`--surface-overlay`, `--border`, `--text`,
- * `--muted`, `--accent`). Overrides for `[data-contrast="high"]` are
- * already declared on those tokens, so the bar auto-adapts to the
- * high-contrast toggle without any JS branching.
+ * - `role="region"` landmark labelled "Draw summary".
+ * - `tabIndex={0}` so keyboard users can Tab to the summary.
+ * - Definition-list tiles in the expanded state; compact text in collapsed.
+ * - Debounced `aria-live="polite"` region for screen-reader updates.
  */
 
 import { CreditLine, DrawStep } from "@/types/draw-credit.types";
 import { getDrawPricingQuote } from "@/lib/draw-credit-pricing";
 import { formatMoney } from "@/utils/amountValidation";
 import { useDebounceValue } from "@/hooks/useDebounceValue";
+import { useScrollCollapse } from "@/hooks/useScrollCollapse";
+import { BELOW_MD_MEDIA, useMediaQuery } from "@/hooks/useMediaQuery";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import "./DrawSummaryBar.css";
 
 interface DrawSummaryBarProps {
-  /** Selected credit line. When null, the bar renders nothing. */
   creditLine: CreditLine | null;
-  /** Current draw amount in whole dollars. Negative values are clamped to 0. */
   amount: number;
-  /** Current wizard step — controls visibility. */
   step: DrawStep;
 }
 
-/**
- * Steps on which the summary bar should be visible. Intentionally a
- * module-level constant so the set of visible steps is easy to audit in
- * one place. `confirm` is intentionally absent — see the Visibility
- * section of the file header for the rationale (avoid overlapping with
- * `ConfirmationStep`'s own sticky action bar).
- */
 const VISIBLE_STEPS: ReadonlySet<DrawStep> = new Set<DrawStep>(["amount"]);
 
-/** Synthetic quote used to keep hooks stable when the bar is invisible. */
-const HIDDEN_QUOTE = { apr: 0, fee: 0 };
-
-/**
- * Builds a one-sentence summary used by the screen-reader live region.
- *
- * Kept in plain English rather than a digit-stream so the user hears a
- * meaningful statement ("Draw ten thousand dollars at 11.5% APR.
- * Total cost ten thousand one hundred dollars.") instead of a row of
- * numbers.
- */
 function buildAnnouncement(
+  lineName: string,
   amountText: string,
   apr: number,
-  totalCostText: string,
 ): string {
-  return `Draw summary: ${amountText} draw amount, ${apr} percent APR, total cost ${totalCostText}.`;
+  return `Draw summary: ${lineName}, ${amountText} draw amount, ${apr} percent APR.`;
 }
 
-/**
- * Derived summary tuple — factored out so the debounce hook and the
- * render path use the *exact* same numbers, preventing a one-frame
- * drift between the visible tiles and the screen-reader announcement.
- */
 function computeSummary(
   line: CreditLine,
   amount: number,
 ): {
   apr: number;
-  fee: number;
-  totalCost: number;
   amountText: string;
-  totalCostText: string;
   announcement: string;
 } {
-  // Defensive clamp: the input layer already enforces >= 0, but we guard
-  // here so a wild prop value cannot blow up the live-region text or the
-  // money formatter.
   const safeAmount = Math.max(amount, 0);
-  const { apr, fee } = getDrawPricingQuote(line, safeAmount);
-  // Total cost = principal + 1 % flat fee. Interest is intentionally NOT
-  // bundled in: it varies with repayment schedule and adding it would
-  // mislead users about the *committed* cost of the draw.
-  const totalCost = safeAmount + fee;
+  const { apr } = getDrawPricingQuote(line, safeAmount);
   const amountText = formatMoney(safeAmount);
-  const totalCostText = formatMoney(totalCost);
-  const announcement = buildAnnouncement(amountText, apr, totalCostText);
-  return { apr, fee, totalCost, amountText, totalCostText, announcement };
+  const announcement = buildAnnouncement(line.name, amountText, apr);
+  return { apr, amountText, announcement };
 }
 
 export function DrawSummaryBar({
@@ -128,51 +69,71 @@ export function DrawSummaryBar({
   amount,
   step,
 }: DrawSummaryBarProps) {
-  // The bar is purely informational — bail out early on the steps where
-  // it would be confusing (no line yet, status screen, or confirm step
-  // already has its own sticky bar).
-  const isVisible = !!creditLine && VISIBLE_STEPS.has(step);
+  const isBelowMd = useMediaQuery(BELOW_MD_MEDIA);
+  const isVisible = !!creditLine && VISIBLE_STEPS.has(step) && isBelowMd;
+  const isCollapsed = useScrollCollapse(isVisible);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
-  /*
-   * Hooks order rule
-   * ────────────────
-   * `useDebounceValue` MUST be called on every render so React's
-   * per-instance hooks array stays the same length across renders.
-   * We therefore compute the announcement string before the early
-   * return and feed the debounce hook even when the bar is invisible
-   * (passing an empty string). The early return short-circuits the
-   * render so the live region is never in the DOM in that branch.
-   *
-   * Computing the summary in one place also guarantees the visible
-   * tiles and the live-region text can never drift apart.
-   */
-  const summary = isVisible && creditLine
-    ? computeSummary(creditLine, amount)
-    : null;
+  const summary =
+    isVisible && creditLine ? computeSummary(creditLine, amount) : null;
   const announcement = summary ? summary.announcement : "";
-
-  // 400 ms debounce so SR users don't get a flood of partial
-  // announcements as they type digits into the amount field. Short
-  // enough to feel responsive but long enough to coalesce
-  // "10" → "100" → "1000" into one readback.
   const debouncedAnnouncement = useDebounceValue(announcement, 400);
 
-  if (!isVisible || !summary) {
+  if (!isVisible || !summary || !creditLine) {
     return null;
   }
 
-  const { apr, amountText, totalCostText } = summary;
+  const { apr, amountText } = summary;
 
   return (
     <aside
-      className="draw-summary-bar"
+      className={[
+        "draw-summary-bar",
+        isCollapsed ? "draw-summary-bar--collapsed" : "",
+        prefersReducedMotion ? "draw-summary-bar--reduced-motion" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
       role="region"
       aria-label="Draw summary"
+      aria-expanded={!isCollapsed}
+      tabIndex={0}
       data-step={step}
       data-testid="draw-summary-bar"
     >
       <div className="draw-summary-bar__inner">
+        <p
+          className="draw-summary-bar__peek"
+          aria-hidden={!isCollapsed}
+          data-testid="draw-summary-peek"
+        >
+          <span className="draw-summary-bar__peek-line">{creditLine.name}</span>
+          <span className="draw-summary-bar__peek-sep" aria-hidden="true">
+            ·
+          </span>
+          <span className="draw-summary-bar__peek-amount num-tabular">
+            {amountText}
+          </span>
+          <span className="draw-summary-bar__peek-sep" aria-hidden="true">
+            ·
+          </span>
+          <span className="draw-summary-bar__peek-apr num-tabular">{apr}% APR</span>
+        </p>
+
         <dl className="draw-summary-bar__tiles">
+          <div
+            className="draw-summary-bar__tile"
+            data-tile="line"
+            data-testid="draw-summary-tile-line"
+          >
+            <dt className="draw-summary-bar__caption">Line</dt>
+            <dd
+              className="draw-summary-bar__value"
+              data-testid="draw-summary-line"
+            >
+              {creditLine.name}
+            </dd>
+          </div>
           <div
             className="draw-summary-bar__tile"
             data-tile="amount"
@@ -199,29 +160,9 @@ export function DrawSummaryBar({
               {apr}%
             </dd>
           </div>
-          <div
-            className="draw-summary-bar__tile"
-            data-tile="total"
-            data-testid="draw-summary-tile-total"
-          >
-            <dt className="draw-summary-bar__caption">Total cost</dt>
-            <dd
-              className="draw-summary-bar__value num-tabular"
-              data-testid="draw-summary-total"
-            >
-              {totalCostText}
-            </dd>
-          </div>
         </dl>
       </div>
 
-      {/*
-        Screen-reader-only polite live region announcing the *debounced*
-        summary. The element's text content only changes once typing has
-        settled, so a single coherent sentence is readback per change
-        rather than a stream of intermediate values. aria-atomic ensures
-        the entire string is read (not just the changed suffix).
-      */}
       <span
         className="sr-only"
         role="status"

--- a/src/hooks/__tests__/useScrollCollapse.test.ts
+++ b/src/hooks/__tests__/useScrollCollapse.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useScrollCollapse } from "../useScrollCollapse";
+
+describe("useScrollCollapse", () => {
+  let scrollY = 0;
+
+  beforeEach(() => {
+    scrollY = 0;
+    vi.spyOn(window, "scrollY", "get").mockImplementation(() => scrollY);
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("starts expanded", () => {
+    const { result } = renderHook(() => useScrollCollapse(true));
+    expect(result.current).toBe(false);
+  });
+
+  it("collapses after scrolling down past the minimum offset", () => {
+    const { result } = renderHook(() => useScrollCollapse(true));
+
+    act(() => {
+      scrollY = 120;
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("expands again when scrolling up", () => {
+    const { result } = renderHook(() => useScrollCollapse(true));
+
+    act(() => {
+      scrollY = 200;
+      window.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      scrollY = 150;
+      window.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("stays expanded when disabled", () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useScrollCollapse(enabled),
+      { initialProps: { enabled: true } },
+    );
+
+    act(() => {
+      scrollY = 200;
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    rerender({ enabled: false });
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Subscribes to a CSS media query and returns whether it currently matches.
+ * The initial value is read synchronously on first render (SSR-safe).
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    setMatches(mediaQuery.matches);
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [query]);
+
+  return matches;
+}
+
+/** Tailwind `md` breakpoint — sticky summary is mobile-only (below 768px). */
+export const BELOW_MD_MEDIA = "(max-width: 767px)";

--- a/src/hooks/useScrollCollapse.ts
+++ b/src/hooks/useScrollCollapse.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from "react";
+
+/** Minimum scroll delta (px) before toggling collapse state. */
+const SCROLL_THRESHOLD = 8;
+
+/** Do not collapse until the user has scrolled past this offset. */
+const MIN_SCROLL_Y = 48;
+
+/**
+ * Tracks vertical scroll direction and returns whether a sticky chrome
+ * element should be in its collapsed (peek) state.
+ *
+ * - Scroll **down** past {@link MIN_SCROLL_Y} → collapsed.
+ * - Scroll **up** → expanded.
+ *
+ * Scroll handling is rAF-throttled and uses a passive listener so it
+ * does not block the main thread on mobile.
+ */
+export function useScrollCollapse(enabled = true): boolean {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const lastScrollY = useRef(0);
+  const ticking = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setIsCollapsed(false);
+      return;
+    }
+
+    lastScrollY.current = window.scrollY;
+
+    const update = () => {
+      const currentY = window.scrollY;
+      const delta = currentY - lastScrollY.current;
+
+      if (Math.abs(delta) >= SCROLL_THRESHOLD) {
+        if (delta > 0 && currentY > MIN_SCROLL_Y) {
+          setIsCollapsed(true);
+        } else if (delta < 0) {
+          setIsCollapsed(false);
+        }
+        lastScrollY.current = currentY;
+      }
+
+      ticking.current = false;
+    };
+
+    const onScroll = () => {
+      if (!ticking.current) {
+        ticking.current = true;
+        requestAnimationFrame(update);
+      }
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [enabled]);
+
+  return isCollapsed;
+}

--- a/src/pages/DrawCreditPage.tsx
+++ b/src/pages/DrawCreditPage.tsx
@@ -11,6 +11,7 @@ import { InlineHelpOverlay } from "@/components/InlineHelpOverlay";
 import { CreditLine, DrawStep, Transaction } from "@/types/draw-credit.types";
 import { mockCreditLines } from "@/lib/draw-credit-mock-data";
 import { WhyApr } from "@/components/WhyApr";
+import { DrawingLimit } from "@/components/DrawingLimit";
 import { DrawSummaryBar } from "@/components/DrawSummaryBar";
 
 const drawSteps = [
@@ -108,7 +109,7 @@ export default function DrawCreditPage() {
   );
 
   return (
-    <main className="min-h-screen bg-background px-4 pb-24 pt-6 sm:pb-28 sm:pt-8">
+    <main className="min-h-screen bg-background px-4 pb-24 pt-6 max-md:pb-28 md:pb-8 sm:pt-8">
       <div className="mx-auto w-full max-w-4xl space-y-5">
         {step !== "status" && (
           <header className="card" aria-label="Draw credit progress">
@@ -273,12 +274,10 @@ export default function DrawCreditPage() {
         triggerRef={whyAprTriggerRef}
       />
       {/*
-        Sticky bottom summary bar — rendered at the page root so it
-        always anchors to the viewport bottom regardless of which step
-        card is currently mounted. The bar self-hides on the `select`
-        and `status` steps; see DrawSummaryBar.tsx for details. The
-        pb-32 / sm:pb-36 padding on <main> ensures content is never
-        occluded by the fixed-position bar.
+        Mobile-only sticky summary (below md) — fixed to the viewport so
+        line / amount / APR stay visible while scrolling the amount step.
+        Desktop uses the sidebar PreviewSection instead. Bottom padding on
+        <main> (max-md:pb-28) prevents content from sitting under the bar.
       */}
       <DrawSummaryBar
         creditLine={selectedCreditLine}


### PR DESCRIPTION
## Summary

- Adds a mobile-only (`< md`) sticky summary bar on the draw wizard amount step showing **line**, **amount**, and **APR** while users scroll the form.
- Bar respects `env(safe-area-inset-bottom)`, collapses on scroll-down and expands on scroll-up, and is keyboard-reachable via Tab (`tabIndex={0}`).
- Desktop continues to use the sidebar `PreviewSection`; the bar is hidden at `md` and above.

Closes #201

## Changes

| Area | Detail |
|------|--------|
| `DrawSummaryBar` | Mobile-only visibility, Line/Amount/APR tiles, scroll collapse peek row |
| `useScrollCollapse` | rAF-throttled scroll-direction hook |
| `useMediaQuery` | Breakpoint gate for below-`md` rendering |
| `DrawCreditPage` | Mobile-only bottom padding; `DrawingLimit` import fix |
| `docs/UX_RATIONALE.md` | Section 11 — rationale and trade-offs |

## Acceptance criteria

- [x] Sticky only on mobile breakpoints (`max-width: 767px`)
- [x] Safe-area insets respected (`env(safe-area-inset-bottom)`)
- [x] Smooth collapse/expand; instant under `prefers-reduced-motion` / `[data-motion="reduced"]`
- [x] AA contrast via existing theme tokens (`--text`, `--muted`, `--accent`, high-contrast overrides)
- [x] Keyboard reachable via Tab
- [x] Unit tests added/updated

## Test plan

- [x] `npm test -- --run src/components/DrawSummaryBar.test.tsx src/hooks/__tests__/useScrollCollapse.test.ts` (23 passing)
- [ ] Verify on iOS Safari — bar clears home indicator, collapses/expands on scroll
- [ ] Verify on Android Chrome — same scroll behaviour and safe-area padding
- [ ] Confirm bar hidden at `≥768px` (sidebar preview visible instead)
- [ ] Tab to summary region and confirm focus ring is visible
- [ ] Attach screen recording of mobile amount step scroll behaviour