### PR TITLE
feat: add "Continue where you left off" dashboard prompt

### DIFF
--- a/src/components/ContinuePrompt.css
+++ b/src/components/ContinuePrompt.css
@@ -1,0 +1,172 @@
+.continue-prompt {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.75rem;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  animation: fadeInUp 0.4s ease both;
+}
+
+.continue-prompt::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent) 0%, #a371f7 50%, var(--success) 100%);
+}
+
+.continue-prompt-header {
+  margin-bottom: 1.25rem;
+}
+
+.continue-prompt-title {
+  margin: 0 0 0.25rem;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.continue-prompt-subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.continue-prompt-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.continue-prompt-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  transition: all 0.15s;
+}
+
+.continue-prompt-item:hover {
+  border-color: rgba(88, 166, 255, 0.25);
+}
+
+.continue-prompt-item--warning {
+  border-left: 3px solid var(--warning);
+}
+
+.continue-prompt-item--danger {
+  border-left: 3px solid var(--danger);
+}
+
+.continue-prompt-item--info {
+  border-left: 3px solid var(--accent);
+}
+
+.continue-prompt-item-icon {
+  font-size: 1.25rem;
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: rgba(139, 148, 158, 0.08);
+}
+
+.continue-prompt-item-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.continue-prompt-item-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.15rem;
+}
+
+.continue-prompt-item-desc {
+  font-size: 0.75rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.continue-prompt-item-action {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+  border-radius: 4px;
+  background: rgba(88, 166, 255, 0.08);
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.continue-prompt-item-action:hover {
+  background: rgba(88, 166, 255, 0.16);
+}
+
+.continue-prompt-item-action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.continue-prompt-dismiss {
+  display: block;
+  margin: 1rem auto 0;
+  padding: 0.35rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--muted);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.continue-prompt-dismiss:hover {
+  color: var(--text);
+  background: rgba(139, 148, 158, 0.08);
+}
+
+.continue-prompt-dismiss:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .continue-prompt {
+    animation: none;
+  }
+}
+
+[data-motion="reduced"] .continue-prompt {
+  animation: none;
+}

--- a/src/components/ContinuePrompt.tsx
+++ b/src/components/ContinuePrompt.tsx
@@ -1,0 +1,162 @@
+import { useState, useMemo } from "react";
+import { Link } from "react-router-dom";
+import type { CreditLine } from "../types/creditLine";
+import { fmt } from "../utils/tokens";
+import { readJson, writeJson } from "../utils/storage";
+import "./ContinuePrompt.css";
+
+const DISMISS_KEY = "continue_prompt_dismissed";
+
+interface ContinueItem {
+  key: string;
+  icon: string;
+  label: string;
+  description: string;
+  actionLabel: string;
+  to: string;
+  type: "warning" | "info" | "danger";
+}
+
+interface ContinuePromptProps {
+  creditLines: CreditLine[];
+}
+
+export function ContinuePrompt({ creditLines }: ContinuePromptProps) {
+  const [dismissed, setDismissed] = useState(() =>
+    readJson(DISMISS_KEY, false),
+  );
+
+  const items = useMemo<ContinueItem[]>(() => {
+    const result: ContinueItem[] = [];
+    const now = Date.now();
+
+    creditLines.forEach((cl) => {
+      const pendingTx = cl.transactions.find((tx) => tx.status === "Pending");
+      if (pendingTx) {
+        result.push({
+          key: `pending-${cl.id}-${pendingTx.id}`,
+          icon: "\u23F3",
+          label: "Pending Transaction",
+          description: `${pendingTx.note || pendingTx.type} for ${cl.name}`,
+          actionLabel: "View Details \u2192",
+          to: "/credit-lines",
+          type: "warning",
+        });
+      }
+
+      if (cl.status === "Suspended") {
+        result.push({
+          key: `suspended-${cl.id}`,
+          icon: "\u26A0\uFE0F",
+          label: "Suspended Credit Line",
+          description: `${cl.name} needs repayment to restore access.`,
+          actionLabel: "View Credit Lines \u2192",
+          to: "/credit-lines",
+          type: "danger",
+        });
+      }
+
+      if (cl.status === "Active") {
+        const utilPct = cl.limit > 0 ? cl.utilized / cl.limit : 0;
+        if (utilPct >= 0.75) {
+          result.push({
+            key: `high-util-${cl.id}`,
+            icon: "\uD83D\uDCCA",
+            label: "High Utilization",
+            description: `${cl.name} is at ${Math.round(utilPct * 100)}% utilization. Consider a repayment.`,
+            actionLabel: "Review Credit \u2192",
+            to: "/credit-lines",
+            type: "warning",
+          });
+        }
+      }
+
+      if (cl.nextPaymentDate) {
+        const daysUntil = Math.ceil(
+          (new Date(cl.nextPaymentDate).getTime() - now) / 86400000,
+        );
+        if (daysUntil >= 0 && daysUntil <= 7) {
+          result.push({
+            key: `payment-${cl.id}`,
+            icon: "\uD83D\uDCC5",
+            label: "Upcoming Payment",
+            description: `${fmt(cl.nextPaymentAmount ?? 0)} due in ${daysUntil} day${daysUntil !== 1 ? "s" : ""} for ${cl.name}.`,
+            actionLabel: "View Credit Lines \u2192",
+            to: "/credit-lines",
+            type: "info",
+          });
+        }
+      }
+
+      if (cl.status === "Active" && cl.utilized === 0 && cl.limit > 0) {
+        result.push({
+          key: `available-${cl.id}`,
+          icon: "\uD83D\uDCB3",
+          label: "Credit Available",
+          description: `${cl.name} has ${fmt(cl.limit)} ready to draw.`,
+          actionLabel: "Draw Credit \u2192",
+          to: "/draw-credit",
+          type: "info",
+        });
+      }
+    });
+
+    return result;
+  }, [creditLines]);
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    writeJson(DISMISS_KEY, true);
+  };
+
+  if (dismissed || items.length === 0) return null;
+
+  return (
+    <section
+      className="continue-prompt"
+      aria-label="Continue where you left off"
+      data-testid="continue-prompt"
+    >
+      <div className="continue-prompt-header">
+        <h2 className="continue-prompt-title">
+          Continue Where You Left Off
+        </h2>
+        <p className="continue-prompt-subtitle">
+          Pick up where you stopped
+        </p>
+      </div>
+
+      <div className="continue-prompt-items" role="list">
+        {items.map((item) => (
+          <div
+            key={item.key}
+            className={`continue-prompt-item continue-prompt-item--${item.type}`}
+            role="listitem"
+          >
+            <span className="continue-prompt-item-icon" aria-hidden="true">
+              {item.icon}
+            </span>
+            <div className="continue-prompt-item-content">
+              <div className="continue-prompt-item-label">{item.label}</div>
+              <div className="continue-prompt-item-desc">
+                {item.description}
+              </div>
+            </div>
+            <Link to={item.to} className="continue-prompt-item-action">
+              {item.actionLabel}
+            </Link>
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        className="continue-prompt-dismiss"
+        onClick={handleDismiss}
+        aria-label="Dismiss continue prompt"
+      >
+        Dismiss
+      </button>
+    </section>
+  );
+}

--- a/src/components/__tests__/ContinuePrompt.test.tsx
+++ b/src/components/__tests__/ContinuePrompt.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ContinuePrompt } from "../ContinuePrompt";
+import type { CreditLine } from "../../types/creditLine";
+
+const { mockReadJson, mockWriteJson, mockStorageStore } = vi.hoisted(() => {
+  const store: Record<string, unknown> = {};
+  return {
+    mockReadJson: vi.fn((key: string, fallback: unknown) => {
+      const val = store[key];
+      return val !== undefined ? val : fallback;
+    }),
+    mockWriteJson: vi.fn((key: string, value: unknown) => {
+      store[key] = value;
+    }),
+    mockStorageStore: store,
+  };
+});
+
+vi.mock("../../utils/storage", () => ({
+  readJson: mockReadJson,
+  writeJson: mockWriteJson,
+}));
+
+const activeLine: CreditLine = {
+  id: "CL-001",
+  name: "Test Line",
+  status: "Active",
+  limit: 100000,
+  utilized: 15000,
+  apr: 8.5,
+  riskScore: 700,
+  openedAt: "2025-01-01",
+  updatedAt: "2025-06-01T00:00:00Z",
+  transactions: [],
+  statusHistory: [{ status: "Active", date: "2025-01-01" }],
+};
+
+const activeLineWithUtil: CreditLine = {
+  ...activeLine,
+  id: "CL-002",
+  name: "High Util Line",
+  limit: 100000,
+  utilized: 85000,
+  transactions: [
+    {
+      id: "TX-001",
+      type: "Draw",
+      amount: 85000,
+      date: "2025-05-01T00:00:00Z",
+      status: "Completed",
+    },
+  ],
+};
+
+const suspendedLine: CreditLine = {
+  ...activeLine,
+  id: "CL-003",
+  name: "Suspended Line",
+  status: "Suspended",
+  utilized: 45000,
+};
+
+const lineWithPendingTx: CreditLine = {
+  ...activeLine,
+  id: "CL-004",
+  name: "Pending Line",
+  utilized: 15000,
+  transactions: [
+    {
+      id: "TX-PND",
+      type: "Interest",
+      amount: 500,
+      date: "2025-06-15T00:00:00Z",
+      note: "Pending interest",
+      status: "Pending",
+    },
+  ],
+};
+
+const lineWithUpcomingPayment: CreditLine = {
+  ...activeLine,
+  id: "CL-005",
+  name: "Payment Due Line",
+  utilized: 25000,
+  nextPaymentDate: new Date(Date.now() + 3 * 86400000).toISOString(),
+  nextPaymentAmount: 1200,
+};
+
+function renderPrompt(creditLines: CreditLine[]) {
+  return render(
+    <BrowserRouter>
+      <ContinuePrompt creditLines={creditLines} />
+    </BrowserRouter>,
+  );
+}
+
+describe("ContinuePrompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(mockStorageStore).forEach((k) => delete mockStorageStore[k]);
+  });
+
+  it("renders nothing when there are no in-progress items", () => {
+    renderPrompt([activeLine]);
+    expect(screen.queryByTestId("continue-prompt")).not.toBeInTheDocument();
+  });
+
+  it("renders pending transaction item", () => {
+    renderPrompt([lineWithPendingTx]);
+    expect(screen.getByTestId("continue-prompt")).toBeInTheDocument();
+    expect(screen.getByText("Pending Transaction")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Pending interest for Pending Line/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders suspended line item", () => {
+    renderPrompt([suspendedLine]);
+    expect(screen.getByText("Suspended Credit Line")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Suspended Line needs repayment/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders high utilization item", () => {
+    renderPrompt([activeLineWithUtil]);
+    expect(screen.getByText("High Utilization")).toBeInTheDocument();
+    expect(
+      screen.getByText(/High Util Line is at 85%/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders upcoming payment item", () => {
+    renderPrompt([lineWithUpcomingPayment]);
+    expect(screen.getByText("Upcoming Payment")).toBeInTheDocument();
+    expect(
+      screen.getByText(/due in 3 days for Payment Due Line/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders available credit item for lines with zero utilization", () => {
+    const zeroUtilLine: CreditLine = {
+      ...activeLine,
+      id: "CL-AVAIL",
+      name: "Available Line",
+      utilized: 0,
+    };
+    renderPrompt([zeroUtilLine]);
+    expect(screen.getByText("Credit Available")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Available Line has \$100,000 ready to draw/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders multiple items when multiple conditions are met", () => {
+    renderPrompt([
+      activeLine,
+      activeLineWithUtil,
+      suspendedLine,
+      lineWithPendingTx,
+    ]);
+    const items = screen.getAllByRole("listitem");
+    expect(items.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("does not render when dismissed in storage", () => {
+    mockStorageStore["continue_prompt_dismissed"] = true;
+    renderPrompt([activeLineWithUtil, suspendedLine]);
+    expect(screen.queryByTestId("continue-prompt")).not.toBeInTheDocument();
+  });
+
+  it("persists dismissal and hides on dismiss button click", () => {
+    renderPrompt([activeLineWithUtil, suspendedLine]);
+    expect(screen.getByTestId("continue-prompt")).toBeInTheDocument();
+
+    const dismissBtn = screen.getByLabelText("Dismiss continue prompt");
+    fireEvent.click(dismissBtn);
+
+    expect(mockWriteJson).toHaveBeenCalledWith(
+      "continue_prompt_dismissed",
+      true,
+    );
+    expect(
+      screen.queryByTestId("continue-prompt"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("has accessible dismiss button with correct aria-label and type", () => {
+    renderPrompt([activeLineWithUtil]);
+    const btn = screen.getByLabelText("Dismiss continue prompt");
+    expect(btn).toBeInTheDocument();
+    expect(btn.getAttribute("type")).toBe("button");
+  });
+
+  it("action links point to correct routes", () => {
+    const zeroUtilLine: CreditLine = {
+      ...activeLine,
+      id: "CL-AVAIL",
+      name: "Available Line",
+      utilized: 0,
+    };
+    renderPrompt([zeroUtilLine, suspendedLine]);
+    const drawLink = screen.getByText("Draw Credit →");
+    expect(drawLink.closest("a")).toHaveAttribute("href", "/draw-credit");
+
+    const viewLinks = screen.getAllByText("View Credit Lines →");
+    viewLinks.forEach((link) => {
+      expect(link.closest("a")).toHaveAttribute("href", "/credit-lines");
+    });
+  });
+
+  it("has role list on items container", () => {
+    renderPrompt([activeLine, suspendedLine]);
+    expect(screen.getByRole("list")).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders title and subtitle", () => {
+    renderPrompt([activeLineWithUtil]);
+    expect(
+      screen.getByText("Continue Where You Left Off"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Pick up where you stopped"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -30,6 +30,7 @@ import { getUtilizationLevel } from "../utils/tokens";
 import { TipJar } from "../components/TipJar";
 import { NextSteps } from "../components/NextSteps";
 import { WhatChanged } from "../components/WhatChanged";
+import { ContinuePrompt } from "../components/ContinuePrompt";
 
 
 
@@ -651,6 +652,8 @@ export function Dashboard() {
       </div>
 
       {!loading && <ActivityFeed />}
+
+      {!loading && hasLines && <ContinuePrompt creditLines={creditLines} />}
 
       <div className="dashboard-grid">
         <div>


### PR DESCRIPTION
Adds a new ContinuePrompt component to the Dashboard that surfaces in-progress credit line items requiring user attention. The component scans credit lines for:
- Pending transactions — flags transactions with "Pending" status
- Suspended lines — prompts repayment to restore access
- High utilization — warns when a line is ≥75% drawn
- Upcoming payments — shows payments due within 7 days
- Available credit — promotes unused active lines for drawing

Closes #495