### PR TITLE
feat: currency + language settings

### DIFF
--- a/src/pages/settings/Locale.tsx
+++ b/src/pages/settings/Locale.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+
+export const LocaleSettings: React.FC = () => {
+  const [currency, setCurrency] = useState('USD');
+  const [language, setLanguage] = useState('en');
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const handleSave = () => {
+    setIsSaving(true);
+    setSaveMessage(null);
+    // Simulate API call
+    setTimeout(() => {
+      setIsSaving(false);
+      setSaveMessage({ type: 'success', text: 'Settings updated successfully.' });
+    }, 800);
+  };
+
+  return (
+    <div className="p-6 bg-white rounded-lg border border-gray-200 shadow-sm max-w-xl" data-testid="locale-settings-container">
+      <h2 className="text-xl font-semibold text-gray-900 mb-2">Regional Preferences</h2>
+      <p className="text-sm text-gray-600 mb-6">
+        Configure your preferred currency and display language for the GrantFox FWC26 campaign interface.
+      </p>
+
+      {saveMessage && (
+        <div 
+          className={`mb-6 p-3 text-sm rounded-md border ${
+            saveMessage.type === 'success' ? 'bg-green-50 text-green-700 border-green-200' : 'bg-red-50 text-red-700 border-red-200'
+          }`}
+          role="alert"
+        >
+          {saveMessage.text}
+        </div>
+      )}
+
+      <div className="space-y-5 mb-8">
+        <div>
+          <label htmlFor="currency-select" className="block text-sm font-medium text-gray-700 mb-1">
+            Display Currency
+          </label>
+          <div className="relative">
+            <select
+              id="currency-select"
+              value={currency}
+              onChange={(e) => setCurrency(e.target.value)}
+              className="w-full bg-white border border-gray-300 rounded-md py-2.5 pl-3 pr-10 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors"
+              data-testid="currency-select"
+            >
+              <option value="USD">USD ($) - US Dollar</option>
+              <option value="EUR">EUR (€) - Euro</option>
+              <option value="GBP">GBP (£) - British Pound</option>
+              <option value="JPY">JPY (¥) - Japanese Yen</option>
+              <option value="CAD">CAD ($) - Canadian Dollar</option>
+            </select>
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="language-select" className="block text-sm font-medium text-gray-700 mb-1">
+            Display Language
+          </label>
+          <div className="relative">
+            <select
+              id="language-select"
+              value={language}
+              onChange={(e) => setLanguage(e.target.value)}
+              className="w-full bg-white border border-gray-300 rounded-md py-2.5 pl-3 pr-10 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors"
+              data-testid="language-select"
+            >
+              <option value="en">English (US)</option>
+              <option value="es">Español (ES)</option>
+              <option value="fr">Français (FR)</option>
+              <option value="de">Deutsch (DE)</option>
+              <option value="ja">日本語 (JA)</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          onClick={handleSave}
+          disabled={isSaving}
+          className="px-5 py-2.5 bg-indigo-600 text-white font-medium text-sm rounded-md hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all shadow-sm"
+          data-testid="save-preferences-button"
+        >
+          {isSaving ? 'Saving...' : 'Save Preferences'}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/settings/__tests__/Locale.test.tsx
+++ b/src/pages/settings/__tests__/Locale.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { LocaleSettings } from '../Locale';
+
+describe('LocaleSettings', () => {
+  it('renders the component with default values', () => {
+    render(<LocaleSettings />);
+    
+    expect(screen.getByTestId('locale-settings-container')).toBeInTheDocument();
+    expect(screen.getByText('Regional Preferences')).toBeInTheDocument();
+    
+    const currencySelect = screen.getByTestId('currency-select') as HTMLSelectElement;
+    expect(currencySelect.value).toBe('USD');
+    
+    const languageSelect = screen.getByTestId('language-select') as HTMLSelectElement;
+    expect(languageSelect.value).toBe('en');
+  });
+
+  it('allows user to change currency and language', () => {
+    render(<LocaleSettings />);
+    
+    const currencySelect = screen.getByTestId('currency-select');
+    fireEvent.change(currencySelect, { target: { value: 'EUR' } });
+    expect((currencySelect as HTMLSelectElement).value).toBe('EUR');
+    
+    const languageSelect = screen.getByTestId('language-select');
+    fireEvent.change(languageSelect, { target: { value: 'es' } });
+    expect((languageSelect as HTMLSelectElement).value).toBe('es');
+  });
+
+  it('displays saving state and success message upon saving', () => {
+    vi.useFakeTimers();
+    render(<LocaleSettings />);
+    
+    const saveButton = screen.getByTestId('save-preferences-button');
+    fireEvent.click(saveButton);
+    
+    expect(saveButton).toHaveTextContent('Saving...');
+    expect(saveButton).toBeDisabled();
+    
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    
+    expect(screen.getByText('Settings updated successfully.')).toBeInTheDocument();
+    expect(saveButton).toHaveTextContent('Save Preferences');
+    expect(saveButton).not.toBeDisabled();
+    
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
Closes #435 


This PR implements user-selectable currency and language settings for the GrantFox FWC26 campaign.

Changes:
- Created LocaleSettings component (src/pages/Settings/Locale.tsx)
- Added a dropdown selector for Display Currency (USD, EUR, GBP, JPY, CAD)
- Added a dropdown selector for Display Language (English, Spanish, French, German, Japanese)
- Implemented a simulated save state with a success alert message and disabled button states during the save operation
- Added comprehensive unit tests (src/pages/Settings/__tests__/Locale.test.tsx) for rendering, user interactions, and save state simulation

Acceptance Criteria Met:
- Implementation matches the issue description
- Tests added and passing
- Code styled using existing Tailwind CSS patterns
- Output handles edge cases (e.g. disabling the submit button while saving)