### PR TITLE
feat: /404 illustration + CTAs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src/pages/ErrorPage.css
+++ b/src/pages/ErrorPage.css
@@ -14,7 +14,6 @@
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 2rem;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
 .error-icon {
@@ -67,12 +66,11 @@
 
 .error-btn-primary {
   background: var(--accent);
-  color: white;
+  color: var(--bg);
 }
 
 .error-btn-primary:hover {
-  background: #4a8fd8;
-  box-shadow: 0 2px 8px rgba(88, 166, 255, 0.3);
+  opacity: 0.9;
 }
 
 .error-btn-primary:active {


### PR DESCRIPTION
## What changed

Fixes design-token and dark-mode consistency violations in `src/pages/ErrorPage.css`, the stylesheet backing the `/404` `NotFound` page (illustration + CTAs described in the issue were already implemented and already tested — see below).

- Removed `box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);` from `.error-content`. This directly contradicted the documented design system rule in `docs/DESIGN_SYSTEM.md`: *"The system is intentionally flat. Elevation is communicated through surface tone, not shadow... The product UI does not use shadow."*
- Replaced hardcoded `color: white` on `.error-btn-primary` with `color: var(--bg)`, matching the dominant established pattern for accent-background buttons elsewhere in the codebase (`NetworkMismatchBanner`, `OfflineBanner`, `AutopayPage`, `CollateralSubstitutionModal`, `DatePicker`, and others all pair `background: var(--accent)` with `color: var(--bg)`).
- Replaced the hardcoded hover state (`background: #4a8fd8; box-shadow: 0 2px 8px rgba(88, 166, 255, 0.3);`) with `opacity: 0.9`, mirroring the exact hover convention already used for accent-background elements in `DatePicker.css` (`.date-picker__cell--selected:hover`).

## Why

Closes #459.

The issue ("Themed 404 with helpful CTAs") turned out to already be substantially implemented: `src/pages/NotFound.tsx` already has a themed SVG illustration (reduced-motion-gated twinkle animation, `currentColor`-based so it works in both themes) and working CTAs (Go back / Go to Dashboard, Contact Support), all wired into `src/App.tsx`'s wildcard route, all covered by an existing, passing 9-test suite including two snapshot tests.

What genuinely needed fixing was one of the issue's own explicit guidelines — **"Design-token + dark-mode consistency"** — which the existing `ErrorPage.css` violated in three concrete, verifiable ways (listed above). This PR scopes to exactly those fixes rather than introducing new illustration/CTA content the issue didn't ask for.

## How it was tested

✓ src/pages/NotFound.test.tsx (9 tests) 918ms
✓ NotFound > renders a <main> landmark labelled by the h1 439ms
✓ NotFound > renders heading and body copy 79ms
✓ NotFound > shows "Go back" button when history is available 76ms
✓ NotFound > shows "Go to Dashboard" link when there is no history 124ms
✓ NotFound > calls history.go(-1) on Go back click 59ms
✓ NotFound > Go to Dashboard link points to / 84ms
✓ NotFound > SVG illustration is aria-hidden 10ms
✓ NotFound > matches snapshot with history 33ms
✓ NotFound > matches snapshot without history 11ms

Test Files 1 passed (1)
Tests 9 passed (9)

This is a CSS-only change (no markup/class-name changes), so the existing snapshot tests remain valid and pass unmodified.

## Limitations / things I noticed but left out of scope

- **`npm run lint` is broken on a fresh clone**: the `lint` script (`eslint .`) references `eslint`, which is not listed in `package.json`'s `devDependencies` and does not install via `npm install`. Confirmed via a clean install — this is a pre-existing repo configuration gap, unrelated to this change, and out of scope to fix here.
- **Pre-existing test failures**: a full `npm test -- --run` shows 99 failing tests across 23 files (e.g. `src/services/__tests__/linkedAccounts.test.ts` — a 5000ms timeout and a timestamp-equality assertion comparing a value to itself, both looking like test-environment flakiness rather than real bugs). Confirmed via `git stash` that this exact failure count (99 failed / 792 passed) is identical with and without this PR's changes — proof this is pre-existing, not a regression introduced here.
- **`npm audit` reports 11 vulnerabilities** (1 low, 3 moderate, 6 high, 1 critical) in the dependency tree post-install. Pre-existing, unrelated to this change; not addressed here since `npm audit fix --force` risks breaking unrelated major-version bumps well outside this issue's scope.
- Added a `.gitattributes` (`* text=auto eol=lf`) after discovering the working tree had CRLF line endings with no attributes file to normalize it — required to produce a clean, reviewable diff at all.