### PR TITLE
fix: RepaymentVisualizer responsive

### DIFF
--- a/src/components/RepaymentVisualizer.tsx
+++ b/src/components/RepaymentVisualizer.tsx
@@ -284,7 +284,7 @@ function TooltipBubble({ data }: { data: TooltipData }) {
     <div
       role="status"
       aria-live="polite"
-      className="p-2 sm:p-3 text-xs min-w-[140px] sm:min-w-[160px]"
+      className="p-2 sm:p-3 lg:p-4 text-xs lg:text-sm min-w-[140px] sm:min-w-[160px] lg:min-w-[200px]"
       style={{
         background: 'var(--surface-raised, #1c2230)',
         border: `1px solid var(--border, ${COLOR.border})`,
@@ -370,7 +370,7 @@ function SRTable({ schedule, caption }: SRTableProps) {
 function Legend() {
   return (
     <div
-      className="flex flex-wrap gap-3 sm:gap-4 mt-3 sm:mt-4 text-xs"
+      className="flex flex-wrap gap-3 sm:gap-4 lg:gap-6 mt-3 sm:mt-4 lg:mt-6 text-xs lg:text-sm"
       style={{ color: `var(--muted, ${COLOR.muted})` }}
       aria-hidden="true"
     >
@@ -559,14 +559,14 @@ export function RepaymentVisualizer({
   return (
     <section
       aria-label="Repayment plan visualizer"
-      className="p-4 sm:p-5 md:p-6"
+      className="p-4 sm:p-5 md:p-6 lg:p-8"
       style={{
         background: `var(--surface, ${COLOR.surface})`,
         border: `1px solid var(--border, ${COLOR.border})`,
         borderRadius: 10,
       }}
     >
-      <header className="mb-4 sm:mb-6 flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4">
+      <header className="mb-4 sm:mb-6 lg:mb-8 flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 lg:gap-6">
         <h2
           style={{
             fontSize: '1rem',

--- a/src/components/__tests__/RepaymentVisualizer.test.tsx
+++ b/src/components/__tests__/RepaymentVisualizer.test.tsx
@@ -217,14 +217,14 @@ describe('RepaymentVisualizer — responsive breakpoints', () => {
   it('section wrapper has responsive padding classes', () => {
     render(<RepaymentVisualizer {...BASE} />);
     const section = screen.getByRole('region', { name: 'Repayment plan visualizer' });
-    expect(section).toHaveClass('p-4', 'sm:p-5', 'md:p-6');
+    expect(section).toHaveClass('p-4', 'sm:p-5', 'md:p-6', 'lg:p-8');
   });
 
   it('header uses responsive flex layout', () => {
     render(<RepaymentVisualizer {...BASE} />);
     const heading = screen.getByText('Repayment Plan');
     const header = heading.parentElement;
-    expect(header).toHaveClass('flex', 'flex-col', 'sm:flex-row', 'sm:justify-between');
+    expect(header).toHaveClass('flex', 'flex-col', 'sm:flex-row', 'sm:justify-between', 'mb-4', 'sm:mb-6', 'lg:mb-8', 'gap-1', 'sm:gap-4', 'lg:gap-6');
   });
 
   it('legend uses responsive flex layout', () => {
@@ -232,7 +232,15 @@ describe('RepaymentVisualizer — responsive breakpoints', () => {
     // Find legend container via text
     const legendItem = screen.getAllByText(/Principal remaining/i)[0];
     const legendWrapper = legendItem.parentElement;
-    expect(legendWrapper).toHaveClass('flex', 'flex-wrap', 'gap-3', 'sm:gap-4');
+    expect(legendWrapper).toHaveClass('flex', 'flex-wrap', 'gap-3', 'sm:gap-4', 'lg:gap-6', 'mt-3', 'sm:mt-4', 'lg:mt-6', 'text-xs', 'lg:text-sm');
+  });
+
+  it('tooltip uses responsive padding and min-width', () => {
+    render(<RepaymentVisualizer {...BASE} />);
+    const svg = screen.getByRole('img');
+    fireEvent.mouseMove(svg, { clientX: 100, clientY: 100 });
+    const tooltip = screen.getByRole('status');
+    expect(tooltip).toHaveClass('p-2', 'sm:p-3', 'lg:p-4', 'min-w-[140px]', 'sm:min-w-[160px]', 'lg:min-w-[200px]', 'text-xs', 'lg:text-sm');
   });
 
   it('visible table wrapper has responsive negative margin for bleed', () => {


### PR DESCRIPTION
 I have completed the task and improved the responsiveness for the RepaymentVisualizer component on wider screens.

  Here is a summary of the actions taken:

  1. Created a new branch: breakpoint-audit.
  2. Found the target file: I noticed that the file is located at src/components/RepaymentVisualizer.tsx (and not
  src/pages/RepaymentVisualizer.tsx as mentioned in the issue description).
  3. Audited and Adjusted Breakpoints:
      • Added lg: Tailwind breakpoint classes to the TooltipBubble, Legend, Section wrapper, and Header. This ensures
      proper padding, margins, flex layouts, and font sizing on wider viewports (for screens larger than typical
      tablets).
  4. Added Focused Tests:
      • Updated the existing responsive breakpoint tests in src/components/__tests__/RepaymentVisualizer.test.tsx to
      assert the newly added lg: responsive classes.
      • Added a new test tooltip uses responsive padding and min-width specifically to cover the tooltip bubble
      layout adjustments.
  5. Tested and Committed:
      • Ran npm test -- src/components/__tests__/RepaymentVisualizer.test.tsx via Vitest which passed all 28 tests
      smoothly.
      • Staged and committed the changes with the requested commit message: fix: RepaymentVisualizer responsive.


  The codebase is ready for your review and pull request. Let me know if there's anything else you need!
closes #608 