### PR TITLE
feat: AmountInput stepper

### DIFF
--- a/docs/UX_RATIONALE.md
+++ b/docs/UX_RATIONALE.md
@@ -206,6 +206,11 @@ recommended reserve is `warning`; a healthy draw is `success`. The message tone 
 the input's border, the helper text, and the icon all at once — no separate "error
 state" UI.
 
+For the GrantFox draw flow, the amount input also exposes explicit `+` and `-` stepper
+buttons alongside the numeric field. The intent is to make the step-by-step edit pattern
+unambiguous for both touch and keyboard users while preserving the same clamped bounds
+of `0` through `available credit`.
+
 **Trade-off.** More validation states to maintain. We accept this because the input is
 the highest-stakes interaction on the screen.
 

--- a/src/components/AmountInput.test.tsx
+++ b/src/components/AmountInput.test.tsx
@@ -44,12 +44,9 @@ describe("AmountInput", () => {
       target: { value: "36000" },
     });
 
-    // Should have both helper and error in aria-describedby
     const describedBy = input.getAttribute("aria-describedby");
     expect(describedBy).toContain("draw-amount-helper");
     expect(describedBy).toContain("draw-amount-error");
-
-    // aria-invalid should be true when there's an error
     expect(input).toHaveAttribute("aria-invalid", "true");
   });
 
@@ -99,27 +96,24 @@ describe("AmountInput", () => {
       />,
     );
 
-    const maxButton = screen.getByRole("button", {
-      name: /set amount to maximum/i,
-    });
-    expect(maxButton).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /set amount to maximum/i }),
+    ).toBeInTheDocument();
   });
 
   it("sets amount to maximum available when Max button is clicked", () => {
-    const onAmountChange = vi.fn();
     render(
       <AmountInput
         creditLine={creditLine}
-        onAmountChange={onAmountChange}
+        onAmountChange={vi.fn()}
         onNext={vi.fn()}
         onBack={vi.fn()}
       />,
     );
 
-    const maxButton = screen.getByRole("button", {
-      name: /set amount to maximum/i,
-    });
-    fireEvent.click(maxButton);
+    fireEvent.click(
+      screen.getByRole("button", { name: /set amount to maximum/i }),
+    );
 
     const input = screen.getByLabelText(/draw amount/i) as HTMLInputElement;
     expect(input.value).toBe(creditLine.available.toString());
@@ -140,9 +134,7 @@ describe("AmountInput", () => {
     });
 
     expect(screen.getByText("Draw amount looks good")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /continue/i }),
-    ).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled();
   });
 
   it("enables continue button only when amount is valid", () => {
@@ -165,7 +157,7 @@ describe("AmountInput", () => {
     expect(continueButton).not.toBeDisabled();
   });
 
-  it("sanitizes pasted currency strings (strips $, commas, whitespace)", async () => {
+  it("sanitizes pasted currency strings (strips $, commas, whitespace)", () => {
     render(
       <AmountInput
         creditLine={creditLine}
@@ -176,9 +168,8 @@ describe("AmountInput", () => {
     );
 
     const input = screen.getByLabelText(/draw amount/i) as HTMLInputElement;
-    
-    // Mock clipboard event
-    const pasteEvent = new ClipboardEvent("paste", {
+
+    fireEvent.paste(input, {
       clipboardData: {
         getData: (type: string) => {
           if (type === "text") return "$1,500.00";
@@ -186,14 +177,12 @@ describe("AmountInput", () => {
         },
       },
     });
-    
-    fireEvent.paste(input, pasteEvent);
-    
+
     expect(input.value).toBe("1500.00");
     expect(screen.getByText("Pasted value sanitized to $1,500.00")).toBeInTheDocument();
   });
 
-  it("rejects non-numeric pasted text and announces the error", async () => {
+  it("rejects non-numeric pasted text and announces the error", () => {
     render(
       <AmountInput
         creditLine={creditLine}
@@ -204,8 +193,8 @@ describe("AmountInput", () => {
     );
 
     const input = screen.getByLabelText(/draw amount/i) as HTMLInputElement;
-    
-    const pasteEvent = new ClipboardEvent("paste", {
+
+    fireEvent.paste(input, {
       clipboardData: {
         getData: (type: string) => {
           if (type === "text") return "invalid-amount";
@@ -213,15 +202,14 @@ describe("AmountInput", () => {
         },
       },
     });
-    
-    fireEvent.paste(input, pasteEvent);
-    
-    expect(input.value).not.toBe("invalid-amount");
-    expect(screen.getByText("Invalid amount pasted. Please enter a numeric value.")).toBeInTheDocument();
-  });
-});
 
-  it("renders decrease stepper button with accessible label", () => {
+    expect(input.value).not.toBe("invalid-amount");
+    expect(
+      screen.getByText("Invalid amount pasted. Please enter a numeric value."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders explicit +/- stepper buttons with accessible labels", () => {
     render(
       <AmountInput
         creditLine={creditLine}
@@ -231,14 +219,20 @@ describe("AmountInput", () => {
       />,
     );
 
-    const decButton = screen.getByRole("button", {
+    const decreaseButton = screen.getByRole("button", {
       name: /decrease amount/i,
     });
-    expect(decButton).toBeInTheDocument();
-    expect(decButton).toBeDisabled(); // initially 0, can't go below 0
+    const increaseButton = screen.getByRole("button", {
+      name: /increase amount/i,
+    });
+
+    expect(decreaseButton).toBeInTheDocument();
+    expect(decreaseButton).toBeDisabled();
+    expect(increaseButton).toBeInTheDocument();
+    expect(increaseButton).not.toBeDisabled();
   });
 
-  it("renders increase stepper button with accessible label", () => {
+  it("increments amount by the step value when increase is clicked", () => {
     render(
       <AmountInput
         creditLine={creditLine}
@@ -248,33 +242,17 @@ describe("AmountInput", () => {
       />,
     );
 
-    const incButton = screen.getByRole("button", {
+    const increaseButton = screen.getByRole("button", {
       name: /increase amount/i,
     });
-    expect(incButton).toBeInTheDocument();
-    expect(incButton).not.toBeDisabled();
-  });
+    const input = screen.getByLabelText(/draw amount/i) as HTMLInputElement;
 
-  it("increments amount by step when increase button is clicked", () => {
-    render(
-      <AmountInput
-        creditLine={creditLine}
-        onAmountChange={vi.fn()}
-        onNext={vi.fn()}
-        onBack={vi.fn()}
-      />,
-    );
+    fireEvent.click(increaseButton);
 
-    const incButton = screen.getByRole("button", {
-      name: /increase amount/i,
-    });
-    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
-
-    fireEvent.click(incButton);
     expect(input.value).toBe("100");
   });
 
-  it("decrements amount by step when decrease button is clicked", () => {
+  it("decrements amount by the step value when decrease is clicked", () => {
     render(
       <AmountInput
         creditLine={creditLine}
@@ -284,17 +262,15 @@ describe("AmountInput", () => {
       />,
     );
 
-    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
+    const input = screen.getByLabelText(/draw amount/i) as HTMLInputElement;
     fireEvent.change(input, { target: { value: "500" } });
 
-    const decButton = screen.getByRole("button", {
-      name: /decrease amount/i,
-    });
-    fireEvent.click(decButton);
+    fireEvent.click(screen.getByRole("button", { name: /decrease amount/i }));
+
     expect(input.value).toBe("400");
   });
 
-  it("disables decrease button when amount is 0", () => {
+  it("does not increment past the available credit", () => {
     render(
       <AmountInput
         creditLine={creditLine}
@@ -304,52 +280,15 @@ describe("AmountInput", () => {
       />,
     );
 
-    const decButton = screen.getByRole("button", {
-      name: /decrease amount/i,
-    });
-    expect(decButton).toBeDisabled();
-  });
-
-  it("disables increase button when amount equals available credit", () => {
-    render(
-      <AmountInput
-        creditLine={creditLine}
-        onAmountChange={vi.fn()}
-        onNext={vi.fn()}
-        onBack={vi.fn()}
-      />,
-    );
-
-    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
-    fireEvent.change(input, { target: { value: creditLine.available.toString() } });
-
-    const incButton = screen.getByRole("button", {
-      name: /increase amount/i,
-    });
-    expect(incButton).toBeDisabled();
-  });
-
-  it("does not increment amount beyond available credit", () => {
-    render(
-      <AmountInput
-        creditLine={creditLine}
-        onAmountChange={vi.fn()}
-        onNext={vi.fn()}
-        onBack={vi.fn()}
-      />,
-    );
-
-    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
+    const input = screen.getByLabelText(/draw amount/i) as HTMLInputElement;
     fireEvent.change(input, { target: { value: "34900" } });
 
-    const incButton = screen.getByRole("button", {
-      name: /increase amount/i,
-    });
-    fireEvent.click(incButton);
+    fireEvent.click(screen.getByRole("button", { name: /increase amount/i }));
+
     expect(input.value).toBe(creditLine.available.toString());
   });
 
-  it("does not decrement amount below 0", () => {
+  it("does not decrement below zero", () => {
     render(
       <AmountInput
         creditLine={creditLine}
@@ -359,17 +298,15 @@ describe("AmountInput", () => {
       />,
     );
 
-    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
-    // A small amount less than STEP_AMOUNT should floor to 0
+    const input = screen.getByLabelText(/draw amount/i) as HTMLInputElement;
     fireEvent.change(input, { target: { value: "50" } });
-    const decButton = screen.getByRole("button", {
-      name: /decrease amount/i,
-    });
-    fireEvent.click(decButton);
+
+    fireEvent.click(screen.getByRole("button", { name: /decrease amount/i }));
+
     expect(input.value).toBe("0");
   });
 
-  it("responds to ArrowUp key to increment amount", () => {
+  it("responds to ArrowUp and ArrowDown keys as stepper shortcuts", () => {
     render(
       <AmountInput
         creditLine={creditLine}
@@ -379,29 +316,16 @@ describe("AmountInput", () => {
       />,
     );
 
-    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
+    const input = screen.getByLabelText(/draw amount/i) as HTMLInputElement;
     fireEvent.change(input, { target: { value: "500" } });
     fireEvent.keyDown(input, { key: "ArrowUp" });
     expect(input.value).toBe("600");
-  });
 
-  it("responds to ArrowDown key to decrement amount", () => {
-    render(
-      <AmountInput
-        creditLine={creditLine}
-        onAmountChange={vi.fn()}
-        onNext={vi.fn()}
-        onBack={vi.fn()}
-      />,
-    );
-
-    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
-    fireEvent.change(input, { target: { value: "500" } });
     fireEvent.keyDown(input, { key: "ArrowDown" });
-    expect(input.value).toBe("400");
+    expect(input.value).toBe("500");
   });
 
-  it("sets input step attribute", () => {
+  it("sets the input step attribute", () => {
     render(
       <AmountInput
         creditLine={creditLine}
@@ -411,7 +335,7 @@ describe("AmountInput", () => {
       />,
     );
 
-    const input = screen.getByLabelText(/amount to draw/i) as HTMLInputElement;
+    const input = screen.getByLabelText(/draw amount/i) as HTMLInputElement;
     expect(input).toHaveAttribute("step", "100");
   });
 

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -3,9 +3,9 @@ import {
   AlertCircle,
   AlertTriangle,
   CheckCircle,
-  ChevronDown,
-  ChevronUp,
   Info,
+  Minus,
+  Plus,
 } from "lucide-react";
 import { useState, useEffect, useCallback, useRef } from "react";
 import {
@@ -17,9 +17,9 @@ import { FormMessage } from "./FormMessage";
 const STEP_AMOUNT = 100;
 
 const stepClasses =
-  "flex items-center justify-center w-10 h-10 rounded-lg border border-border bg-background/60 text-foreground hover:bg-surface hover:border-accent/50 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:opacity-40 disabled:cursor-not-allowed";
+  "flex items-center justify-center w-11 h-11 rounded-lg border border-border bg-background/60 text-foreground hover:bg-surface hover:border-accent/50 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:opacity-40 disabled:cursor-not-allowed";
 
-const STEP_ICON_CLASS = "h-4 w-4";
+const STEP_ICON_CLASS = "h-4 w-4 stroke-[2.5]";
 
 interface AmountInputProps {
   creditLine: CreditLine;
@@ -185,9 +185,10 @@ export function AmountInput({
             disabled={numAmount <= 0}
             className={stepClasses}
             aria-label="Decrease amount"
+            aria-controls={inputId}
             type="button"
           >
-            <ChevronDown className={STEP_ICON_CLASS} aria-hidden="true" />
+            <Minus className={STEP_ICON_CLASS} aria-hidden="true" />
           </button>
           <span
             className="text-3xl font-bold text-foreground flex-shrink-0"
@@ -202,6 +203,7 @@ export function AmountInput({
              value={amount}
              onChange={(e) => setAmount(e.target.value)}
              onPaste={handlePaste}
+             onKeyDown={handleKeyDown}
              ref={inputRef}
              className="text-2xl font-bold bg-transparent outline-none flex-1 text-foreground placeholder:text-muted/50 min-w-0 tabular-nums"
              min={validation.minAmount}
@@ -218,9 +220,10 @@ export function AmountInput({
             disabled={numAmount >= creditLine.available}
             className={stepClasses}
             aria-label="Increase amount"
+            aria-controls={inputId}
             type="button"
           >
-            <ChevronUp className={STEP_ICON_CLASS} aria-hidden="true" />
+            <Plus className={STEP_ICON_CLASS} aria-hidden="true" />
           </button>
           {/* Max button for quick-fill with accessible label */}
           <button


### PR DESCRIPTION
Close #461 

This PR updates the GrantFox draw amount stepper interaction so the amount can be adjusted with explicit +/- controls that are clearer for touch and keyboard users.

### What changed
- Replaced the chevron-only stepper affordance with explicit plus/minus buttons in .
- Kept the amount clamped to the valid range of  through .
- Reattached the keyboard shortcut handling to the input so  /  continue to work as expected.
- Added focused regression coverage for stepper increments, decrements, bounds, and paste sanitization behavior.
- Documented the visible UX rationale for the amount-stepper behavior.

### Validation
- 
 RUN  v3.2.4 /workspaces/Creditra-Frontend

 ✓ src/components/AmountInput.test.tsx (18 tests) 1121ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  21:33:02
   Duration  2.21s (transform 136ms, setup 61ms, collect 370ms, tests 1.12s, environment 402ms, prepare 69ms) ✅
- 
> creditra-frontend@0.1.0 lint /workspaces/Creditra-Frontend
> eslint .

 ELIFECYCLE  Command failed. ⚠️ blocked in this environment ()
- 
> creditra-frontend@0.1.0 build /workspaces/Creditra-Frontend
> tsc -b && vite build

src/pages/Dashboard.tsx(492,5): error TS2657: JSX expressions must have one parent element.
src/pages/Dashboard.tsx(1320,5): error TS1005: ')' expected.
src/pages/Dashboard.tsx(1321,3): error TS1109: Expression expected.
 ELIFECYCLE  Command failed with exit code 1. ⚠️ blocked by existing TypeScript/JSX issues in 