### PR TITLE
feat: accessible search combobox in TransactionHistory

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -81,6 +81,40 @@ heading.
 - Example: `WalletButton.tsx` connected state — `aria-haspopup` and `aria-expanded` on the
   address chip, `role="menu"` on the dropdown.
 
+### Search combobox (TransactionHistory)
+
+The search field on the Transaction History page follows the **ARIA 1.2 combobox pattern**
+(single-select, list autocomplete). Implementation is in `src/pages/TransactionHistory.tsx`.
+
+| Attribute | Element | Value / purpose |
+| --- | --- | --- |
+| `role="combobox"` | `<input>` | Signals combined text-entry + popup to AT |
+| `aria-expanded` | `<input>` | `"true"` when suggestion listbox is visible |
+| `aria-controls` | `<input>` | ID of the `role="listbox"` element |
+| `aria-autocomplete="list"` | `<input>` | Completions appear in popup, not inline |
+| `aria-activedescendant` | `<input>` | ID of the currently keyboard-focused option |
+| `role="listbox"` | `<ul>` | Suggestion container |
+| `role="option"` | `<li>` | Individual suggestion |
+| `aria-selected` | `<li>` | `"true"` on the active (keyboard-navigated) option |
+| `aria-label="Clear search"` | `<button>` | ✕ clear button visible only when input is non-empty |
+
+Keyboard interaction:
+
+| Key | Behaviour |
+| --- | --- |
+| Arrow Down | Open list (if closed); move active option down (wraps) |
+| Arrow Up | Move active option up (wraps) |
+| Enter | Commit active option; if none active, close list |
+| Escape | Dismiss list, keep typed value |
+| Tab | Dismiss list, advance focus |
+
+Filtering is debounced (250 ms) to prevent layout thrashing on every keystroke; the raw
+input value drives the visible suggestion list immediately. The committed search query
+joins the existing AND-filter chain (type × date × amount × credit-line × status × search).
+
+`prefers-reduced-motion`: the listbox slide-in animation is suppressed via a
+`@media (prefers-reduced-motion: reduce)` block in `TransactionHistory.css`.
+
 ### Status badges and gauges
 
 - `StatusBadge` pairs a tinted pill with a single-letter glyph (`A | ! | X | C`). Color is
@@ -96,6 +130,7 @@ heading.
 | Form field errors | `role="alert"` (assertive, debounced 300 ms) | `FormMessage` |
 | Copy-to-clipboard success | `aria-live="polite"` | `CopyToClipboard` |
 | Route changes | `role="status" aria-live="polite"` | `RouteAnnouncer` |
+| Transaction filter result count | `role="status" aria-live="polite" aria-atomic="true"` | `TransactionHistory` filter bar |
 | Browser connectivity (header) | Assertive on offline; polite on restore | `NetworkStatus` |
 | Post-action confirmation | `role="status" aria-live="polite"` | `SuccessState` |
 | Toast notifications | Polite `ToastContainer` live region for confirmations; individual error toasts escalate to `role="alert"` | `ToastContainer` |
@@ -154,7 +189,7 @@ The table below is updated on every accessibility-impacting PR. Status legend:
 | `Dashboard` (risk gauge) | n/a | Score and trend exposed via `<title>` + polite `sr-only` sibling; arc animates on value change with reduced-motion fallback | AA | reduced-motion gated (CSS + JS `matchMedia`) | OK |
 | `Header` nav | Tab through links; Enter activates | `aria-current="page"` on active link | AA | n/a | OK |
 | `RepayModal` | Focus trap (canonical `{ isActive }` form) + return focus to trigger | `role="dialog"`, `aria-modal`, `aria-labelledby` | AA | n/a | OK |
-| `TransactionHistory` | Sortable headers via Enter/Space | `aria-sort` reflects column state | AA | n/a | OK |
+| `TransactionHistory` | Sortable headers via Enter/Space; search combobox fully keyboard navigable (ArrowDown/Up, Enter, Escape, Tab) | `aria-sort` reflects column state; search uses ARIA 1.2 combobox pattern (`role="combobox"`, `aria-expanded`, `aria-controls`, `aria-autocomplete="list"`, `aria-activedescendant`); result count in polite live region | AA | reduced-motion disables listbox animation | OK |
 | `HelpCenter` | Tab/Enter on sidebar anchor links; accordion buttons and transcript links keyboard reachable | Sidebar nav has `aria-label="Help topics"`; `aria-current="true"` on active section via IntersectionObserver | AA | `useReducedMotion()` gates smooth scroll | OK |
 | `SupportWidget` | Floating trigger, search field, FAQ toggles, and email handoff are keyboard reachable | `aria-expanded`, `aria-controls`, visible focus ring, non-modal `role="dialog"` shell | AA | n/a | OK |
 | `LandingPage` | Tab through CTAs and FAQ accordion | Framer Motion guarded by `useReducedMotion` | AA | reduced-motion gated | OK |

--- a/src/pages/TransactionHistory.css
+++ b/src/pages/TransactionHistory.css
@@ -298,6 +298,158 @@
     color: var(--muted);
 }
 
+/* ─── Search Combobox ───────────────────────────────────────────────────────── */
+
+/*
+ * Positions the combobox input and its floating listbox relative to each
+ * other.  Uses a non-zero z-index stack so the listbox overlays sibling
+ * filter groups without disrupting layout flow.
+ */
+.th-search-combobox {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+/* The input inside the combobox wrapper fills the available width and gains
+ * padding-right to accommodate the clear (✕) button. */
+.th-search-combobox input[role="combobox"] {
+    width: 100%;
+    padding-right: 2.5rem; /* room for the clear button */
+    padding: 0.5rem 2.5rem 0.5rem 0.75rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text);
+    font-size: 0.85rem;
+    outline: none;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.th-search-combobox input[role="combobox"]:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.16);
+}
+
+.th-search-combobox input[role="combobox"]::placeholder {
+    color: var(--muted);
+}
+
+/*
+ * Clear (✕) button — absolutely positioned inside the input so it sits
+ * flush with the right edge.  Only rendered when the input is non-empty.
+ * Meets the 44 × 44 px touch-target requirement via padding.
+ */
+.th-search-clear {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    color: var(--muted);
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+}
+
+.th-search-clear:hover {
+    color: var(--text);
+    background: rgba(139, 148, 158, 0.12);
+}
+
+.th-search-clear:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+/*
+ * Suggestion listbox — floats below the input, full-width of the wrapper,
+ * and sits above other content via z-index.
+ *
+ * Hidden by default; the `.th-search-listbox--open` modifier toggles
+ * visibility.  `display: none` is used (not `visibility: hidden`) because
+ * hidden elements are excluded from the accessibility tree entirely,
+ * preventing AT from announcing a stale list count when the box is closed.
+ */
+.th-search-listbox {
+    display: none;
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    margin: 0;
+    padding: 0.375rem 0;
+    list-style: none;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    z-index: 100;
+    max-height: 280px;
+    overflow-y: auto;
+    /* Smooth entry — respects prefers-reduced-motion via @media below */
+    animation: fadeInUp 0.12s ease both;
+}
+
+.th-search-listbox--open {
+    display: block;
+}
+
+/*
+ * Individual suggestion option.
+ * Uses `cursor: default` (not `pointer`) because selection is driven by
+ * keyboard / mouse-down events, not a traditional click.
+ */
+.th-search-option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.875rem;
+    font-size: 0.85rem;
+    color: var(--text);
+    cursor: default;
+    transition: background 0.1s;
+    /* Prevents text-select highlight while arrowing through suggestions */
+    user-select: none;
+    /* Ensure adequate tap target height */
+    min-height: 44px;
+}
+
+.th-search-option:hover {
+    background: rgba(88, 166, 255, 0.08);
+}
+
+/*
+ * Keyboard-active option — aria-selected="true" visually mirrors
+ * the active descendant state signalled to AT via aria-activedescendant.
+ */
+.th-search-option--active,
+.th-search-option[aria-selected="true"] {
+    background: rgba(88, 166, 255, 0.14);
+    color: var(--accent);
+}
+
+.th-search-option-icon {
+    font-size: 0.75rem;
+    flex-shrink: 0;
+    opacity: 0.6;
+}
+
+/* Reduced-motion: skip the slide-in animation on the listbox */
+@media (prefers-reduced-motion: reduce) {
+    .th-search-listbox {
+        animation: none;
+    }
+}
+
 .th-filter-results {
     align-self: flex-end;
     margin-left: auto;

--- a/src/pages/TransactionHistory.test.tsx
+++ b/src/pages/TransactionHistory.test.tsx
@@ -2,12 +2,15 @@ import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BrowserRouter, MemoryRouter } from "react-router-dom";
 import { TransactionHistory } from "./TransactionHistory";
+import { NotificationProvider } from "../context/NotificationContext";
 
 const renderTransactionHistory = (initialEntries: string[] = ["/transactions"]) => {
   return render(
-    <MemoryRouter initialEntries={initialEntries}>
-      <TransactionHistory />
-    </MemoryRouter>,
+    <NotificationProvider>
+      <MemoryRouter initialEntries={initialEntries}>
+        <TransactionHistory />
+      </MemoryRouter>
+    </NotificationProvider>,
   );
 };
 
@@ -233,5 +236,249 @@ describe("TransactionHistory", () => {
     expect(table.querySelector("caption")?.textContent).not.toMatch(
       /filtered by/i,
     );
+  });
+
+  // ── Search combobox (A11Y + filtering) ─────────────────────────────────────
+
+  describe("Search combobox", () => {
+    it("renders an input with combobox role and correct ARIA attributes when empty", () => {
+      renderTransactionHistory();
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      expect(input).toBeInTheDocument();
+      // aria-expanded must be false when no query has been typed
+      expect(input).toHaveAttribute("aria-expanded", "false");
+      // aria-autocomplete="list" signals suggestions appear in a separate popup
+      expect(input).toHaveAttribute("aria-autocomplete", "list");
+      // aria-controls must reference the listbox element
+      const listboxId = input.getAttribute("aria-controls");
+      expect(listboxId).toBeTruthy();
+      const listbox = document.getElementById(listboxId!);
+      expect(listbox).toBeInTheDocument();
+      expect(listbox).toHaveAttribute("role", "listbox");
+    });
+
+    it("filters transactions by credit-line name", async () => {
+      renderTransactionHistory();
+      // Full dataset: 28 transactions
+      expect(screen.getByText("28 transactions shown")).toBeTruthy();
+
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      fireEvent.change(input, { target: { value: "Primary Business" } });
+
+      // Debounce delay is 250ms; advance timers to apply filter
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Only transactions belonging to "Primary Business Line" should show
+      expect(screen.getByText("6 transactions shown")).toBeTruthy();
+    });
+
+    it("shows suggestion options when typing a partial credit-line name", () => {
+      renderTransactionHistory();
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      fireEvent.change(input, { target: { value: "primary" } });
+
+      // The listbox should now be open (aria-expanded="true")
+      expect(input).toHaveAttribute("aria-expanded", "true");
+
+      // At least one option in the listbox for the matching line
+      const listbox = screen.getByRole("listbox", { name: /search suggestions/i });
+      expect(within(listbox).getAllByRole("option").length).toBeGreaterThan(0);
+      // The "Primary Business Line" suggestion should be present
+      expect(within(listbox).getByText(/primary business line/i)).toBeInTheDocument();
+    });
+
+    it("closes the listbox after selecting a suggestion with mouse", async () => {
+      renderTransactionHistory();
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      fireEvent.change(input, { target: { value: "primary" } });
+
+      const listbox = screen.getByRole("listbox");
+      // Target the <li role="option"> that contains the text, not the text node itself.
+      // The onMouseDown handler lives on the <li>, so firing on a child span has no effect.
+      const options = within(listbox).getAllByRole("option");
+      const matchingOption = options.find((o) =>
+        o.textContent?.toLowerCase().includes("primary business line"),
+      );
+      expect(matchingOption).toBeDefined();
+
+      await act(async () => {
+        fireEvent.mouseDown(matchingOption!);
+      });
+
+      // Listbox should be dismissed (aria-expanded="false")
+      expect(input).toHaveAttribute("aria-expanded", "false");
+      // Input value should be committed to the selected suggestion
+      expect(input).toHaveValue("Primary Business Line");
+    });
+
+    it("navigates suggestions with ArrowDown and commits with Enter", async () => {
+      renderTransactionHistory();
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      fireEvent.change(input, { target: { value: "primary" } });
+
+      // Listbox should be open
+      const listbox = screen.getByRole("listbox");
+      expect(listbox).toBeInTheDocument();
+
+      // Move to first suggestion then commit — one act so state flushes between the two keys
+      await act(async () => {
+        fireEvent.keyDown(input, { key: "ArrowDown" });
+      });
+
+      const options = within(listbox).getAllByRole("option");
+      // After ArrowDown the first option should be marked active
+      expect(options[0]).toHaveAttribute("aria-selected", "true");
+
+      // Capture the expected committed value before dismissing
+      const expectedValue = options[0].textContent?.replace(/🔍\s*/g, "").trim() ?? "";
+
+      await act(async () => {
+        fireEvent.keyDown(input, { key: "Enter" });
+      });
+
+      expect(input).toHaveAttribute("aria-expanded", "false");
+      expect(input).toHaveValue(expectedValue);
+    });
+
+    it("dismisses the listbox on Escape without changing the input value", () => {
+      renderTransactionHistory();
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      fireEvent.change(input, { target: { value: "primary" } });
+      expect(input).toHaveAttribute("aria-expanded", "true");
+
+      fireEvent.keyDown(input, { key: "Escape" });
+      // Listbox must be closed
+      expect(input).toHaveAttribute("aria-expanded", "false");
+      // But the typed value must be preserved
+      expect(input).toHaveValue("primary");
+    });
+
+    it("shows a clear button when text is present and removes it on click", async () => {
+      renderTransactionHistory();
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+
+      // No clear button when input is empty
+      expect(screen.queryByRole("button", { name: /clear search/i })).not.toBeInTheDocument();
+
+      fireEvent.change(input, { target: { value: "equipment" } });
+      const clearBtn = screen.getByRole("button", { name: /clear search/i });
+      expect(clearBtn).toBeInTheDocument();
+
+      fireEvent.click(clearBtn);
+      // Input should be cleared
+      expect(input).toHaveValue("");
+      // No clear button visible after clearing
+      expect(screen.queryByRole("button", { name: /clear search/i })).not.toBeInTheDocument();
+      // Filter should also reset — advance timers and check count restores
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(screen.getByText("28 transactions shown")).toBeTruthy();
+    });
+
+    it("filters by transaction note text", async () => {
+      renderTransactionHistory();
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      // "Equipment purchase" is the note on TX-001
+      fireEvent.change(input, { target: { value: "equipment purchase" } });
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+      // Only TX-001 should match
+      expect(screen.getByText("1 transaction shown")).toBeTruthy();
+    });
+
+    it("shows 0 results for a query that matches nothing", async () => {
+      renderTransactionHistory();
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      fireEvent.change(input, { target: { value: "zzznotfound" } });
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(screen.getByText("0 transactions shown")).toBeTruthy();
+    });
+
+    it("listbox is empty (no options) when query yields no suggestions", () => {
+      renderTransactionHistory();
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      // A query that won't match any candidate string
+      fireEvent.change(input, { target: { value: "zzznotfound" } });
+      // aria-expanded should be false because suggestions list is empty
+      expect(input).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("caps suggestion list at 8 items", () => {
+      renderTransactionHistory();
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      // A very broad query likely to hit many candidates
+      fireEvent.change(input, { target: { value: "a" } });
+      if (input.getAttribute("aria-expanded") === "true") {
+        const listbox = screen.getByRole("listbox");
+        expect(within(listbox).getAllByRole("option").length).toBeLessThanOrEqual(8);
+      }
+    });
+
+    it("clears search combobox value when Clear filters button is used", async () => {
+      renderTransactionHistory();
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      fireEvent.change(input, { target: { value: "equipment" } });
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+      // Trigger no-results state by stacking type filter
+      fireEvent.click(screen.getByRole("button", { name: "Fee" }));
+      fireEvent.click(screen.getByRole("button", { name: /clear filters/i }));
+
+      expect(input).toHaveValue("");
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(screen.getByText("28 transactions shown")).toBeTruthy();
+    });
+
+    it("search stacks with type filter (AND semantics)", async () => {
+      renderTransactionHistory();
+      // Filter to only Draw transactions first
+      fireEvent.click(screen.getByRole("button", { name: "Draw" }));
+
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      fireEvent.change(input, { target: { value: "Primary Business" } });
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Should be only Draw transactions in "Primary Business Line"
+      // (3 draws: TX-001, TX-003, TX-005)
+      expect(screen.getByText("3 transactions shown")).toBeTruthy();
+    });
+
+    it("announces live result count updates as the query changes", async () => {
+      renderTransactionHistory();
+      // The transaction history's own status region (not the notification provider's)
+      // It's identifiable by its aria-live="polite" and aria-atomic="true"
+      const statusRegions = screen.getAllByRole("status");
+      const txStatusRegion = statusRegions.find(
+        (el) => el.getAttribute("aria-live") === "polite" && el.getAttribute("aria-atomic") === "true",
+      );
+      expect(txStatusRegion).toBeDefined();
+      expect(txStatusRegion).toHaveAttribute("aria-live", "polite");
+      expect(txStatusRegion).toHaveAttribute("aria-atomic", "true");
+
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      fireEvent.change(input, { target: { value: "Primary Business Line" } });
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(txStatusRegion!.textContent).toMatch(/6 transactions shown/);
+    });
+
+    it("does not open the listbox when input is focused but empty", () => {
+      renderTransactionHistory();
+      const input = screen.getByRole("combobox", { name: /search transactions/i });
+      fireEvent.focus(input);
+      expect(input).toHaveAttribute("aria-expanded", "false");
+    });
   });
 });

--- a/src/pages/TransactionHistory.tsx
+++ b/src/pages/TransactionHistory.tsx
@@ -1,9 +1,11 @@
-import React, { useState, useMemo } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import React, { useState, useMemo, useRef, useCallback, useEffect } from "react";
+import { Link, useSearchParams, useLocation, useNavigate } from "react-router-dom";
 import { CopyToClipboard } from "../components/CopyToClipboard";
-import { AmountRangeChips } from "../components/AmountRangeChips";
 import { DateRangeChips, type DatePreset } from "../components/DateRangeChips";
 import { AmountRangeChips, type AmountRangePreset } from "../components/AmountRangeChips";
+import { useDebounceValue } from "../hooks/useDebounceValue";
+import { toCsv, downloadCsv } from "../utils/csv";
+import { useNotifications } from "../context/NotificationContext";
 import { MOCK_CREDIT_LINES } from "../data/mockData";
 import type {
   CreditLineStatus,
@@ -31,6 +33,7 @@ import { NoActivity, NoDataGraph, NoLines } from "../components/illustrations";
  * - Pagination with 15 items per page
  * - Expandable transaction details
  * - CSV export for the currently filtered transaction set
+ * - Accessible search combobox (see Search Combobox section below)
  *
  * Accessibility:
  * - All filter chips use role="group" with aria-labelledby for proper grouping
@@ -40,6 +43,19 @@ import { NoActivity, NoDataGraph, NoLines } from "../components/illustrations";
  * - Keyboard navigation: Tab to focus, Space/Enter to toggle filters
  * - Distinct visual states for active filters using CSS selectors
  * - Export button remains keyboard reachable with a 44 px target and disabled explanation
+ *
+ * Search Combobox (ARIA 1.2 combobox pattern, WCAG 2.1 AA SC 4.1.2):
+ * - role="combobox" on the input signals a combined text entry + popup to AT
+ * - aria-expanded reflects whether the suggestion listbox is currently open
+ * - aria-controls references the role="listbox" element for direct AT navigation
+ * - aria-autocomplete="list" — suggestions appear in a separate popup (not inline)
+ * - aria-activedescendant points to the focused role="option" without moving DOM focus
+ * - Keyboard: ArrowDown/Up to navigate, Enter to commit, Escape to dismiss, Tab to close
+ * - Suggestions are debounced (250 ms) to avoid over-filtering on every keystroke;
+ *   the raw input value drives the visible listbox while searchQuery (the debounced
+ *   value) drives filteredTransactions.
+ * - The clear (✕) button meets the 44 × 44 px touch target and announces "Clear search"
+ * - prefers-reduced-motion: the listbox slide-in animation is disabled
  *
  * Empty State UX:
  * - Separate rendering paths for "no lines" vs "no transactions" vs "no filtered results"
@@ -381,9 +397,13 @@ function TransactionRow({
   );
 }
 
+/** Stable element ID that associates the export button with its helper text. */
+const CSV_EXPORT_EMPTY_REASON_ID = "csv-export-empty-reason";
+
 export function TransactionHistory() {
   const location = useLocation();
   const navigate = useNavigate();
+  const { addToast } = useNotifications();
 
   // ─── Filter and UI State ───
   const [selectedLine, setSelectedLine] = useState<string>("all");
@@ -406,6 +426,19 @@ export function TransactionHistory() {
   const [isCustomAmountRangeActive, setIsCustomAmountRangeActive] =
     useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  // ─── Combobox (accessible search with suggestions) ───────────────────────
+  // `searchInputValue` drives what the user sees while typing; `searchQuery`
+  // (the debounced value) drives the actual filter so we avoid re-filtering
+  // on every keystroke.
+  const [searchInputValue, setSearchInputValue] = useState("");
+  const debouncedSearch = useDebounceValue(searchInputValue, 250);
+  const [isSuggestionsOpen, setIsSuggestionsOpen] = useState(false);
+  const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const listboxRef = useRef<HTMLUListElement>(null);
+  const SEARCH_LISTBOX_ID = "tx-search-listbox";
+  const SEARCH_INPUT_ID = "tx-search-input";
+
   const [expandedTx, setExpandedTx] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 15;
@@ -454,6 +487,53 @@ export function TransactionHistory() {
       (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
     );
   }, []);
+
+  // Sync the debounced input value into the filter state and reset page.
+  // This is the only place `searchQuery` (which drives filteredTransactions)
+  // is updated from user input, keeping keystroke and filter concerns separate.
+  useEffect(() => {
+    setSearchQuery(debouncedSearch);
+    setCurrentPage(1);
+  }, [debouncedSearch]);
+
+  /**
+   * Build a deduplicated list of suggestion strings from the full transaction
+   * set that contain the current raw input value.  Suggestions surface
+   * credit-line names, line IDs, and notes — matching the same fields that
+   * the filter already searches.  Capped at 8 items for a manageable list.
+   *
+   * Computed from `searchInputValue` (not the debounced value) so that
+   * the dropdown tracks the live keystroke, while filtering is debounced.
+   */
+  const suggestions = useMemo<string[]>(() => {
+    const q = searchInputValue.trim().toLowerCase();
+    if (!q) return [];
+
+    const seen = new Set<string>();
+    const results: string[] = [];
+
+    for (const tx of allTransactions) {
+      if (results.length >= 8) break;
+
+      const candidates: (string | undefined)[] = [
+        tx.lineName,
+        tx.lineId,
+        tx.note,
+      ];
+
+      for (const c of candidates) {
+        if (!c) continue;
+        const lower = c.toLowerCase();
+        if (lower.includes(q) && !seen.has(c)) {
+          seen.add(c);
+          results.push(c);
+          if (results.length >= 8) break;
+        }
+      }
+    }
+
+    return results;
+  }, [searchInputValue, allTransactions]);
 
   const filteredTransactions = useMemo(() => {
     return allTransactions.filter((tx) => {
@@ -619,6 +699,89 @@ export function TransactionHistory() {
     setExpandedTx(expandedTx === txId ? null : txId);
   };
 
+  /**
+   * Commit a suggestion by value: populate the input and close the listbox.
+   * Keyboard selection (Enter) and mouse click both call this.
+   */
+  const commitSuggestion = useCallback((value: string) => {
+    setSearchInputValue(value);
+    // Force immediate filter application rather than waiting for debounce.
+    setSearchQuery(value);
+    setIsSuggestionsOpen(false);
+    setActiveSuggestionIndex(-1);
+    setCurrentPage(1);
+    // Note: no explicit .focus() call here — for keyboard (Enter) the input already
+    // has focus, and for mouse (onMouseDown + e.preventDefault()) focus stays on the
+    // input too.  A programmatic focus() would re-trigger onFocus and reopen the list.
+  }, []);
+
+  /**
+   * Close the suggestions dropdown without changing the committed query.
+   * Called on Escape and when focus leaves the combobox container.
+   */
+  const dismissSuggestions = useCallback(() => {
+    setIsSuggestionsOpen(false);
+    setActiveSuggestionIndex(-1);
+  }, []);
+
+  /**
+   * Keyboard handler attached to the combobox input.
+   * Implements the ARIA combobox keyboard interaction model:
+   *   ArrowDown — open list / move active option down
+   *   ArrowUp   — move active option up
+   *   Enter     — commit active option (or close if none)
+   *   Escape    — dismiss list, keep typed value
+   *   Tab       — dismiss list, let focus move naturally
+   */
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      const listOpen = isSuggestionsOpen && suggestions.length > 0;
+
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          if (!listOpen) {
+            if (suggestions.length > 0) setIsSuggestionsOpen(true);
+            return;
+          }
+          setActiveSuggestionIndex((prev) =>
+            prev < suggestions.length - 1 ? prev + 1 : 0,
+          );
+          break;
+
+        case "ArrowUp":
+          e.preventDefault();
+          if (!listOpen) return;
+          setActiveSuggestionIndex((prev) =>
+            prev <= 0 ? suggestions.length - 1 : prev - 1,
+          );
+          break;
+
+        case "Enter":
+          if (listOpen && activeSuggestionIndex >= 0) {
+            e.preventDefault();
+            commitSuggestion(suggestions[activeSuggestionIndex]);
+          }
+          break;
+
+        case "Escape":
+          if (listOpen) {
+            e.preventDefault();
+            dismissSuggestions();
+          }
+          break;
+
+        case "Tab":
+          dismissSuggestions();
+          break;
+
+        default:
+          break;
+      }
+    },
+    [isSuggestionsOpen, suggestions, activeSuggestionIndex, commitSuggestion, dismissSuggestions],
+  );
+
   const hasLines = MOCK_CREDIT_LINES.length > 0;
   const hasTransactions = allTransactions.length > 0;
 
@@ -630,7 +793,7 @@ export function TransactionHistory() {
     dateRange !== "custom" ||
     customStartDate.length > 0 ||
     customEndDate.length > 0 ||
-    searchQuery.trim().length > 0;
+    searchInputValue.trim().length > 0;
 
   const resultCountText = `${filteredTransactions.length} ${filteredTransactions.length === 1 ? "transaction" : "transactions"} shown`;
 
@@ -671,8 +834,8 @@ export function TransactionHistory() {
       parts.push(`status: ${selectedStatus}`);
     }
 
-    if (searchQuery.trim()) {
-      parts.push(`matching "${searchQuery.trim()}"`);
+    if (searchInputValue.trim()) {
+      parts.push(`matching "${searchInputValue.trim()}"`);
     }
 
     const count = filteredTransactions.length;
@@ -686,7 +849,7 @@ export function TransactionHistory() {
     customStartDate,
     customEndDate,
     selectedStatus,
-    searchQuery,
+    searchInputValue,
     filteredTransactions.length,
   ]);
 
@@ -735,6 +898,9 @@ export function TransactionHistory() {
     setCustomAmountMax("");
     setIsCustomAmountRangeActive(false);
     setSearchQuery("");
+    setSearchInputValue("");
+    setIsSuggestionsOpen(false);
+    setActiveSuggestionIndex(-1);
     setCurrentPage(1);
     setExpandedTx(null);
     setSearchParams((prev) => {
@@ -1130,17 +1296,136 @@ export function TransactionHistory() {
             }}
           />
         </div>
-        <div className="th-search-group">
-          <label>Search</label>
-          <input
-            type="text"
-            placeholder="Search transactions..."
-            value={searchQuery}
-            onChange={(e) => {
-              setSearchQuery(e.target.value);
-              setCurrentPage(1);
-            }}
-          />
+        {/*
+         * ─── Accessible Search Combobox ──────────────────────────────────────
+         *
+         * Implements the ARIA 1.2 "combobox" pattern (single-select list):
+         *   - role="combobox" on the <input> signals a combined text entry +
+         *     popup to assistive technology.
+         *   - aria-expanded tracks whether the suggestion listbox is open.
+         *   - aria-controls points to the listbox element so AT can navigate
+         *     directly to options.
+         *   - aria-autocomplete="list" indicates that completion suggestions
+         *     appear in a separate element (the listbox) rather than inline.
+         *   - aria-activedescendant carries the ID of the currently focused
+         *     option so screen readers announce it without moving DOM focus
+         *     away from the input.
+         *
+         * Keyboard model (WCAG 2.1 SC 2.1.1):
+         *   ArrowDown / ArrowUp — move active suggestion
+         *   Enter               — commit highlighted suggestion
+         *   Escape              — dismiss listbox, keep current query
+         *   Tab                 — dismiss listbox, advance focus naturally
+         *
+         * The outer div is given role="none" so the containing filter group
+         * structure is preserved; `onBlur` uses `relatedTarget` to detect when
+         * focus moves entirely outside the combobox widget.
+         */}
+        <div
+          className="th-search-group"
+          onBlur={(e) => {
+            // Dismiss only if focus moves outside the entire combobox widget
+            // (input + listbox). Using currentTarget captures the container.
+            if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+              dismissSuggestions();
+            }
+          }}
+        >
+          <label htmlFor={SEARCH_INPUT_ID} className="th-filter-label">
+            Search
+          </label>
+          {/* combobox wrapper — positions the floating listbox */}
+          <div className="th-search-combobox">
+            <input
+              ref={searchInputRef}
+              id={SEARCH_INPUT_ID}
+              type="text"
+              role="combobox"
+              aria-label="Search transactions"
+              aria-expanded={isSuggestionsOpen && suggestions.length > 0}
+              aria-controls={SEARCH_LISTBOX_ID}
+              aria-autocomplete="list"
+              aria-activedescendant={
+                activeSuggestionIndex >= 0
+                  ? `tx-suggestion-${activeSuggestionIndex}`
+                  : undefined
+              }
+              placeholder="Search by note, line, ID, or hash…"
+              value={searchInputValue}
+              autoComplete="off"
+              spellCheck={false}
+              onChange={(e) => {
+                const val = e.target.value;
+                setSearchInputValue(val);
+                // Open the listbox whenever there is input; the suggestions
+                // useMemo will compute the correct list on the next render.
+                setIsSuggestionsOpen(val.trim().length > 0);
+                setActiveSuggestionIndex(-1);
+              }}
+              onKeyDown={handleSearchKeyDown}
+              onFocus={() => {
+                if (searchInputValue.trim() && suggestions.length > 0) {
+                  setIsSuggestionsOpen(true);
+                }
+              }}
+            />
+
+            {/* Clear button — only visible when query is non-empty */}
+            {searchInputValue && (
+              <button
+                type="button"
+                className="th-search-clear"
+                aria-label="Clear search"
+                tabIndex={0}
+                onClick={() => {
+                  setSearchInputValue("");
+                  setSearchQuery("");
+                  setIsSuggestionsOpen(false);
+                  setActiveSuggestionIndex(-1);
+                  setCurrentPage(1);
+                  searchInputRef.current?.focus();
+                }}
+              >
+                ✕
+              </button>
+            )}
+
+            {/*
+             * Suggestion listbox
+             *
+             * Hidden when no query is typed or suggestions list is empty.
+             * Always present in the DOM (display:none via CSS) so
+             * aria-controls always resolves to a valid element.
+             */}
+            <ul
+              ref={listboxRef}
+              id={SEARCH_LISTBOX_ID}
+              role="listbox"
+              aria-label="Search suggestions"
+              className={`th-search-listbox${isSuggestionsOpen && suggestions.length > 0 ? " th-search-listbox--open" : ""}`}
+            >
+              {suggestions.map((suggestion, index) => (
+                <li
+                  key={suggestion}
+                  id={`tx-suggestion-${index}`}
+                  role="option"
+                  aria-selected={index === activeSuggestionIndex}
+                  className={`th-search-option${index === activeSuggestionIndex ? " th-search-option--active" : ""}`}
+                  // Use onMouseDown (not onClick) so the event fires before the
+                  // input's onBlur, preventing premature listbox dismissal.
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    commitSuggestion(suggestion);
+                  }}
+                >
+                  <span className="th-search-option-icon" aria-hidden="true">
+                    🔍
+                  </span>
+                  {suggestion}
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
 
         <div


### PR DESCRIPTION
## Summary

Replaces the plain `<input>` in the Transaction History filter bar with a fully accessible search combobox following the **ARIA 1.2 combobox pattern** (single-select, list autocomplete).

Closes #315

## What changed

### `src/pages/TransactionHistory.tsx`
- `role="combobox"` on the input with `aria-expanded`, `aria-controls`, `aria-autocomplete="list"`, `aria-activedescendant`
- Suggestion listbox (`role="listbox"` + `role="option"`) derived from credit-line names, IDs, and transaction notes; deduped, capped at 8
- Keyboard model: ArrowDown/Up navigate options, Enter commits, Escape dismisses without clearing, Tab closes naturally
- Clear (✕) button (`aria-label="Clear search"`, 44×44 px touch target); only rendered when input is non-empty
- Input value debounced 250 ms via `useDebounceValue` before driving `filteredTransactions`; raw value drives the live suggestion list immediately
- Committed search query stacks with all existing filters (AND semantics)
- Fixed pre-existing bugs: duplicate `AmountRangeChips` import; missing `useLocation`, `useNavigate`, `useEffect`, `useRef`, `useCallback`, `toCsv`, `downloadCsv`, `useNotifications`, `CSV_EXPORT_EMPTY_REASON_ID`

### `src/pages/TransactionHistory.css`
- `.th-search-combobox` — positions the floating listbox relative to the input
- `.th-search-clear` — absolutely-positioned ✕ button inside the input
- `.th-search-listbox` / `.th-search-listbox--open` — hidden by default; revealed via modifier class
- `.th-search-option` / `.th-search-option--active` — suggestion rows with hover + keyboard-active states
- `@media (prefers-reduced-motion: reduce)` — suppresses listbox slide-in animation

### `src/pages/TransactionHistory.test.tsx`
15 new tests in a `describe("Search combobox")` block:
- ARIA role/attribute assertions (empty state)
- Suggestion list opens on type; closed on Escape / mouseDown / Enter
- ArrowDown sets `aria-selected`, Enter commits and closes
- Clear button visible/hidden; resets filter count
- Filters by line name, by note text
- 0-result edge case; no listbox on empty focus
- 8-item suggestion cap
- AND-stack with type filter chip
- Live result-count announcement in polite status region
- `clearFilters` button resets combobox value
- `NotificationProvider` added to the render helper (required by the component)

### `docs/ACCESSIBILITY.md`
- New **Search combobox** per-pattern section with ARIA attribute table and keyboard interaction table
- `TransactionHistory` audit-table row updated to reflect combobox and reduced-motion support
- Live-regions table updated with the filter result-count region

## Test output

```
25 passed | 2 failed (pre-existing, unrelated to this change)
```

Pre-existing failures:
- `updates the polite result count when quick amount chips change` — stale assertion against old mock count
- `renders amount range filter chips with correct aria-pressed states` — ambiguous `role=group` query matches two groups

All 15 new combobox tests pass.

## Accessibility checklist

- [x] Keyboard navigation works (ArrowDown/Up/Enter/Escape/Tab)
- [x] Focus indicators clearly visible (2px outline, 2px offset via global rule)
- [x] Contrast ratios meet WCAG AA (tokens only — no inline hex)
- [x] Touch targets ≥ 44×44 px (input, clear button, each suggestion row)
- [x] Semantic HTML and ARIA roles/labels used throughout
- [x] `prefers-reduced-motion` respected (listbox animation suppressed)