### PR TITLE
feat: ? shortcut help overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,8 @@ import { LinkedAccounts } from "./pages/LinkedAccounts";
 import { WalletReconnectBanner } from "./components/WalletReconnectBanner";
 import { NetworkMismatchBanner } from "./components/notifications/NetworkMismatchBanner";
 import { Header } from "./layouts/Header";
+import { SessionTimeoutBanner } from "./components/SessionTimeoutBanner";
+import { NotificationPreferences } from "./pages/NotificationPreferences";
 
 const isEditableTarget = (target: EventTarget | null) => {
   if (!(target instanceof HTMLElement)) return false;


### PR DESCRIPTION
Closes #457

---

Here's the PR description you can paste in:

feat: ? keyboard shortcuts help overlay

Summary
Implements the ? keyboard shortcut help overlay as specified in the GitHub issue. Pressing ? anywhere in the app (when focus is not in an input/textarea/select/contenteditable) opens a modal listing all available keyboard shortcuts. The overlay closes on Escape, backdrop click, or the close button.

The component and its global key listener were already fully implemented on this branch. This PR fixes the final blocker: App.tsx was referencing <SessionTimeoutBanner /> and <NotificationPreferences /> without importing them, which would cause a build failure.

Changes
App.tsx
 — added two missing imports (SessionTimeoutBanner, NotificationPreferences)
ShortcutHelpOverlay.tsx
 — new component (already on branch)
ShortcutHelpOverlay.css
 — styles using design tokens only (already on branch)
ShortcutHelpOverlay.test.tsx
 — full test suite (already on branch)
Shortcuts shown
Keys	Description
?	Open this keyboard shortcut guide
Esc	Close the current dialog or overlay
Tab	Move focus to next interactive element
Shift + Tab	Move focus to previous interactive element
Enter / Space	Activate focused button or link
← / →	Previous / next onboarding wizard step
Accessibility
role="dialog" with aria-modal, aria-labelledby, aria-describedby
Focus trapped inside while open (Tab/Shift+Tab cycle); returns to trigger on close
Backdrop and background content marked inert / aria-hidden
Escape closes the overlay
Minimum 44×44px touch target on close button
focus-visible ring on all interactive elements
Entry animation suppressed under prefers-reduced-motion
All colors reference CSS custom properties — correct in both default and high-contrast themes
Tests
All tests in ShortcutHelpOverlay.test.tsx pass:

Hidden from accessibility tree when isOpen=false
Renders all shortcut groups
role="dialog" with correct aria attributes
Focus moves to close button on open
Closes on Escape, backdrop click, close button click
Settings link points to /help#shortcuts
Manual QA
Open the app, click outside any input and press ? — overlay should appear
Press Escape — overlay closes
Click the backdrop — overlay closes
Click inside a search/text input, press ? — overlay should NOT open
Press Cmd+K — command palette opens independently, no conflict