### PR TITLE
Resolve 4 issues assigned to NickiM84 (#452, #451, #447, #426)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,12 @@ import { LinkedAccounts } from "./pages/LinkedAccounts";
 import { WalletReconnectBanner } from "./components/WalletReconnectBanner";
 import { NetworkMismatchBanner } from "./components/notifications/NetworkMismatchBanner";
 import { Header } from "./layouts/Header";
+import {
+  RouteHeadProvider,
+  RouteAnnouncer,
+} from "./components/RouteAnnouncer";
+import { SessionTimeoutBanner } from "./components/SessionTimeoutBanner";
+import { NotificationPreferences } from "./pages/NotificationPreferences";
 
 const isEditableTarget = (target: EventTarget | null) => {
   if (!(target instanceof HTMLElement)) return false;
@@ -42,15 +48,28 @@ const isEditableTarget = (target: EventTarget | null) => {
  *       <ContrastProvider> — high-contrast override, [data-contrast="high"]
  *         <WalletProvider> — wallet lifecycle visible to every route
  *           <BrowserRouter>
- *             <header />   — persistent nav chrome
- *             <main>
- *               <Routes /> — current route
- *             </main>
+ *             <RouteHeadProvider> — per-route title/description/announcement
+ *               <RouteAnnouncer /> — bound to the URL + override context
+ *               <header />         — persistent nav chrome
+ *               <main>
+ *                 <Routes />        — current route
+ *               </main>
+ *             </RouteHeadProvider>
  *           </BrowserRouter>
  *         </WalletProvider>
  *       </ContrastProvider>
  *     </ThemeProvider>
  *   </ErrorBoundary>
+ *
+ * Note on the RouteStack pair (RouteHeadProvider + RouteAnnouncer):
+ *   Previously the RouteAnnouncer component was defined but never
+ *   mounted in the running app; pages relied on whatever browser
+ *   title survived from the last navigation.  GitHub issue #451
+ *   ("Add per-route RouteAnnouncer") asked us to (a) actually mount
+ *   it so every navigation triggers a screen-reader announcement,
+ *   and (b) let individual pages push custom titles + descriptions
+ *   via `useRouteHead`.  The provider context here enables (b) without
+ *   forcing every page into a wrapper.
  *
  * See docs/ARCHITECTURE.md for the full component topology.
  */
@@ -96,64 +115,70 @@ function App() {
         <NotificationProvider>
         <ReducedMotionProvider>
         <BrowserRouter>
-          <div className="app">
-            <Header
-              settingsTriggerRef={settingsTriggerRef}
-              kycTriggerRef={kycTriggerRef}
-              onSettingsClick={() => {
-                setOpenedFromSettingsLink(true);
-                setIsShortcutHelpOpen(true);
-              }}
-              onKycClick={() => setIsKycDrawerOpen(true)}
-            />
+          <RouteHeadProvider>
+            <div className="app">
+              <Header
+                settingsTriggerRef={settingsTriggerRef}
+                kycTriggerRef={kycTriggerRef}
+                onSettingsClick={() => {
+                  setOpenedFromSettingsLink(true);
+                  setIsShortcutHelpOpen(true);
+                }}
+                onKycClick={() => setIsKycDrawerOpen(true)}
+              />
 
-            {/* Wallet auto-reconnect timeout banner — self-dismissing,
-                non-blocking; only visible when reconnect takes > 8 s. */}
-            <WalletReconnectBanner />
-            {/* Session-timeout warning banner — visible 60 s before
-                the wallet extension silently disconnects (#227). */}
-            <SessionTimeoutBanner />
-            <main className="main">
-              <NetworkMismatchBanner />
-              <Routes>
-                <Route path="/" element={<Dashboard />} />
-                <Route path="/transactions" element={<TransactionHistory />} />
-                <Route path="/credit-lines" element={<CreditLines />} />
-                <Route path="/help" element={<HelpCenter />} />
-                <Route path="/draw-credit" element={<DrawCreditPage />} />
-                <Route
-                  path="/draw-credit/success"
-                  element={<DrawCreditPage />}
-                />
-                <Route path="/open-credit" element={<RequestEvaluation />} />
-                <Route path="/dutch-auctions" element={<DutchAuctions />} />
-                <Route path="/linked-accounts" element={<LinkedAccounts />} />
-                <Route path="/notification-preferences" element={<NotificationPreferences />} />
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </main>
-            <ShortcutHelpOverlay
-              isOpen={isShortcutHelpOpen}
-              onClose={() => setIsShortcutHelpOpen(false)}
-              triggerRef={openedFromSettingsLink ? settingsTriggerRef : undefined}
-            />
-            <KycDrawer
-              isOpen={isKycDrawerOpen}
-              onClose={() => setIsKycDrawerOpen(false)}
-              onResume={(stepId) => {
-                // Navigate to the KYC page with the step pre-selected.
-                // Replace with router.push('/kyc?step=' + stepId) when the
-                // full KYC page exists.
-                console.info('[KYC] Resume at step:', stepId);
-              }}
-              triggerRef={kycTriggerRef}
-            />
-            <CommandPalette
-              isOpen={isPaletteOpen}
-              onClose={() => setIsPaletteOpen(false)}
-              triggerRef={paletteTriggerRef}
-            />
-          </div>
+              {/* Wallet auto-reconnect timeout banner — self-dismissing,
+                  non-blocking; only visible when reconnect takes > 8 s. */}
+              <WalletReconnectBanner />
+              {/* Session-timeout warning banner — visible 60 s before
+                  the wallet extension silently disconnects (#227). */}
+              <SessionTimeoutBanner />
+              <main className="main">
+                <NetworkMismatchBanner />
+                <Routes>
+                  <Route path="/" element={<Dashboard />} />
+                  <Route path="/transactions" element={<TransactionHistory />} />
+                  <Route path="/credit-lines" element={<CreditLines />} />
+                  <Route path="/help" element={<HelpCenter />} />
+                  <Route path="/draw-credit" element={<DrawCreditPage />} />
+                  <Route
+                    path="/draw-credit/success"
+                    element={<DrawCreditPage />}
+                  />
+                  <Route path="/open-credit" element={<RequestEvaluation />} />
+                  <Route path="/dutch-auctions" element={<DutchAuctions />} />
+                  <Route path="/linked-accounts" element={<LinkedAccounts />} />
+                  <Route path="/notification-preferences" element={<NotificationPreferences />} />
+                  <Route path="*" element={<NotFound />} />
+                </Routes>
+              </main>
+              <ShortcutHelpOverlay
+                isOpen={isShortcutHelpOpen}
+                onClose={() => setIsShortcutHelpOpen(false)}
+                triggerRef={openedFromSettingsLink ? settingsTriggerRef : undefined}
+              />
+              <KycDrawer
+                isOpen={isKycDrawerOpen}
+                onClose={() => setIsKycDrawerOpen(false)}
+                onResume={(stepId) => {
+                  // Navigate to the KYC page with the step pre-selected.
+                  // Replace with router.push('/kyc?step=' + stepId) when the
+                  // full KYC page exists.
+                  console.info('[KYC] Resume at step:', stepId);
+                }}
+                triggerRef={kycTriggerRef}
+              />
+              <CommandPalette
+                isOpen={isPaletteOpen}
+                onClose={() => setIsPaletteOpen(false)}
+                triggerRef={paletteTriggerRef}
+              />
+              {/* Per-route screen-reader announcer (#451).  Mounted at
+                  the bottom of the tree so route-side `useRouteHead`
+                  overrides apply before the announcer effect runs. */}
+              <RouteAnnouncer />
+            </div>
+          </RouteHeadProvider>
         </BrowserRouter>
         </ReducedMotionProvider>
         </NotificationProvider>

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -22,6 +22,22 @@ interface BaseFormFieldProps {
   error?: string;
   /** Pass-through class name on the field wrapper. */
   className?: string;
+  /**
+   * Debounce window (ms) for the screen-reader announcement of the
+   * error message.  The visual error renders immediately; only the
+   * `aria-live` readback is delayed so rapid edits to a field
+   * ("1" → "10" → "100") produce one readback instead of three.
+   *
+   * Defaults to 300 ms — long enough to coalesce a typical typing
+   * burst, short enough to feel responsive.  Set to `0` to read each
+   * change instantly (useful in tests + critical forms).
+   *
+   * The value is forwarded to the inner `FormMessage` debounce hook so
+   * the announcement cadence is owned by `FormField` itself rather
+   * than buried in a child component.  This addresses GitHub
+   * issue #452 ("Add debounce-announce on FormField errors").
+   */
+  announceDelayMs?: number;
 }
 
 interface InputFormFieldProps extends BaseFormFieldProps {
@@ -55,6 +71,9 @@ type FormFieldProps = InputFormFieldProps | TextareaFormFieldProps | CustomFormF
  * - Required indicator with screen reader announcement
  * - Help text linked via aria-describedby
  * - Error messaging with aria-invalid and aria-describedby
+ * - Debounced live-region announcement (configurable via
+ *   `announceDelayMs`, default 300 ms) so rapid error toggles
+ *   collapse into one readback (#452).
  * - Consistent spacing and color tokens
  * - Focus management with visible focus rings
  *
@@ -70,7 +89,15 @@ type FormFieldProps = InputFormFieldProps | TextareaFormFieldProps | CustomFormF
  * />
  */
 export function FormField(props: FormFieldProps) {
-  const { id, label, required = false, helpText, error, className = '' } = props;
+  const {
+    id,
+    label,
+    required = false,
+    helpText,
+    error,
+    className = '',
+    announceDelayMs,
+  } = props;
 
   const helpTextId = `${id}-help`;
   const errorId = `${id}-error`;
@@ -122,12 +149,15 @@ export function FormField(props: FormFieldProps) {
       )}
 
       {error && (
+        // `announceDelayMs` is optionally forwarded.  React drops
+        // `undefined` props, so passing unconditionally is safe.
         <FormMessage
           id={errorId}
           title={error}
           type="danger"
           tone="inline"
           reserveSpace={false}
+          announceDelayMs={announceDelayMs}
         />
       )}
     </div>

--- a/src/components/FormMessage.tsx
+++ b/src/components/FormMessage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import { AlertCircle, CheckCircle, Info, AlertTriangle } from "lucide-react";
 
-const ANNOUNCEMENT_DELAY_MS = 300;
+const DEFAULT_ANNOUNCEMENT_DELAY_MS = 300;
 
 interface FormMessageProps {
   /** Optional stable id so callers can wire `aria-describedby`. */
@@ -29,6 +29,17 @@ interface FormMessageProps {
   reserveSpace?: boolean;
   /** Override the default reserved height (52 px inline, 88 px alert). */
   minHeight?: number;
+  /**
+   * Time (ms) to wait before announcing the message to screen readers.
+   * The visual message is rendered immediately; only the `aria-live`
+   * readback is debounced. Defaults to 300 ms, which is long enough to
+   * coalesce rapid edits ("10" → "100" → "1000") into a single
+   * readback but short enough to feel responsive.
+   *
+   * Setting to `0` disables the debounce — useful in tests and for
+   * critical errors that must be read immediately.
+   */
+  announceDelayMs?: number;
   /** Pass-through inline style for one-off layout tweaks. */
   style?: CSSProperties;
   /** Pass-through class name appended to the slot container. */
@@ -60,8 +71,17 @@ function useDebouncedAnnouncement(text: string, delay: number) {
   const [announcedText, setAnnouncedText] = useState("");
 
   useEffect(() => {
+    // `delay === 0` is a valid signal to skip the debounce entirely
+    // (used by tests + critical errors).  We do not read the live
+    // region straight off the prop because passing `delay === 0` to
+    // setTimeout would still queue a microtask-deferred readback.
     if (!text) {
       setAnnouncedText("");
+      return;
+    }
+
+    if (delay <= 0) {
+      setAnnouncedText(text);
       return;
     }
 
@@ -81,8 +101,9 @@ function useDebouncedAnnouncement(text: string, delay: number) {
  * Tone-coded inline message for form fields and form-level alerts.
  *
  * The visual message is rendered immediately, but the live announcement is
- * debounced for 300 ms so assistive technology hears the settled validation
- * state instead of every intermediate keystroke.
+ * debounced (default 300 ms) so assistive technology hears the settled
+ * validation state instead of every intermediate keystroke.  Callers can
+ * override the debounce with `announceDelayMs` — `0` disables it.
  *
  * Use `reserveSpace` on the canonical version below an input to prevent
  * layout shift when a message toggles on or off.
@@ -95,13 +116,14 @@ export function FormMessage({
   type = "danger",
   reserveSpace = false,
   minHeight,
+  announceDelayMs = DEFAULT_ANNOUNCEMENT_DELAY_MS,
   style,
   className = "",
 }: FormMessageProps) {
   const hasContent = Boolean(title) || Boolean(message);
   const announcement = useDebouncedAnnouncement(
     [getPlainText(title), getPlainText(message)].filter(Boolean).join(" "),
-    ANNOUNCEMENT_DELAY_MS,
+    announceDelayMs,
   );
 
   if (!hasContent && !reserveSpace) {

--- a/src/components/RiskExplainerOverlay.css
+++ b/src/components/RiskExplainerOverlay.css
@@ -1,0 +1,346 @@
+/*
+ * RiskExplainerOverlay styles
+ *
+ * Tokens referenced (CSS custom properties declared in src/index.css):
+ *   --surface, --surface-elevated, --border, --text, --muted, --accent
+ *
+ * Each rule keeps to design tokens — no hex literals.  Theme + dark +
+ * reduced-motion overrides are handled at the bottom of the file so
+ * the bulk of the rules stay readable.
+ *
+ * WCAG considerations baked in:
+ *   - AA contrast on the dialog surface (≥ 4.5:1).
+ *   - Minimum tap target of 44×44 px on the close + footer buttons.
+ *   - Visible focus rings via :focus-visible.
+ *   - Colour is always paired with text so colour-blind users still
+ *     understand each band from the band name + APR range alone.
+ */
+
+/* ── Portal & positioning ─────────────────────────────────────── */
+
+.risk-explainer-overlay__portal {
+  position: fixed;
+  inset: 0;
+  z-index: 1100; /* Same tier as InlineHelpOverlay */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.risk-explainer-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  animation: risk-explainer-overlay-fade 200ms ease-out;
+}
+
+@keyframes risk-explainer-overlay-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* ── Dialog shell ─────────────────────────────────────────────── */
+
+.risk-explainer-overlay__dialog {
+  position: relative;
+  width: 100%;
+  max-width: 640px;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+  background: var(--surface, #161b22);
+  border: 1px solid var(--border, #30363d);
+  border-radius: 16px;
+  padding: 1.5rem 1.5rem 1.25rem;
+  box-shadow:
+    0 24px 48px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+  animation: risk-explainer-overlay-rise 220ms cubic-bezier(0.16, 1, 0.3, 1);
+  outline: none;
+  color: var(--text, #e6edf3);
+  font-family: inherit;
+}
+
+.risk-explainer-overlay__dialog:focus-visible {
+  outline: 3px solid var(--focus, #58a6ff);
+  outline-offset: 2px;
+}
+
+@keyframes risk-explainer-overlay-rise {
+  from {
+    opacity: 0;
+    transform: translateY(20px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* ── Header ───────────────────────────────────────────────────── */
+
+.risk-explainer-overlay__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.75rem;
+}
+
+.risk-explainer-overlay__eyebrow {
+  margin: 0 0 0.25rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent, #58a6ff);
+}
+
+.risk-explainer-overlay__title {
+  margin: 0;
+  font-size: 1.375rem;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--text, #e6edf3);
+}
+
+.risk-explainer-overlay__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0.5rem;
+  border: 1px solid transparent;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--muted, #8b949e);
+  font-size: 1.25rem;
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.risk-explainer-overlay__close:hover {
+  background: var(--border, #30363d);
+  color: var(--text, #e6edf3);
+}
+
+.risk-explainer-overlay__close:focus-visible {
+  outline: 3px solid var(--focus, #58a6ff);
+  outline-offset: 2px;
+}
+
+.risk-explainer-overlay__close:active {
+  transform: scale(0.96);
+}
+
+/* ── Lede ─────────────────────────────────────────────────────── */
+
+.risk-explainer-overlay__lede {
+  margin: 1rem 0 1.25rem;
+  padding: 0.875rem 1rem;
+  background: rgba(88, 166, 255, 0.08);
+  border: 1px solid rgba(88, 166, 255, 0.2);
+  border-radius: 10px;
+  color: var(--text, #e6edf3);
+}
+
+.risk-explainer-overlay__lede p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+/* ── Bands list ───────────────────────────────────────────────── */
+
+.risk-explainer-overlay__bands {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.risk-explainer-overlay__band {
+  position: relative;
+  padding: 0.875rem 1rem;
+  background: var(--surface-elevated, rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--border, #30363d);
+  border-left-width: 4px;
+  border-radius: 10px;
+}
+
+.risk-explainer-overlay__band-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+}
+
+.risk-explainer-overlay__band-name {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text, #e6edf3);
+}
+
+.risk-explainer-overlay__band-pill {
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(139, 148, 158, 0.18);
+  color: var(--muted, #8b949e);
+  letter-spacing: 0.04em;
+}
+
+.risk-explainer-overlay__band-description {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--muted, #8b949e);
+}
+
+.risk-explainer-overlay__band-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.risk-explainer-overlay__stat {
+  background: rgba(0, 0, 0, 0.18);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  margin: 0;
+}
+
+.risk-explainer-overlay__stat dt {
+  margin: 0;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted, #8b949e);
+}
+
+.risk-explainer-overlay__stat dd {
+  margin: 0.125rem 0 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text, #e6edf3);
+}
+
+/* ── Footer ───────────────────────────────────────────────────── */
+
+.risk-explainer-overlay__footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border, #30363d);
+}
+
+.risk-explainer-overlay__docs-link {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--accent, #58a6ff);
+  text-decoration: none;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  transition: background 150ms ease;
+}
+
+.risk-explainer-overlay__docs-link:hover {
+  background: rgba(88, 166, 255, 0.1);
+  text-decoration: underline;
+}
+
+.risk-explainer-overlay__docs-link:focus-visible {
+  outline: 3px solid var(--focus, #58a6ff);
+  outline-offset: 2px;
+}
+
+.risk-explainer-overlay__primary {
+  min-height: 44px;
+  min-width: 96px;
+  padding: 0.5rem 1.25rem;
+  background: var(--accent, #58a6ff);
+  color: var(--bg, #0d1117);
+  border: none;
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 150ms ease, transform 150ms ease;
+}
+
+.risk-explainer-overlay__primary:hover {
+  background: #4c8ed1;
+}
+
+.risk-explainer-overlay__primary:active {
+  transform: scale(0.97);
+}
+
+.risk-explainer-overlay__primary:focus-visible {
+  outline: 3px solid var(--focus, #58a6ff);
+  outline-offset: 2px;
+}
+
+/* ── Mobile ───────────────────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .risk-explainer-overlay__portal {
+    padding: 0.5rem;
+    align-items: flex-end;
+  }
+
+  .risk-explainer-overlay__dialog {
+    max-height: 92vh;
+    border-radius: 14px 14px 0 0;
+    padding-bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+  }
+
+  .risk-explainer-overlay__title {
+    font-size: 1.15rem;
+  }
+
+  .risk-explainer-overlay__band-stats {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Reduced motion ───────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .risk-explainer-overlay__backdrop,
+  .risk-explainer-overlay__dialog {
+    animation: none;
+  }
+  .risk-explainer-overlay__dialog {
+    transform: none;
+    opacity: 1;
+  }
+}
+
+/* ── High contrast ────────────────────────────────────────────── */
+
+@media (prefers-contrast: more) {
+  .risk-explainer-overlay__dialog {
+    border-width: 2px;
+  }
+  .risk-explainer-overlay__band {
+    border-width: 2px;
+  }
+}

--- a/src/components/RiskExplainerOverlay.tsx
+++ b/src/components/RiskExplainerOverlay.tsx
@@ -1,0 +1,242 @@
+/**
+ * RiskExplainerOverlay
+ *
+ * Centered modal overlay that explains the four Creditra risk bands in
+ * detail.  This component is the third of three risk-explanation entry
+ * points:
+ *
+ *   1. `RiskExplainerCard` - inline dismissable banner.
+ *   2. `RiskBandsPanel`    - right-side slide-out panel.
+ *   3. `RiskExplainerOverlay` - centered modal with detailed band info.
+ *
+ * Why a third variant?
+ * ─────────────────────
+ * The inline card is too small for full explanations and the side
+ * panel dominates the viewport at rest.  The centered overlay is the
+ * right shape for a single "tell me everything at once" use case,
+ * mirroring the patterns we already use for `WhyApr` and
+ * `InlineHelpOverlay`.
+ *
+ * Accessibility
+ * ─────────────
+ * - `role="dialog"` + `aria-modal="true"` + `aria-labelledby`
+ *   (WCAG 4.1.2 Name, Role, Value).
+ * - Focus trap via `useFocusTrap` (WCAG 2.4.3 Focus Order + 2.1.2 No
+ *   Keyboard Trap).
+ * - Inert backdrop so screen-reader rotors don't reach the page
+ *   chrome while the modal is open.
+ * - Body scroll lock prevents the background from scrolling during a
+ *   drag-scroll gesture on the modal content.
+ * - Reduced-motion respected: we strip animations when
+ *   `prefers-reduced-motion: reduce`.
+ *
+ * Visual treatment
+ * ────────────────
+ * - Listing from `Excellent` (5-10% APR) downward through `Recovery`
+ *   (31%+).
+ * - Each band has a left-border color so color-blind users can
+ *   still scan between rows.  The text content carries the band
+ *   name, APR range, and limit guidance so color is never the only
+ *   signal (WCAG 1.4.1 Use of Color).
+ */
+
+import type { RefObject } from "react";
+import { createPortal } from "react-dom";
+import { useBodyScrollLock } from "@/hooks/useBodyScrollLock";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
+import { useInertBackdrop } from "@/hooks/useInertBackdrop";
+import { COLOR } from "@/utils/tokens";
+import "./RiskExplainerOverlay.css";
+
+export interface RiskBandInfo {
+  name: string;
+  /** Inclusive lower-bound score for the band (FICO-style 0-850). */
+  minScore: number;
+  description: string;
+  aprRange: string;
+  limitGuidance: string;
+  /** Display accent (hex).  Always paired with text - never colour-only. */
+  color: string;
+}
+
+/**
+ * Canonical four-band definition.  Kept here (not pulled from
+ * src/components/RiskBandsPanel) so each surface can optimise its
+ * own layout without a shared module becoming a leaky abstraction.
+ */
+const RISK_BANDS: ReadonlyArray<RiskBandInfo> = [
+  {
+    name: "Excellent",
+    minScore: 700,
+    description:
+      "Highest tier of creditworthiness with optimal terms. Strong repayment history and low utilisation keep rates at the floor of the market.",
+    aprRange: "5% \u2013 10%",
+    limitGuidance: "Maximum available limits",
+    color: COLOR.success,
+  },
+  {
+    name: "Good",
+    minScore: 600,
+    description:
+      "Strong credit profile with competitive rates. Maintaining timely repayments can graduate you into the Excellent range within one cycle.",
+    aprRange: "11% \u2013 20%",
+    limitGuidance: "High to medium limits",
+    color: COLOR.warning,
+  },
+  {
+    name: "Caution",
+    minScore: 500,
+    description:
+      "Moderate risk; terms may be more restrictive. Reducing utilisation and avoiding missed payments is the fastest path back into the Good band.",
+    aprRange: "21% \u2013 30%",
+    limitGuidance: "Limited initial limits",
+    color: COLOR.danger,
+  },
+  {
+    name: "Recovery",
+    minScore: 0,
+    description:
+      "High risk; Creditra is focused on rebuilding credit history. Repayments on time are weighted heavily here - every clean cycle raises your score.",
+    aprRange: "31%+",
+    limitGuidance: "Minimum baseline limits",
+    color: COLOR.danger,
+  },
+];
+
+interface RiskExplainerOverlayProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /**
+   * Ref to the button that opened the modal - required so focus can
+   * be restored to the trigger on close (WCAG 2.4.3 Focus Order).
+   */
+  triggerRef?: RefObject<HTMLElement | null>;
+}
+
+const modalId = "risk-explainer-overlay";
+const titleId = "risk-explainer-overlay-title";
+
+export function RiskExplainerOverlay({
+  isOpen,
+  onClose,
+  triggerRef,
+}: RiskExplainerOverlayProps) {
+  const dialogRef = useFocusTrap({
+    isActive: isOpen,
+    triggerRef,
+    onEscape: onClose,
+  });
+
+  useBodyScrollLock({ isLocked: isOpen });
+  useInertBackdrop({ isInert: isOpen, modalId });
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      id={modalId}
+      className="risk-explainer-overlay__portal"
+      aria-hidden="false"
+    >
+      <div
+        className="risk-explainer-overlay__backdrop"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        ref={dialogRef as RefObject<HTMLDivElement>}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="risk-explainer-overlay__dialog"
+        data-testid="risk-explainer-overlay"
+      >
+        <header className="risk-explainer-overlay__header">
+          <div>
+            <p className="risk-explainer-overlay__eyebrow">Risk pricing</p>
+            <h2 id={titleId} className="risk-explainer-overlay__title">
+              How risk bands shape your APR
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="risk-explainer-overlay__close"
+            aria-label="Close risk band explainer"
+          >
+            <span aria-hidden="true">{"\u2715"}</span>
+          </button>
+        </header>
+
+        <div className="risk-explainer-overlay__lede">
+          <p>
+            Creditra prices your credit dynamically, using your on-chain
+            repayment history, collateral volatility, and current
+            utilisation to map you into one of four bands. Each band
+            defines an APR range and an initial limit guidance.
+          </p>
+        </div>
+
+        <ul
+          className="risk-explainer-overlay__bands"
+          aria-label="Creditra risk bands"
+          data-testid="risk-explainer-overlay-bands"
+        >
+          {RISK_BANDS.map((band) => (
+            <li
+              key={band.name}
+              className="risk-explainer-overlay__band"
+              style={{ borderLeftColor: band.color }}
+            >
+              <header className="risk-explainer-overlay__band-header">
+                <h3 className="risk-explainer-overlay__band-name">
+                  {band.name}
+                </h3>
+                <span
+                  className="risk-explainer-overlay__band-pill"
+                  data-testid="risk-explainer-overlay-score"
+                >
+                  {band.minScore}+
+                </span>
+              </header>
+              <p className="risk-explainer-overlay__band-description">
+                {band.description}
+              </p>
+              <dl className="risk-explainer-overlay__band-stats">
+                <div className="risk-explainer-overlay__stat">
+                  <dt>APR range</dt>
+                  <dd data-testid="risk-explainer-overlay-apr">
+                    {band.aprRange}
+                  </dd>
+                </div>
+                <div className="risk-explainer-overlay__stat">
+                  <dt>Limit guidance</dt>
+                  <dd>{band.limitGuidance}</dd>
+                </div>
+              </dl>
+            </li>
+          ))}
+        </ul>
+
+        <footer className="risk-explainer-overlay__footer">
+          <a
+            href="/docs/risk-pricing"
+            className="risk-explainer-overlay__docs-link"
+            aria-label="Read the full risk pricing documentation"
+          >
+            Read the full risk-pricing docs
+            <span aria-hidden="true">{"\u2192"}</span>
+          </a>
+          <button
+            type="button"
+            onClick={onClose}
+            className="risk-explainer-overlay__primary"
+          >
+            Got it
+          </button>
+        </footer>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/RouteAnnouncer.tsx
+++ b/src/components/RouteAnnouncer.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useState } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import type { ReactNode, ReactElement } from "react";
 import { matchPath, useLocation } from "react-router-dom";
 
 type RouteMetadata = {
@@ -73,7 +79,7 @@ export const NOT_FOUND_METADATA: Omit<RouteMetadata, "path"> = {
 const titleFor = (pageName: string) => `Creditra · ${pageName}`;
 
 const getRouteMetadata = (pathname: string) =>
-  ROUTE_METADATA.find(route =>
+  ROUTE_METADATA.find((route) =>
     matchPath({ path: route.path, end: true }, pathname),
   ) ?? NOT_FOUND_METADATA;
 
@@ -92,18 +98,113 @@ const syncMetaDescription = (description: string) => {
   metaDescription.content = description;
 };
 
-export function RouteAnnouncer() {
+// ─── Per-route override (Issue #451) ────────────────────────────────────────
+//
+// Some pages carry sub-state - onboarding steps, wizard stages, filtered
+// lists - where the same URL maps to dramatically different content over
+// time.  The centre-of-mass metadata captured in `ROUTE_METADATA` is a
+// useful default but cannot describe a "filtered down to two credit
+// lines" transactions view, or an OnboardingFlow mid-step.
+//
+// Pages that need richer announcements push a `RouteHead` via
+// `useRouteHead({...})`.  The provider is intentionally lightweight so
+// pages do not have to import the context directly - the consumer hook
+// reads context if present and silently does nothing otherwise.
+//
+// Implementation note: the Provider component is bound to a const
+// before JSX (`const Provider = RouteHeadContext.Provider`) so the
+// emit does not depend on `<Context.Provider>` syntax.  Both forms are
+// valid TSX, but the bound-form keeps the parse predictable across
+// all bundlers including vite + esbuild.
+
+export type RouteHead = {
+  /** Override the document title (`<title>` tag). */
+  title?: string;
+  /** Override the `<meta name="description">` content. */
+  description?: string;
+  /** Override the polite live-region announcement text. */
+  announcement?: string;
+};
+
+interface RouteHeadContextValue {
+  head: RouteHead | undefined;
+  setHead: (next: RouteHead | undefined) => void;
+}
+
+const RouteHeadContext = createContext<RouteHeadContextValue | undefined>(
+  undefined,
+);
+
+/**
+ * `RouteHeadProvider` - wrap children once (the App.tsx boundary).
+ * The provider supplies the *most recent* override; overrides are
+ * reset on unmount of `useRouteHead`.
+ */
+export function RouteHeadProvider(props: {
+  initialHead?: RouteHead;
+  children: ReactNode;
+}): ReactElement {
+  const [head, setHead] = useState<RouteHead | undefined>(props.initialHead);
+  const Provider = RouteHeadContext.Provider;
+  return (
+    <Provider value={{ head, setHead }}>
+      {props.children}
+    </Provider>
+  );
+}
+
+/**
+ * Push per-route head/announcement metadata.  Re-renders when `head`
+ * changes, and clears the override on unmount so consumers do not
+ * leak stale title/description from a sibling page that was visited
+ * earlier.
+ */
+export function useRouteHead(head: RouteHead | undefined): void {
+  const ctx = useContext(RouteHeadContext);
+  useEffect(() => {
+    if (!ctx) return;
+    ctx.setHead(head);
+    return () => ctx.setHead(undefined);
+    // We intentionally exclude `ctx` from deps - the context object
+    // is stable across renders for the same provider.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [head?.title, head?.description, head?.announcement]);
+}
+
+// ─── Announcer ──────────────────────────────────────────────────────────────
+
+/**
+ * RouteAnnouncer - announces the current route to assistive tech and
+ * keeps the document title + meta description in sync with the URL.
+ *
+ * Resolution order for the announcement text:
+ *
+ *   1. The most-recent `useRouteHead({ announcement })` override.
+ *   2. The matching entry from `ROUTE_METADATA`, formatted as
+ *      "${pageName} page loaded".
+ *   3. The `NOT_FOUND_METADATA` fallback.
+ *
+ * Document title and meta description follow the same priority
+ * (`useRouteHead` wins, then `ROUTE_METADATA`, then Not Found).
+ */
+export function RouteAnnouncer(): ReactElement {
   const location = useLocation();
+  const headCtx = useContext(RouteHeadContext);
+  const override = headCtx?.head;
   const [announcement, setAnnouncement] = useState("");
 
   useEffect(() => {
     const metadata = getRouteMetadata(location.pathname);
-    const title = titleFor(metadata.pageName);
+
+    const title = override?.title ?? titleFor(metadata.pageName);
+    const description = override?.description ?? metadata.description;
+    const nextAnnouncement =
+      override?.announcement ?? `${metadata.pageName} page loaded`;
 
     document.title = title;
-    syncMetaDescription(metadata.description);
-    setAnnouncement(`${metadata.pageName} page loaded`);
-  }, [location.pathname]);
+    syncMetaDescription(description);
+    setAnnouncement(nextAnnouncement);
+  }, [location.pathname, override]);
 
   return (
     <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">

--- a/src/components/__tests__/FormField.test.tsx
+++ b/src/components/__tests__/FormField.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen, act } from '@testing-library/react';
 import { FormField } from '../FormField';
 
+/**
+ * Tests for FormField — particularly the debounced `aria-live` error
+ * announcement introduced in (#452).
+ *
+ * The 300 ms default debounce is the original behaviour; the
+ * `announceDelayMs` prop exposes it so callers can tune the cadence
+ * for critical (or test-only) forms.
+ */
 describe('FormField', () => {
   beforeAll(() => {
     vi.useFakeTimers();
@@ -109,5 +117,58 @@ describe('FormField', () => {
     });
 
     expect(screen.getByRole('alert')).toHaveTextContent('Second error');
+  });
+
+  test('honors a custom announceDelayMs prop — short delay', () => {
+    const { rerender } = render(
+      <FormField
+        id="test"
+        label="Test Field"
+        type="text"
+        announceDelayMs={50}
+      />
+    );
+
+    rerender(
+      <FormField
+        id="test"
+        label="Test Field"
+        type="text"
+        error="Custom delay error"
+        announceDelayMs={50}
+      />
+    );
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Custom delay error',
+    );
+  });
+
+  test('announceDelayMs={0} disables the debounce entirely', () => {
+    const { rerender } = render(
+      <FormField
+        id="test"
+        label="Test Field"
+        type="text"
+        announceDelayMs={0}
+      />
+    );
+
+    rerender(
+      <FormField
+        id="test"
+        label="Test Field"
+        type="text"
+        error="Immediate error"
+        announceDelayMs={0}
+      />
+    );
+
+    // No timer advance — the announcement should be live immediately.
+    expect(screen.getByRole('alert')).toHaveTextContent('Immediate error');
   });
 });

--- a/src/components/__tests__/RiskExplainerOverlay.test.tsx
+++ b/src/components/__tests__/RiskExplainerOverlay.test.tsx
@@ -1,0 +1,207 @@
+import { useRef } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RiskExplainerOverlay } from "../RiskExplainerOverlay";
+
+// Focus-trap and scroll-lock hooks are mocked so the test doesn't depend on
+// DOM internals jsdom doesn't support (multiple focusable hosts, escape
+// propagation).  The component itself is the unit under test.
+vi.mock("@/hooks/useFocusTrap", () => ({
+  useFocusTrap: () => ({ current: null }),
+}));
+vi.mock("@/hooks/useBodyScrollLock", () => ({
+  useBodyScrollLock: vi.fn(),
+}));
+vi.mock("@/hooks/useInertBackdrop", () => ({
+  useInertBackdrop: vi.fn(),
+}));
+
+/**
+ * Tests for the centred risk-band explainer overlay (GitHub issue #426).
+ *
+ * Verifies:
+ *   - Modal only renders when `isOpen === true`.
+ *   - Renders all 4 risk bands with their canonical names.
+ *   - ARIA: dialog role, aria-modal, aria-labelledby, aria-label on the
+ *     close affordance.
+ *   - Close button + backdrop click both invoke `onClose`.
+ *   - The slide-out panel / inline-card patterns do not regress — this
+ *     component is the THIRD risk UI, not a replacement.
+ */
+
+const Trigger = ({
+  onOpen,
+}: {
+  onOpen: (open: boolean) => void;
+}) => {
+  const ref = useRef<HTMLButtonElement>(null);
+  return (
+    <>
+      <button
+        ref={ref}
+        type="button"
+        onClick={() => onOpen(true)}
+        data-testid="trigger"
+      >
+        Open overlay
+      </button>
+      <RiskExplainerOverlay
+        isOpen={true}
+        onClose={() => onOpen(false)}
+        triggerRef={ref}
+      />
+    </>
+  );
+};
+
+describe("RiskExplainerOverlay", () => {
+  it("renders nothing when closed", () => {
+    render(
+      <RiskExplainerOverlay
+        isOpen={false}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("risk-explainer-overlay"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the dialog with role + aria attributes when open", () => {
+    render(
+      <RiskExplainerOverlay
+        isOpen={true}
+        onClose={() => {}}
+      />,
+    );
+
+    const dialog = screen.getByTestId("risk-explainer-overlay");
+    expect(dialog).toHaveAttribute("role", "dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby");
+  });
+
+  it("renders all four canonical risk bands", () => {
+    render(
+      <RiskExplainerOverlay
+        isOpen={true}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /Excellent/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /Good/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /Caution/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /Recovery/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("exposes the score threshold and APR range for each band", () => {
+    render(
+      <RiskExplainerOverlay
+        isOpen={true}
+        onClose={() => {}}
+      />,
+    );
+
+    // Each band surfaces its `minScore+` pill and its `APR range` dd.
+    const scorePills = screen.getAllByTestId("risk-explainer-overlay-score");
+    expect(scorePills.map((el) => el.textContent)).toEqual([
+      "700+",
+      "600+",
+      "500+",
+      "0+",
+    ]);
+
+    const aprRanges = screen.getAllByTestId("risk-explainer-overlay-apr");
+    expect(aprRanges.map((el) => el.textContent)).toEqual([
+      "5% \u2013 10%",
+      "11% \u2013 20%",
+      "21% \u2013 30%",
+      "31%+",
+    ]);
+  });
+
+  it("close button invokes onClose", () => {
+    const handleClose = vi.fn();
+    render(
+      <RiskExplainerOverlay
+        isOpen={true}
+        onClose={handleClose}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /close risk band explainer/i }),
+    );
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("'Got it' footer button invokes onClose", () => {
+    const handleClose = vi.fn();
+    render(
+      <RiskExplainerOverlay
+        isOpen={true}
+        onClose={handleClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^got it$/i }));
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking the backdrop invokes onClose", () => {
+    const handleClose = vi.fn();
+    render(
+      <RiskExplainerOverlay
+        isOpen={true}
+        onClose={handleClose}
+      />,
+    );
+
+    // createPortal mounts the overlay to document.body, OUTSIDE the
+    // RTL test container, so query document directly.  RTL's
+    // automatic `cleanup()` (run in `afterEach`) handles portal
+    // teardown between tests, so we don't manually clear body.innerHTML
+    // here — that conflicts with React's own unmount walk.
+    const backdrop = document.querySelector(
+      ".risk-explainer-overlay__backdrop",
+    );
+    expect(backdrop).toBeTruthy();
+    fireEvent.click(backdrop as Element);
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a 'learn more' link to /docs/risk-pricing", () => {
+    render(
+      <RiskExplainerOverlay
+        isOpen={true}
+        onClose={() => {}}
+      />,
+    );
+
+    const docsLink = screen.getByRole("link", {
+      name: /risk pricing documentation/i,
+    });
+    expect(docsLink).toHaveAttribute("href", "/docs/risk-pricing");
+  });
+
+  it("is invocable from a trigger button (typical Dashboard wiring)", () => {
+    const noop = () => {};
+    render(<Trigger onOpen={noop} />);
+
+    // Trigger is in the DOM; overlay is opened immediately by the wrapper.
+    expect(screen.getByTestId("trigger")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("risk-explainer-overlay"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -7,6 +7,7 @@ import { useWallet } from "../context/WalletContext";
 import { Sparkline } from "../components/Sparkline";
 import { RiskBandsPanel } from "../components/RiskBandsPanel";
 import { WhatsChangedPanel } from "../components/WhatsChangedPanel";
+import { RiskExplainerOverlay } from "../components/RiskExplainerOverlay";
 import { MOCK_CREDIT_LINES } from "../data/mockData";
 import type { Transaction } from "../types/creditLine";
 import {
@@ -241,6 +242,9 @@ export function Dashboard() {
   const [repayCount, setRepayCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [isExplainOpen, setIsExplainOpen] = useState(false);
+  // `isExplainOpen` now drives the centred RiskExplainerOverlay (#426).
+  // The slide-out panel (`RiskBandsPanel`) keeps its own local state and
+  // is unaffected.
 
   // ─── Sync timestamps ─────────────────────────────────────────────────────
   const [riskSyncedAt, setRiskSyncedAt] = useState<Date>(() => new Date());
@@ -711,7 +715,35 @@ export function Dashboard() {
 
           {/* Risk Score */}
           <div className="card" data-tour-target="riskGauge" style={{ animationDelay: '0.15s' }} aria-busy={loading}>
-            <h2><span className="icon">🛡️</span> Risk Score</h2>
+            <h2>
+              <span className="icon">🛡️</span> Risk Score
+              {!loading && (
+                <button
+                  ref={explainTriggerRef}
+                  type="button"
+                  onClick={() => setIsExplainOpen(true)}
+                  aria-haspopup="dialog"
+                  aria-expanded={isExplainOpen}
+                  aria-label="Explain risk bands"
+                  className="risk-explainer-trigger"
+                  data-testid="risk-explainer-trigger"
+                  style={{
+                    marginLeft: "auto",
+                    fontSize: "0.75rem",
+                    fontWeight: 600,
+                    padding: "0.25rem 0.6rem",
+                    borderRadius: 6,
+                    background: "transparent",
+                    border: "1px solid var(--border, #30363d)",
+                    color: "var(--muted, #8b949e)",
+                    cursor: "pointer",
+                    minHeight: "32px",
+                  }}
+                >
+                  Explain
+                </button>
+              )}
+            </h2>
             {loading ? (
               <div className="risk-gauge-container">
                 <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100px', width: '160px', marginBottom: '0.75rem' }}>
@@ -1317,6 +1349,15 @@ export function Dashboard() {
         </div>
       </div>
       <DashboardTour />
+      {/* Centered risk-band explainer overlay (#426).  Triggered by the
+          "Explain risk bands" button rendered next to the risk gauge
+          header.  The component manages its own focus trap, body scroll
+          lock, and inert backdrop. */}
+      <RiskExplainerOverlay
+        isOpen={isExplainOpen}
+        onClose={() => setIsExplainOpen(false)}
+        triggerRef={explainTriggerRef}
+      />
     </div>
   );
 }

--- a/src/state/walletPrefs.test.tsx
+++ b/src/state/walletPrefs.test.tsx
@@ -1,0 +1,137 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useWalletPrefs } from "./walletPrefs";
+
+/**
+ * Tests for the React state layer over src/utils/wallet.ts.
+ *
+ * Verifies:
+ *   - Default state reads from storage.
+ *   - `recordUse` updates local state and storage.
+ *   - `setRemember` toggles the opt-in flag with correct storage
+ *     semantics (false removes the key).
+ *   - `clearAll` wipes both signals.
+ *   - Multiple subscribers each get their own subscription; a mutation
+ *     in one is reflected in storage so any subscriber re-rendering
+ *     observes the new value on its next read.
+ */
+
+const STORAGE_KEY_RECENT = "creditra-wallet-recent";
+const STORAGE_KEY_REMEMBER = "creditra-wallet-remember";
+
+describe("useWalletPrefs", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns empty MRU and remember=false when no storage exists", () => {
+    const { result } = renderHook(() => useWalletPrefs());
+    expect(result.current.recentWallets).toEqual([]);
+    expect(result.current.remember).toBe(false);
+  });
+
+  it("mirrors stored MRU (reversed so most-recent is first)", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY_RECENT,
+      JSON.stringify(["freighter", "albedo"]),
+    );
+    const { result } = renderHook(() => useWalletPrefs());
+    // Storage keeps most-recent at the END.  Hook reverses for
+    // left-to-right "first -> last used" consumption.
+    expect(result.current.recentWallets).toEqual(["albedo", "freighter"]);
+  });
+
+  it("mirrors stored remember flag", () => {
+    window.localStorage.setItem(STORAGE_KEY_REMEMBER, JSON.stringify(true));
+    const { result } = renderHook(() => useWalletPrefs());
+    expect(result.current.remember).toBe(true);
+  });
+
+  it("recordUse promotes the wallet to most-recent and updates state", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY_RECENT,
+      JSON.stringify(["freighter"]),
+    );
+    const { result } = renderHook(() => useWalletPrefs());
+
+    act(() => {
+      result.current.recordUse("albedo");
+    });
+
+    expect(result.current.recentWallets[0]).toBe("albedo");
+    // On-disk list keeps the most-recent at the END (matches recordRecentWallet).
+    const onDisk = JSON.parse(
+      window.localStorage.getItem(STORAGE_KEY_RECENT) ?? "[]",
+    );
+    expect(onDisk[onDisk.length - 1]).toBe("albedo");
+  });
+
+  it("recordUse is de-duplicating (calling twice does not duplicate)", () => {
+    const { result } = renderHook(() => useWalletPrefs());
+
+    act(() => {
+      result.current.recordUse("xbull");
+    });
+    act(() => {
+      result.current.recordUse("xbull");
+    });
+
+    expect(
+      result.current.recentWallets.filter((w) => w === "xbull"),
+    ).toHaveLength(1);
+  });
+
+  it("setRemember(true) writes the flag; setRemember(false) removes the key", () => {
+    const { result } = renderHook(() => useWalletPrefs());
+
+    act(() => {
+      result.current.setRemember(true);
+    });
+    expect(window.localStorage.getItem(STORAGE_KEY_REMEMBER)).toBe("true");
+    expect(result.current.remember).toBe(true);
+
+    act(() => {
+      result.current.setRemember(false);
+    });
+    expect(window.localStorage.getItem(STORAGE_KEY_REMEMBER)).toBeNull();
+    expect(result.current.remember).toBe(false);
+  });
+
+  it("clearAll wipes both signal sources atomically", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY_RECENT,
+      JSON.stringify(["rabet", "freighter"]),
+    );
+    window.localStorage.setItem(STORAGE_KEY_REMEMBER, JSON.stringify(true));
+    const { result } = renderHook(() => useWalletPrefs());
+
+    act(() => {
+      result.current.clearAll();
+    });
+
+    expect(result.current.recentWallets).toEqual([]);
+    expect(result.current.remember).toBe(false);
+    expect(window.localStorage.getItem(STORAGE_KEY_RECENT)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY_REMEMBER)).toBeNull();
+  });
+
+  it("storage event from another document triggers re-read", () => {
+    const { result } = renderHook(() => useWalletPrefs());
+
+    // Simulate a `storage` event fired by another tab/window.
+    act(() => {
+      window.localStorage.setItem(
+        STORAGE_KEY_RECENT,
+        JSON.stringify(["freighter", "albedo"]),
+      );
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: STORAGE_KEY_RECENT,
+          newValue: JSON.stringify(["freighter", "albedo"]),
+        }),
+      );
+    });
+
+    expect(result.current.recentWallets).toEqual(["albedo", "freighter"]);
+  });
+});

--- a/src/state/walletPrefs.tsx
+++ b/src/state/walletPrefs.tsx
@@ -1,0 +1,124 @@
+/**
+ * walletPrefs - React state layer over `src/utils/wallet.ts`.
+ *
+ * The storage layer in `src/utils/wallet.ts` exposes plain helpers
+ * that any consumer can call.  This module re-renders React consumers
+ * when the underlying storage changes.
+ *
+ * Public API (returned by `useWalletPrefs()`):
+ *
+ *   - `recentWallets`   - most-recent-first list.  Storage keeps the
+ *     list newest-at-end for O(1) appends; we reverse on read.
+ *   - `remember`        - opt-in flag for next-visit auto-reconnect.
+ *   - `recordUse(type)` - promote `type` to the front of MRU.
+ *   - `setRemember(v)`  - set or clear the opt-in flag.
+ *   - `clearAll()`      - wipe both signals.
+ *
+ * Note on Provider
+ * ────────────────
+ * Earlier iterations exposed an optional `WalletPrefsProvider` +
+ * `useWalletPrefs()` that fell back to a standalone hook outside the
+ * tree.  That pairing could not actually share state across two
+ * separate React roots (e.g. two `renderHook` calls): each Provider
+ * instance runs its own `useState`, so consumers in two Provider
+ * trees never see each other's updates.  The Provider boundary was
+ * therefore removed; consumers use `useWalletPrefs()` directly and
+ * each gets its own subscription from the storage layer.
+ *
+ * Cross-tree synchronisation is provided by the `storage` event
+ * listener in `useWalletPrefsStandalone`, which re-reads the storage
+ * layer when *another* document mutates the keys.  Trees sharing the
+ * same DOM (i.e. one app) don't rely on `storage` events - the writer
+ * updates its own state via the action callbacks before the next
+ * subscriber re-renders.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  clearMRU,
+  getRecentWalletOrder,
+  isWalletRemembered,
+  recordRecentWallet as recordRecentWalletStorage,
+  setWalletRemembered as setWalletRememberedStorage,
+} from "../utils/wallet";
+import type { WalletType } from "../types/wallet";
+
+// ─── Public surface ───────────────────────────────────────────────────────────
+
+export interface WalletPrefsShape {
+  /** Wallets in most-recent-first order (storage is newest-at-end). */
+  recentWallets: WalletType[];
+  /** Opt-in flag for next-visit auto-reconnect. */
+  remember: boolean;
+  /** Promote `type` to the front of MRU. */
+  recordUse: (type: WalletType) => void;
+  /** Set or clear the opt-in flag. */
+  setRemember: (value: boolean) => void;
+  /** Wipe both signals. */
+  clearAll: () => void;
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Hook returning the user's wallet preferences.
+ *
+ * Direct usage:
+ *
+ *   const { recentWallets, remember } = useWalletPrefs();
+ *
+ * Per the rules of hooks, callers must invoke this hook
+ * unconditionally on every render.  Wrapping in `useMemo`/`useEffect`
+ * with conditional branches is fine as long as the call site is
+ * unconditional.
+ */
+export function useWalletPrefs(): WalletPrefsShape {
+  const [recentWallets, setRecentWallets] = useState<WalletType[]>(() =>
+    getRecentWalletOrder().slice().reverse(),
+  );
+  const [remember, setRememberState] = useState<boolean>(() =>
+    isWalletRemembered(),
+  );
+
+  // Cross-tab consistency: re-read when another document mutates storage.
+  // Within the same document the writing tab updates its own state via
+  // the action callbacks below, so we don't need a `storage` listener
+  // for local sync.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handler = (event: StorageEvent) => {
+      if (!event.key) {
+        setRecentWallets(getRecentWalletOrder().slice().reverse());
+        setRememberState(isWalletRemembered());
+        return;
+      }
+      if (event.key === "creditra-wallet-recent") {
+        setRecentWallets(getRecentWalletOrder().slice().reverse());
+      } else if (event.key === "creditra-wallet-remember") {
+        setRememberState(isWalletRemembered());
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, []);
+
+  const recordUse = useCallback((type: WalletType) => {
+    recordRecentWalletStorage(type);
+    setRecentWallets(getRecentWalletOrder().slice().reverse());
+  }, []);
+
+  const setRemember = useCallback((value: boolean) => {
+    setWalletRememberedStorage(value);
+    setRememberState(value);
+  }, []);
+
+  const clearAll = useCallback(() => {
+    clearMRU();
+    setWalletRememberedStorage(false);
+    setRecentWallets([]);
+    setRememberState(false);
+  }, []);
+
+  return { recentWallets, remember, recordUse, setRemember, clearAll };
+}


### PR DESCRIPTION
# Resolve 4 issues assigned to NickiM84

Closes #452 
Closes #451 
Closes #447 
Closes #426

All work on a single feature branch `feat/resolve-nickim84-issues`. Each issue
is implemented, unit-tested, and follows existing repo conventions
(WCAG 2.1 AA focus trap + body scroll lock + inert backdrop, design tokens,
`useDebounceValue` hook, parity with `WhyApr` / `InlineHelpOverlay`).

## #452 — Add debounce-announce on FormField errors

**Where:** `src/components/FormField.tsx`, `src/components/FormMessage.tsx`,
`src/components/__tests__/FormField.test.tsx`.

Added a configurable `announceDelayMs` prop (default `300` ms) that
FormField owns and forwards to its inner FormMessage. The visual error
remains immediate; only the `aria-live` readback is debounced so rapid
edits ("1" → "10" → "100") produce a single readback instead of three.
Setting `announceDelayMs={0}` disables the debounce for critical forms /
tests.

Tests added: short custom delay, `0` delay (immediate), and the existing
300 ms default path.

## #451 — Add per-route RouteAnnouncer

**Where:** `src/components/RouteAnnouncer.tsx`, `src/App.tsx`.

The `RouteAnnouncer` component was defined but never rendered. This PR:

1. Actually mounts `<RouteAnnouncer />` inside `BrowserRouter` in `App.tsx`
   so every navigation fires a screen-reader announcement and updates
   `document.title` + `<meta name="description">`.

2. Adds `useRouteHead({ title?, description?, announcement? })` so any
   page can publish a richer announcement than the URL-table default
   (e.g., OnboardingFlow mid-step, transactions filtered to N rows,
   auctions filtered by status). Wrapped in `<RouteHeadProvider>` at
   the App boundary.

Default behaviour preserved: existing `RouteAnnouncer.test.tsx` tests
(`${pageName} page loaded`, `Creditra · ${pageName}`) still pass.

## #447 — Add MRU wallet provider ordering

**Where:** NEW `src/state/walletPrefs.tsx`,
`src/state/walletPrefs.test.tsx`.

Created the React state layer the issue specified was missing. The MRU
storage helpers already exist in `src/utils/wallet.ts`
(`getRecentWalletOrder` / `recordRecentWallet`) and are already wired
through `WalletContext.connect()` and `WalletContext.runReconnect()`,
consumed by `WalletConnectionModal` for the "Continue with …" affordance
(continue-with primary wallet, switch-wallet expansion, opt-in remember).

The new `useWalletPrefs()` hook is the typed React API over the
storage helpers, with a cross-document `storage` event listener for
cross-tab consistency. Forward-looking: future modal/dropdown
components can subscribe instead of touching `localStorage` directly.

Hook tests cover: initial read, mutation + state propagation, dedup,
remember-flag WIPE semantics (`false` removes the key), atomic
`clearAll`, and the `storage` event re-read path.

## #426 — Add risk-band explainer overlay

**Where:** NEW `src/components/RiskExplainerOverlay.tsx`,
`NEW src/components/RiskExplainerOverlay.css`,
`NEW src/components/__tests__/RiskExplainerOverlay.test.tsx`,
modified `src/pages/Dashboard.tsx`.

This is the third of the three risk-explainer surfaces
(the existing ones are `RiskExplainerCard` — inline dismissable banner,
`RiskBandsPanel` — right-side slide-out panel). The new
`RiskExplainerOverlay` is a centered modal that lists all four bands
(Excellent 700+ / Good 600+ / Caution 500+ / Recovery <500) with
description, APR range, and limit guidance per band. Accessibility
follows the existing modal pattern in `WhyApr.tsx` /
`InlineHelpOverlay.tsx`:

- `role="dialog"` + `aria-modal` + `aria-labelledby`
- `useFocusTrap` (Tab/Shift+Tab cycling + Escape-to-close + return focus)
- `useBodyScrollLock` to lock background scroll
- `useInertBackdrop` so SR rotors don't reach page chrome

Wired into the Dashboard's Risk Score card via a new "Explain" button.
The previously unused `isExplainOpen` state and `explainTriggerRef`
are now the modal's open state and trigger ref.

CSS uses the existing token defaults (`var(--surface)`, `var(--border)`,
`var(--accent)`) with hex fallbacks where tokens aren't yet defined;
follows existing modal CSS files in style.

## Tests

- `npx vitest run src/components/__tests__/FormField.test.tsx` — 7 pass
- `npx vitest run src/components/__tests__/RiskExplainerOverlay.test.tsx` — 9 pass
- `npx vitest run src/state/walletPrefs.test.tsx` — 8 pass
- `npx vitest run src/components/RouteAnnouncer.test.tsx` — 12 pass (existing tests preserved)

Total: 36 tests, all passing in the new feature branch's working tree.

## Scope creep — explicit

This PR also adds the two missing imports that the **original**
`src/App.tsx` already referenced without importing:

- `<SessionTimeoutBanner />` → imports `SessionTimeoutBanner` from `./components/SessionTimeoutBanner`
- `<NotificationPreferences />` → imports `NotificationPreferences` from `./pages/NotificationPreferences`

Without these the file would not typecheck even on `main`. They are
**not** part of any of the four issues and are flagged here so reviewers
do not conflate them with the feature work.

## Out of scope — pre-existing Dashboard.tsx errors

`tsc -b` reports a `TS2657` ("JSX expressions must have one parent
element") at `src/pages/Dashboard.tsx(496,5)`, with downstream
cascades at lines 1352 / 1361 / 1362. **Confirmed pre-existing** via
`git stash`: the same errors exist on `main` at
`src/pages/Dashboard.tsx(492,5)` etc., before this PR's changes.

These errors are NOT introduced by this PR. They block `tsc -b` in
CI but were left alone to keep the diff focused on the four assigned
issues. Recommend a follow-up PR that wraps the early-return
conditional in a single `<>...</>` fragment (or restructures the
left/middle/right grid) to clear the cascade.

## Branch / commit

- Branch: `feat/resolve-nickim84-issues`
- Total changes: 11 files, +1410 / -74

Reviewer note: the feature branch was created with
`git reset --soft HEAD~1 && git checkout -b feat/resolve-nickim84-issues`,
so `main` was preserved and a single fresh commit contains all the
work. Push with `git push -u origin feat/resolve-nickim84-issues` and
open the PR against `main`.
