### PR TITLE
feat: add per-step micro-progress indicators to draw wizard (#194)

### DIFF
--- a/docs/UX_RATIONALE.md
+++ b/docs/UX_RATIONALE.md
@@ -293,7 +293,33 @@ motion-reduced animation behavior.
 
 ---
 
-## 11. Microcopy glossary
+## 11. Per-step micro-progress in the draw wizard
+
+**Problem.** The draw wizard header shows which step is active but not whether
+each step's requirements are satisfied (line chosen, amount in bounds, preview
+computed, terms acknowledged). Users had to infer readiness from the form body.
+
+**Alternatives considered.**
+
+- **Colour-only step borders.** Rejected — completion colour on the card does
+  not spell out *what* is missing ("amount out of bounds" vs. "not started").
+- **Toast on each validity change.** Rejected — too noisy for sighted users and
+  redundant with polite `aria-live` for AT.
+- **Separate progress bar.** Rejected — duplicates the existing four-step header.
+
+**Chosen approach.** Compact chips beneath each step label in
+`DrawCreditPage` (`DrawWizardMicroIndicator`) driven by
+`computeDrawWizardMicroProgress`. Tones use existing `--success`, `--warning`,
+and `--muted` tokens. A single debounced `aria-live="polite"` region announces
+changes. Confirmation checkbox state is lifted to the page so the confirm chip
+stays in sync.
+
+**Trade-off.** Slightly denser header on mobile. Chips use ellipsis truncation
+so all four remain visible at compact density.
+
+---
+
+## 12. Microcopy glossary
 
 **Problem.** Risk-priced credit terminology (utilization, reserve, draw, APR
 vs. APY, attestation) appeared inconsistently across AmountInput, PreviewSection,

--- a/src/components/ConfirmationStep.tsx
+++ b/src/components/ConfirmationStep.tsx
@@ -27,6 +27,10 @@ interface ConfirmationStepProps {
    * network request state.
    */
   isLoading?: boolean;
+  /** Controlled checkbox state for terms acknowledgment (lifted to wizard). */
+  agreedToTerms?: boolean;
+  /** Notified when the user toggles the terms checkbox. */
+  onAgreedToTermsChange?: (agreed: boolean) => void;
 }
 
 /**
@@ -52,8 +56,17 @@ export function ConfirmationStep({
   onBack,
   onCancel,
   isLoading = false,
+  agreedToTerms: agreedToTermsProp,
+  onAgreedToTermsChange,
 }: ConfirmationStepProps) {
-  const [agreedToTerms, setAgreedToTerms] = useState(false);
+  const [agreedToTermsInternal, setAgreedToTermsInternal] = useState(false);
+  const agreedToTerms = agreedToTermsProp ?? agreedToTermsInternal;
+  const setAgreedToTerms = (value: boolean) => {
+    onAgreedToTermsChange?.(value);
+    if (agreedToTermsProp === undefined) {
+      setAgreedToTermsInternal(value);
+    }
+  };
   const { status } = useWallet();
   const utilizedBalance = creditLine.limit - creditLine.available;
   const safeAmount = Math.max(amount, 0);

--- a/src/components/CreditLineSelector.tsx
+++ b/src/components/CreditLineSelector.tsx
@@ -11,6 +11,11 @@ interface CreditLineSelectorProps {
    * state in this component.
    */
   onSelect: (creditLine: CreditLine) => void;
+  /**
+   * Optional id of the header micro-indicator (`draw-wizard-micro-select`)
+   * so the step heading is described by the wizard validity chip.
+   */
+  microProgressDescribedBy?: string;
 }
 
 /**
@@ -34,6 +39,7 @@ interface CreditLineSelectorProps {
 export function CreditLineSelector({
   creditLines,
   onSelect,
+  microProgressDescribedBy,
 }: CreditLineSelectorProps) {
   return (
     <div className="space-y-8">
@@ -42,6 +48,9 @@ export function CreditLineSelector({
         <h2
           id="select-credit-line-heading"
           className="mt-1 text-2xl font-bold text-foreground sm:text-3xl"
+          {...(microProgressDescribedBy
+            ? { "aria-describedby": microProgressDescribedBy }
+            : {})}
         >
           Select Credit Line
         </h2>

--- a/src/components/DrawWizardMicroIndicator.test.tsx
+++ b/src/components/DrawWizardMicroIndicator.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DrawWizardMicroIndicator } from "./DrawWizardMicroIndicator";
+
+describe("DrawWizardMicroIndicator", () => {
+  it("renders the label with the correct tone data attribute", () => {
+    render(
+      <DrawWizardMicroIndicator
+        stepId="amount"
+        tone="success"
+        label="Amount valid"
+      />,
+    );
+
+    const indicator = screen.getByTestId("draw-micro-indicator-amount");
+    expect(indicator).toHaveAttribute("data-tone", "success");
+    expect(indicator).toHaveTextContent("Amount valid");
+    expect(indicator).toHaveAttribute("id", "draw-wizard-micro-amount");
+  });
+
+  it("exposes warning and muted tones for styling hooks", () => {
+    const { rerender } = render(
+      <DrawWizardMicroIndicator
+        stepId="confirm"
+        tone="warning"
+        label="Acknowledge terms"
+      />,
+    );
+
+    expect(screen.getByTestId("draw-micro-indicator-confirm")).toHaveAttribute(
+      "data-tone",
+      "warning",
+    );
+
+    rerender(
+      <DrawWizardMicroIndicator
+        stepId="select"
+        tone="muted"
+        label="Select a line"
+      />,
+    );
+
+    expect(screen.getByTestId("draw-micro-indicator-select")).toHaveAttribute(
+      "data-tone",
+      "muted",
+    );
+  });
+});

--- a/src/components/DrawWizardMicroIndicator.tsx
+++ b/src/components/DrawWizardMicroIndicator.tsx
@@ -1,0 +1,34 @@
+import type {
+  DrawWizardMicroStepId,
+  MicroIndicatorTone,
+} from "@/lib/draw-wizard-micro-progress";
+import "./DrawWizardMicroProgress.css";
+
+interface DrawWizardMicroIndicatorProps {
+  stepId: DrawWizardMicroStepId;
+  tone: MicroIndicatorTone;
+  label: string;
+}
+
+/**
+ * Compact inline validity chip rendered beneath a wizard step header.
+ * Uses semantic tokens only (--success, --warning, --muted).
+ */
+export function DrawWizardMicroIndicator({
+  stepId,
+  tone,
+  label,
+}: DrawWizardMicroIndicatorProps) {
+  return (
+    <p
+      className="draw-wizard-micro-indicator"
+      data-step={stepId}
+      data-tone={tone}
+      data-testid={`draw-micro-indicator-${stepId}`}
+      id={`draw-wizard-micro-${stepId}`}
+    >
+      <span className="draw-wizard-micro-indicator__icon" aria-hidden="true" />
+      <span className="draw-wizard-micro-indicator__text">{label}</span>
+    </p>
+  );
+}

--- a/src/components/DrawWizardMicroProgress.css
+++ b/src/components/DrawWizardMicroProgress.css
@@ -1,0 +1,58 @@
+/*
+ * draw-wizard-micro-progress.css — per-step validity chips in the draw header.
+ *
+ * Tones map to existing semantic tokens:
+ *   --muted   → not yet satisfied
+ *   --warning → needs attention
+ *   --success → requirement met
+ *
+ * Compact density: single-line chips with a 0.625rem icon dot so all four
+ * fit beneath step labels on narrow viewports.
+ */
+
+.draw-wizard-micro-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin: 0.375rem 0 0;
+  padding: 0;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: 0.01em;
+}
+
+.draw-wizard-micro-indicator__icon {
+  flex-shrink: 0;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.draw-wizard-micro-indicator__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+}
+
+.draw-wizard-micro-indicator[data-tone="warning"] .draw-wizard-micro-indicator__icon {
+  background: var(--warning);
+}
+
+.draw-wizard-micro-indicator[data-tone="warning"] .draw-wizard-micro-indicator__text {
+  color: var(--warning);
+}
+
+.draw-wizard-micro-indicator[data-tone="success"] .draw-wizard-micro-indicator__icon {
+  background: var(--success);
+}
+
+.draw-wizard-micro-indicator[data-tone="success"] .draw-wizard-micro-indicator__text {
+  color: var(--success);
+}
+
+[data-contrast="high"] .draw-wizard-micro-indicator__text {
+  font-weight: 700;
+}

--- a/src/hooks/__tests__/useDrawWizardMicroProgress.test.ts
+++ b/src/hooks/__tests__/useDrawWizardMicroProgress.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDrawWizardMicroProgress } from "../useDrawWizardMicroProgress";
+import type { CreditLine } from "@/types/draw-credit.types";
+
+const line: CreditLine = {
+  id: "cl-001",
+  name: "Business Line of Credit",
+  limit: 50000,
+  available: 35000,
+  utilization: 30,
+  riskBand: "Standard",
+  termMonths: 24,
+};
+
+describe("useDrawWizardMicroProgress", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns four step states", () => {
+    const { result } = renderHook(() =>
+      useDrawWizardMicroProgress({
+        selectedCreditLine: null,
+        amount: 0,
+        confirmationAcknowledged: false,
+        isOnConfirmStep: false,
+      }),
+    );
+
+    expect(result.current.steps).toHaveLength(4);
+    expect(result.current.debouncedAnnouncement).toBe("");
+  });
+
+  it("debounces live-region announcements when validity changes", () => {
+    const { result, rerender } = renderHook(
+      (props) => useDrawWizardMicroProgress(props),
+      {
+        initialProps: {
+          selectedCreditLine: null as CreditLine | null,
+          amount: 0,
+          confirmationAcknowledged: false,
+          isOnConfirmStep: false,
+        },
+      },
+    );
+
+    rerender({
+      selectedCreditLine: line,
+      amount: 0,
+      confirmationAcknowledged: false,
+      isOnConfirmStep: false,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(result.current.debouncedAnnouncement).toBe("");
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(result.current.debouncedAnnouncement).toMatch(/Select line:/);
+  });
+});

--- a/src/hooks/useDrawWizardMicroProgress.ts
+++ b/src/hooks/useDrawWizardMicroProgress.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react";
+import { useDebounceValue } from "@/hooks/useDebounceValue";
+import {
+  buildMicroProgressAnnouncement,
+  computeDrawWizardMicroProgress,
+  type DrawWizardMicroProgressInput,
+  type DrawWizardMicroStepState,
+} from "@/lib/draw-wizard-micro-progress";
+
+const ANNOUNCEMENT_DEBOUNCE_MS = 300;
+
+/**
+ * Derives per-step micro-progress states and a debounced polite announcement
+ * string when any step's validity changes.
+ */
+export function useDrawWizardMicroProgress(input: DrawWizardMicroProgressInput): {
+  steps: DrawWizardMicroStepState[];
+  debouncedAnnouncement: string;
+} {
+  const steps = computeDrawWizardMicroProgress(input);
+  const previousRef = useRef<DrawWizardMicroStepState[] | null>(null);
+  const announcement = buildMicroProgressAnnouncement(previousRef.current, steps);
+
+  useEffect(() => {
+    previousRef.current = steps;
+  });
+
+  const debouncedAnnouncement = useDebounceValue(
+    announcement,
+    ANNOUNCEMENT_DEBOUNCE_MS,
+  );
+
+  return { steps, debouncedAnnouncement };
+}

--- a/src/lib/draw-wizard-micro-progress.test.ts
+++ b/src/lib/draw-wizard-micro-progress.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMicroProgressAnnouncement,
+  computeDrawWizardMicroProgress,
+} from "@/lib/draw-wizard-micro-progress";
+import type { CreditLine } from "@/types/draw-credit.types";
+
+const standardLine: CreditLine = {
+  id: "cl-001",
+  name: "Business Line of Credit",
+  limit: 50000,
+  available: 35000,
+  utilization: 30,
+  riskBand: "Standard",
+  termMonths: 24,
+};
+
+describe("computeDrawWizardMicroProgress", () => {
+  it("returns muted select, amount, preview, and confirm when nothing is chosen", () => {
+    const steps = computeDrawWizardMicroProgress({
+      selectedCreditLine: null,
+      amount: 0,
+      confirmationAcknowledged: false,
+      isOnConfirmStep: false,
+    });
+
+    expect(steps).toHaveLength(4);
+    expect(steps.map((s) => s.tone)).toEqual([
+      "muted",
+      "muted",
+      "muted",
+      "muted",
+    ]);
+    expect(steps[0].label).toBe("Select a line");
+  });
+
+  it("marks select as success once a line is chosen", () => {
+    const steps = computeDrawWizardMicroProgress({
+      selectedCreditLine: standardLine,
+      amount: 0,
+      confirmationAcknowledged: false,
+      isOnConfirmStep: false,
+    });
+
+    expect(steps[0]).toMatchObject({
+      id: "select",
+      tone: "success",
+      label: "Line selected",
+    });
+    expect(steps[1].tone).toBe("muted");
+    expect(steps[1].label).toBe("Enter amount");
+  });
+
+  it("marks amount as success and preview as ready when amount is in bounds", () => {
+    const steps = computeDrawWizardMicroProgress({
+      selectedCreditLine: standardLine,
+      amount: 5000,
+      confirmationAcknowledged: false,
+      isOnConfirmStep: false,
+    });
+
+    expect(steps[1]).toMatchObject({
+      id: "amount",
+      tone: "success",
+      label: "Amount valid",
+    });
+    expect(steps[2]).toMatchObject({
+      id: "preview",
+      tone: "success",
+      label: "Preview ready",
+    });
+  });
+
+  it("marks amount as warning when amount exceeds available credit", () => {
+    const steps = computeDrawWizardMicroProgress({
+      selectedCreditLine: standardLine,
+      amount: 40000,
+      confirmationAcknowledged: false,
+      isOnConfirmStep: false,
+    });
+
+    expect(steps[1]).toMatchObject({
+      tone: "warning",
+      label: "Amount out of bounds",
+    });
+    expect(steps[2].tone).toBe("muted");
+  });
+
+  it("marks confirm as warning on confirm step until terms are acknowledged", () => {
+    const steps = computeDrawWizardMicroProgress({
+      selectedCreditLine: standardLine,
+      amount: 1000,
+      confirmationAcknowledged: false,
+      isOnConfirmStep: true,
+    });
+
+    expect(steps[3]).toMatchObject({
+      id: "confirm",
+      tone: "warning",
+      label: "Acknowledge terms",
+    });
+  });
+
+  it("marks confirm as success when terms are acknowledged on confirm step", () => {
+    const steps = computeDrawWizardMicroProgress({
+      selectedCreditLine: standardLine,
+      amount: 1000,
+      confirmationAcknowledged: true,
+      isOnConfirmStep: true,
+    });
+
+    expect(steps[3]).toMatchObject({
+      tone: "success",
+      label: "Terms acknowledged",
+    });
+  });
+});
+
+describe("buildMicroProgressAnnouncement", () => {
+  it("returns empty string on first render (no prior snapshot)", () => {
+    const current = computeDrawWizardMicroProgress({
+      selectedCreditLine: standardLine,
+      amount: 1000,
+      confirmationAcknowledged: false,
+      isOnConfirmStep: false,
+    });
+
+    expect(buildMicroProgressAnnouncement(null, current)).toBe("");
+  });
+
+  it("announces only steps whose state changed", () => {
+    const before = computeDrawWizardMicroProgress({
+      selectedCreditLine: null,
+      amount: 0,
+      confirmationAcknowledged: false,
+      isOnConfirmStep: false,
+    });
+    const after = computeDrawWizardMicroProgress({
+      selectedCreditLine: standardLine,
+      amount: 0,
+      confirmationAcknowledged: false,
+      isOnConfirmStep: false,
+    });
+
+    const announcement = buildMicroProgressAnnouncement(before, after);
+    expect(announcement).toContain("Select line:");
+    expect(announcement).toContain("Business Line of Credit");
+  });
+});

--- a/src/lib/draw-wizard-micro-progress.ts
+++ b/src/lib/draw-wizard-micro-progress.ts
@@ -1,0 +1,194 @@
+import { CreditLine } from "@/types/draw-credit.types";
+import { getDrawAmountValidation } from "@/utils/amountValidation";
+
+/** Semantic tone for a step micro-indicator — maps to --muted, --warning, --success. */
+export type MicroIndicatorTone = "muted" | "warning" | "success";
+
+export type DrawWizardMicroStepId = "select" | "amount" | "preview" | "confirm";
+
+export interface DrawWizardMicroStepState {
+  id: DrawWizardMicroStepId;
+  tone: MicroIndicatorTone;
+  /** Compact visible label shown beneath the step header. */
+  label: string;
+  /** Plain-language string for aria-live announcements on state change. */
+  announcement: string;
+}
+
+export interface DrawWizardMicroProgressInput {
+  selectedCreditLine: CreditLine | null;
+  /** Whole-dollar draw amount from the wizard (0 when unset). */
+  amount: number;
+  /** Whether the user has ticked the confirmation checkbox on the confirm step. */
+  confirmationAcknowledged: boolean;
+  /** True when the confirm step is the active wizard screen. */
+  isOnConfirmStep: boolean;
+}
+
+function selectStepState(line: CreditLine | null): DrawWizardMicroStepState {
+  if (line) {
+    return {
+      id: "select",
+      tone: "success",
+      label: "Line selected",
+      announcement: `Select line: ${line.name} chosen.`,
+    };
+  }
+
+  return {
+    id: "select",
+    tone: "muted",
+    label: "Select a line",
+    announcement: "Select line: waiting for credit line selection.",
+  };
+}
+
+function amountStepState(
+  line: CreditLine | null,
+  amount: number,
+): DrawWizardMicroStepState {
+  if (!line) {
+    return {
+      id: "amount",
+      tone: "muted",
+      label: "Amount pending",
+      announcement: "Amount: waiting for credit line.",
+    };
+  }
+
+  if (amount <= 0) {
+    return {
+      id: "amount",
+      tone: "muted",
+      label: "Enter amount",
+      announcement: "Amount: enter a draw amount within your available credit.",
+    };
+  }
+
+  const validation = getDrawAmountValidation(String(amount), line);
+
+  if (!validation.isValid) {
+    return {
+      id: "amount",
+      tone: "warning",
+      label: "Amount out of bounds",
+      announcement: `Amount: ${validation.feedback.title}. ${validation.feedback.message}`,
+    };
+  }
+
+  return {
+    id: "amount",
+    tone: "success",
+    label: "Amount valid",
+    announcement: "Amount: within available credit limits.",
+  };
+}
+
+function previewStepState(
+  line: CreditLine | null,
+  amount: number,
+): DrawWizardMicroStepState {
+  if (!line) {
+    return {
+      id: "preview",
+      tone: "muted",
+      label: "Preview pending",
+      announcement: "Preview: waiting for credit line and amount.",
+    };
+  }
+
+  const validation = getDrawAmountValidation(String(amount), line);
+  const previewReady = amount > 0 && validation.isValid;
+
+  if (!previewReady) {
+    return {
+      id: "preview",
+      tone: "muted",
+      label: "Preview pending",
+      announcement: "Preview: enter a valid amount to compute costs.",
+    };
+  }
+
+  return {
+    id: "preview",
+    tone: "success",
+    label: "Preview ready",
+    announcement: "Preview: draw costs computed.",
+  };
+}
+
+function confirmStepState(
+  isOnConfirmStep: boolean,
+  confirmationAcknowledged: boolean,
+): DrawWizardMicroStepState {
+  if (!isOnConfirmStep) {
+    return {
+      id: "confirm",
+      tone: "muted",
+      label: "Confirm pending",
+      announcement: "Confirmation: complete earlier steps first.",
+    };
+  }
+
+  if (!confirmationAcknowledged) {
+    return {
+      id: "confirm",
+      tone: "warning",
+      label: "Acknowledge terms",
+      announcement: "Confirmation: accept the authorization terms to continue.",
+    };
+  }
+
+  return {
+    id: "confirm",
+    tone: "success",
+    label: "Terms acknowledged",
+    announcement: "Confirmation: terms acknowledged.",
+  };
+}
+
+/**
+ * Derives per-step micro-progress indicators for the draw wizard header.
+ * Pure function — safe to unit test and call on every render.
+ */
+export function computeDrawWizardMicroProgress(
+  input: DrawWizardMicroProgressInput,
+): DrawWizardMicroStepState[] {
+  const { selectedCreditLine, amount, confirmationAcknowledged, isOnConfirmStep } =
+    input;
+
+  return [
+    selectStepState(selectedCreditLine),
+    amountStepState(selectedCreditLine, amount),
+    previewStepState(selectedCreditLine, amount),
+    confirmStepState(isOnConfirmStep, confirmationAcknowledged),
+  ];
+}
+
+/**
+ * Builds a single polite live-region sentence when any step's announcement
+ * changes. Returns an empty string when nothing changed.
+ */
+export function buildMicroProgressAnnouncement(
+  previous: DrawWizardMicroStepState[] | null,
+  current: DrawWizardMicroStepState[],
+): string {
+  if (!previous) {
+    return "";
+  }
+
+  const changed = current.filter((step, index) => {
+    const prior = previous[index];
+    return (
+      !prior ||
+      prior.tone !== step.tone ||
+      prior.announcement !== step.announcement
+    );
+  });
+
+  if (changed.length === 0) {
+    return "";
+  }
+
+  return changed.map((step) => step.announcement).join(" ");
+}

--- a/src/pages/DrawCreditPage.tsx
+++ b/src/pages/DrawCreditPage.tsx
@@ -12,6 +12,9 @@ import { CreditLine, DrawStep, Transaction } from "@/types/draw-credit.types";
 import { mockCreditLines } from "@/lib/draw-credit-mock-data";
 import { WhyApr } from "@/components/WhyApr";
 import { DrawSummaryBar } from "@/components/DrawSummaryBar";
+import { DrawWizardMicroIndicator } from "@/components/DrawWizardMicroIndicator";
+import { useDrawWizardMicroProgress } from "@/hooks/useDrawWizardMicroProgress";
+import "@/components/DrawWizardMicroProgress.css";
 
 const drawSteps = [
   { id: "select", label: "Select line" },
@@ -40,10 +43,21 @@ export default function DrawCreditPage() {
   const [transaction, setTransaction] = useState<Transaction | null>(
     routeTransaction ?? null,
   );
+  const [confirmationAcknowledged, setConfirmationAcknowledged] =
+    useState(false);
+
+  const { steps: microProgressSteps, debouncedAnnouncement: microProgressAnnouncement } =
+    useDrawWizardMicroProgress({
+      selectedCreditLine,
+      amount,
+      confirmationAcknowledged,
+      isOnConfirmStep: step === "confirm",
+    });
 
   const handleSelectCreditLine = (creditLine: CreditLine) => {
     setSelectedCreditLine(creditLine);
     setAmount(0);
+    setConfirmationAcknowledged(false);
     setStep("amount");
   };
 
@@ -85,6 +99,7 @@ export default function DrawCreditPage() {
     setStep("select");
     setSelectedCreditLine(null);
     setAmount(0);
+    setConfirmationAcknowledged(false);
     setTransaction(null);
   };
 
@@ -92,8 +107,10 @@ export default function DrawCreditPage() {
     if (step === "amount") {
       setStep("select");
       setSelectedCreditLine(null);
+      setConfirmationAcknowledged(false);
     } else if (step === "confirm") {
       setStep("amount");
+      setConfirmationAcknowledged(false);
     }
   };
 
@@ -124,6 +141,7 @@ export default function DrawCreditPage() {
               {drawSteps.map((drawStep, index) => {
                 const isActive = index === activeStepIndex;
                 const isComplete = index < activeStepIndex;
+                const microStep = microProgressSteps[index];
 
                 return (
                   <li
@@ -143,10 +161,31 @@ export default function DrawCreditPage() {
                     <p className="mt-1 text-sm font-semibold text-foreground">
                       {drawStep.label}
                     </p>
+                    {microStep && (
+                      <DrawWizardMicroIndicator
+                        stepId={microStep.id}
+                        tone={microStep.tone}
+                        label={microStep.label}
+                      />
+                    )}
                   </li>
                 );
               })}
             </ol>
+            {/*
+              Polite live region for micro-progress updates — one announcer
+              for the whole header so AT users hear validity changes without
+              four competing regions.
+            */}
+            <span
+              className="sr-only"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              data-testid="draw-micro-progress-live"
+            >
+              {microProgressAnnouncement}
+            </span>
           </header>
         )}
 
@@ -156,6 +195,7 @@ export default function DrawCreditPage() {
               <CreditLineSelector
                 creditLines={mockCreditLines}
                 onSelect={handleSelectCreditLine}
+                microProgressDescribedBy="draw-wizard-micro-select"
               />
             </section>
           </div>
@@ -196,6 +236,8 @@ export default function DrawCreditPage() {
                 onBack={handleBack}
                 onCancel={handleCancel}
                 isLoading={isLoading}
+                agreedToTerms={confirmationAcknowledged}
+                onAgreedToTermsChange={setConfirmationAcknowledged}
               />
             </section>
           </div>


### PR DESCRIPTION
## Summary

- Adds compact validity chips beneath each of the four draw-wizard step headers so users can see at a glance whether **line selection**, **amount**, **preview**, and **confirmation** requirements are satisfied.
- Chips use existing semantic tokens (`--success`, `--warning`, `--muted`) with no new design tokens.
- A single debounced `aria-live="polite"` region announces validity changes for assistive technology users.

Closes #194

## Changes

| Area | Detail |
|------|--------|
| `DrawCreditPage` | Renders `DrawWizardMicroIndicator` under each step label; hosts polite live region |
| `draw-wizard-micro-progress.ts` | Pure functions for per-step tone, label, and announcement text |
| `DrawWizardMicroIndicator` | Compact inline chip component + CSS |
| `useDrawWizardMicroProgress` | Hook wiring computation to debounced announcements |
| `ConfirmationStep` | Controlled `agreedToTerms` / `onAgreedToTermsChange` props |
| `CreditLineSelector` | Optional `microProgressDescribedBy` for AT linkage |
| `docs/UX_RATIONALE.md` | Section 11 — rationale and trade-offs |

## Acceptance criteria

- [x] Each step shows a clear validity indicator
- [x] Updates announced politely (`aria-live="polite"`, debounced)
- [x] AA contrast via existing semantic tokens (+ high-contrast weight bump)
- [x] No new tokens introduced
- [x] Renders at compact density (ellipsis truncation, 0.6875rem chips)
- [x] Unit tests (12 passing)

## Test plan

- [x] `npm test -- --run src/lib/draw-wizard-micro-progress.test.ts src/components/DrawWizardMicroIndicator.test.tsx src/hooks/__tests__/useDrawWizardMicroProgress.test.ts`
- [ ] Step 1: confirm chip moves from "Select a line" → "Line selected" after picking a line
- [ ] Step 2: enter invalid then valid amount — chip toggles warning ↔ success; preview chip follows
- [ ] Step 4: on confirm screen, checkbox toggles confirm chip warning ↔ success
- [ ] VoiceOver: hear polite announcements when validity changes (no spam on every keystroke)
- [ ] Screenshots of each step showing all four chips at mobile width