### PR TITLE
fix: skeleton shape parity

### DIFF
--- a/src/components/Skeleton.css
+++ b/src/components/Skeleton.css
@@ -31,3 +31,10 @@
     animation: none;
   }
 
+.skeleton--circular {
+  border-radius: 50%;
+}
+
+.skeleton--rounded {
+  border-radius: var(--radius-md, 8px);
+}

--- a/src/components/Skeleton.test.tsx
+++ b/src/components/Skeleton.test.tsx
@@ -21,4 +21,15 @@ describe('Skeleton', () => {
     expect(element).toBeInTheDocument();
     expect(element.getAttribute('aria-hidden')).toBe('true');
   });
+
+  it('applies shape classes correctly', () => {
+    const { container: containerRect } = render(<Skeleton shape="rectangular" />);
+    expect((containerRect.firstChild as HTMLElement).className).toContain('skeleton--rectangular');
+
+    const { container: containerCirc } = render(<Skeleton shape="circular" />);
+    expect((containerCirc.firstChild as HTMLElement).className).toContain('skeleton--circular');
+
+    const { container: containerRound } = render(<Skeleton shape="rounded" />);
+    expect((containerRound.firstChild as HTMLElement).className).toContain('skeleton--rounded');
+  });
 });

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -6,6 +6,8 @@ type SkeletonProps = React.HTMLAttributes<HTMLDivElement> & {
   width?: string | number;
   /** Height passed through as a CSS dimension (string or px number). */
   height?: string | number;
+  /** Shape of the skeleton. Defaults to 'rectangular'. */
+  shape?: 'rectangular' | 'circular' | 'rounded';
 };
 
 /**
@@ -22,9 +24,9 @@ type SkeletonProps = React.HTMLAttributes<HTMLDivElement> & {
  * @example
  *   <Skeleton width="100%" height={48} aria-label="Loading credit lines" />
  */
-export const Skeleton: React.FC<SkeletonProps> = ({ width, height, style, className, ...rest }) => (
+export const Skeleton: React.FC<SkeletonProps> = ({ width, height, shape = 'rectangular', style, className, ...rest }) => (
   <div
-    className={`skeleton ${className ?? ''}`.trim()}
+    className={`skeleton skeleton--${shape} ${className ?? ''}`.trim()}
     style={{ width, height, ...style }}
     {...rest}
   />


### PR DESCRIPTION
Closes #467 


This PR resolves the UI/UX issue for the GrantFox FWC26 campaign by standardizing shape parity across Skeleton components. 

Changes Made:
- src/components/Skeleton.tsx: Added a 'shape' property that accepts 'rectangular', 'circular', or 'rounded', with 'rectangular' as the default value to preserve existing component behavior.
- src/components/Skeleton.css: Added '.skeleton--circular' (border-radius: 50%) and '.skeleton--rounded' (border-radius: 8px) modifier classes to support the new shapes.
- src/components/Skeleton.test.tsx: Added unit tests to ensure the correct CSS classes are applied for each shape variation.

Acceptance Criteria Met:
- Implementation matches the issue description for shape parity
- Tests added and passing
- Isolated scope (no unrelated codebase changes)