### PR TITLE
feat: add accessible RiskBand component with pattern-based color-blin…

### DIFF
--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -265,9 +265,15 @@ Touch targets stay at 44×44 px regardless of density (see [`ACCESSIBILITY.md`](
 
 Implemented inline in `src/pages/Dashboard.tsx` as an SVG semicircle. A 180° arc from
 `(cx - r, cy)` to `(cx + r, cy)` is drawn twice — a muted background path and a coloured
-foreground path. The foreground's `strokeDashoffset` is computed from the normalised
 score (`0–100`). The colour comes from `RISK_COLOR(score)` and the trend arrow is
 `▲ | ▼ | ─` paired with `improving | declining | stable` text — never colour alone.
+
+### Risk bands
+
+`RiskBand` pairs a colored background with a secondary visual pattern to distinguish risk levels without relying solely on color (WCAG 1.4.1).
+- **Excellent/Success**: Minimal dotted pattern (`radial-gradient`).
+- **Good/Warning**: Diagonal stripes.
+- **Caution & Recovery/Danger**: Crosshatch pattern.
 
 ### Status badge
 

--- a/src/components/RiskBand.css
+++ b/src/components/RiskBand.css
@@ -1,0 +1,53 @@
+.risk-band {
+  position: relative;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: row;
+}
+
+.risk-band__pattern {
+  width: 12px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+}
+
+.risk-band__content {
+  flex: 1;
+  padding: 1rem;
+}
+
+/* 
+  Color-blind safe patterns 
+  We use --bg as the contrasting color for the pattern shapes so it looks seamless.
+*/
+
+/* Success (Excellent): Dots */
+.risk-band__pattern--success {
+  background-color: var(--success);
+  background-image: radial-gradient(var(--bg) 1.5px, transparent 1.5px);
+  background-size: 6px 6px;
+  background-position: 0 0;
+}
+
+/* Warning (Good): Diagonal stripes */
+.risk-band__pattern--warning {
+  background-color: var(--warning);
+  background-image: repeating-linear-gradient(
+    45deg,
+    transparent,
+    transparent 4px,
+    var(--bg) 4px,
+    var(--bg) 8px
+  );
+}
+
+/* Danger (Caution/Recovery): Crosshatch */
+.risk-band__pattern--danger {
+  background-color: var(--error);
+  background-image: 
+    repeating-linear-gradient(45deg, transparent, transparent 3px, var(--bg) 3px, var(--bg) 6px),
+    repeating-linear-gradient(-45deg, transparent, transparent 3px, var(--bg) 3px, var(--bg) 6px);
+}

--- a/src/components/RiskBand.test.tsx
+++ b/src/components/RiskBand.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { RiskBand } from './RiskBand';
+
+describe('RiskBand Component', () => {
+  it('renders children correctly', () => {
+    render(
+      <RiskBand level="success">
+        <div data-testid="child-element">Test Content</div>
+      </RiskBand>
+    );
+
+    expect(screen.getByTestId('child-element')).toBeInTheDocument();
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('renders with the correct pattern modifier class based on level prop', () => {
+    const { rerender } = render(<RiskBand level="success">Content</RiskBand>);
+    expect(screen.getByTestId('risk-band-pattern-success')).toHaveClass('risk-band__pattern--success');
+
+    rerender(<RiskBand level="warning">Content</RiskBand>);
+    expect(screen.getByTestId('risk-band-pattern-warning')).toHaveClass('risk-band__pattern--warning');
+
+    rerender(<RiskBand level="danger">Content</RiskBand>);
+    expect(screen.getByTestId('risk-band-pattern-danger')).toHaveClass('risk-band__pattern--danger');
+  });
+
+  it('passes additional props to the root wrapper element', () => {
+    render(
+      <RiskBand level="success" data-custom="value" id="test-id" className="extra-class">
+        Content
+      </RiskBand>
+    );
+
+    const rootElement = screen.getByText('Content').closest('.risk-band');
+    expect(rootElement).toHaveAttribute('data-custom', 'value');
+    expect(rootElement).toHaveAttribute('id', 'test-id');
+    expect(rootElement).toHaveClass('extra-class');
+  });
+
+  it('pattern container is hidden from assistive tech', () => {
+    render(<RiskBand level="warning">Content</RiskBand>);
+    const patternEl = screen.getByTestId('risk-band-pattern-warning');
+    expect(patternEl).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/src/components/RiskBand.tsx
+++ b/src/components/RiskBand.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import './RiskBand.css';
+
+export type RiskBandLevel = 'success' | 'warning' | 'danger';
+
+export interface RiskBandProps extends React.HTMLAttributes<HTMLDivElement> {
+  level: RiskBandLevel;
+  children: React.ReactNode;
+}
+
+export function RiskBand({ level, children, className = '', ...props }: RiskBandProps) {
+  return (
+    <div className={`risk-band ${className}`} {...props}>
+      <div 
+        className={`risk-band__pattern risk-band__pattern--${level}`} 
+        aria-hidden="true" 
+        data-testid={`risk-band-pattern-${level}`}
+      />
+      <div className="risk-band__content">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/RiskBandsPanel.tsx
+++ b/src/components/RiskBandsPanel.tsx
@@ -2,16 +2,19 @@ import React, { useEffect, useRef } from 'react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { RISK_COLOR, COLOR } from '../utils/tokens';
 
-interface RiskBand {
+import { RiskBand, RiskBandLevel } from './RiskBand';
+
+interface RiskBandData {
   name: string;
   description: string;
   aprRange: string;
   limitGuidance: string;
   minScore: number;
   color: string;
+  level: RiskBandLevel;
 }
 
-const RISK_BANDS: RiskBand[] = [
+const RISK_BANDS: RiskBandData[] = [
   {
     name: 'Excellent',
     description: 'Highest tier of creditworthiness with optimal terms.',
@@ -19,6 +22,7 @@ const RISK_BANDS: RiskBand[] = [
     limitGuidance: 'Maximum available limits',
     minScore: 700,
     color: COLOR.success,
+    level: 'success',
   },
   {
     name: 'Good',
@@ -27,6 +31,7 @@ const RISK_BANDS: RiskBand[] = [
     limitGuidance: 'High to medium limits',
     minScore: 600,
     color: COLOR.warning,
+    level: 'warning',
   },
   {
     name: 'Caution',
@@ -35,6 +40,7 @@ const RISK_BANDS: RiskBand[] = [
     limitGuidance: 'Limited initial limits',
     minScore: 500,
     color: COLOR.danger,
+    level: 'danger',
   },
   {
     name: 'Recovery',
@@ -43,6 +49,7 @@ const RISK_BANDS: RiskBand[] = [
     limitGuidance: 'Minimum baseline limits',
     minScore: 0,
     color: COLOR.danger,
+    level: 'danger',
   },
 ];
 
@@ -162,15 +169,10 @@ export function RiskBandsPanel({ isOpen, onClose, triggerRef }: RiskBandsPanelPr
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
             {RISK_BANDS.map(band => (
-              <div 
-                key={band.name} 
-                style={{ 
-                  padding: '1rem', 
-                  background: COLOR.bg, 
-                  border: `1px solid ${COLOR.border}`, 
-                  borderRadius: 8,
-                  borderLeft: `4px solid ${band.color}`
-                }}
+              <RiskBand 
+                key={band.name}
+                level={band.level}
+                style={{ marginBottom: '0.5rem' }}
               >
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
                   <span style={{ fontWeight: 600, color: COLOR.text, fontSize: '1rem' }}>{band.name}</span>
@@ -192,7 +194,7 @@ export function RiskBandsPanel({ isOpen, onClose, triggerRef }: RiskBandsPanelPr
                     <p style={{ margin: 0, fontSize: '0.85rem', color: COLOR.text, fontWeight: 500 }}>{band.limitGuidance}</p>
                   </div>
                 </div>
-              </div>
+              </RiskBand>
             ))}
           </div>
         </div>


### PR DESCRIPTION
closed #442 

## Summary
Resolves #442. This PR introduces secondary visual patterns beyond just color to differentiate risk bands, significantly enhancing accessibility for color-blind users in accordance with WCAG 2.1 AA.

## What changed
- Created `RiskBand` component (`src/components/RiskBand.tsx`) to act as a wrapper for risk bands, abstracting the pattern rendering logic.
- Implemented lightweight CSS patterns (`src/components/RiskBand.css`) using `radial-gradient` and `repeating-linear-gradient` to represent Excellent (dots), Good (diagonal stripes), and Caution/Recovery (crosshatch) bands, without adding external asset bloat.
- Refactored `src/components/RiskBandsPanel.tsx` to utilize the new `RiskBand` component instead of relying solely on solid left borders for visual distinction.
- Updated `docs/DESIGN_SYSTEM.md` to formally document the visual patterns as a secondary visual indicator for risk levels.

## Why
Relying solely on color to communicate state or value (like credit risk) is a violation of WCAG 1.4.1 (Use of Color). By introducing subtle, performant background patterns, we ensure that users with different types of color vision deficiency can quickly and accurately distinguish between "Excellent", "Good", and "Caution" risk levels.

## Testing
- Added comprehensive unit tests in `src/components/RiskBand.test.tsx` verifying component rendering, proper assignment of pattern CSS classes, and `aria-hidden` constraints for decorative elements.
- Verified local builds (`npm run build`) and test suite (`npm test`).
- Visually verified the patterns across different risk bands.

### Accessibility Check
- [x] Keyboard navigation works (Tab, Shift+Tab, Enter, Escape)
- [x] Focus indicators are clearly visible (2px outline, 2px offset)
- [x] Contrast ratios meet WCAG AA (4.5:1 text, 3:1 large text/icons)
- [x] Touch targets are at least 44×44 px
- [x] Semantic HTML and ARIA roles/labels are used
- [x] `prefers-reduced-motion` is respected
