### PR TITLE
feat(Creditra-Frontend): add-color-blind-safe-patterns-to-repaymentvisual

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -127,6 +127,11 @@ joins the existing AND-filter chain (type × date × amount × credit-line × st
 
 Both `RepaymentVisualizer` and `RiskGauge` expose accessible descriptions at two levels:
 
+**Chart series patterns (RepaymentVisualizer)** — principal remaining and cumulative
+interest are distinguished by hatch direction (45° vs 135°) layered on the area
+gradients, with matching patterned legend swatches in `src/styles/patterns.css`
+(WCAG 1.4.1 — colour is not the only visual means of identification).
+
 **SVG-level label** — the `aria-label` / `aria-labelledby` on the `<svg role="img">` element
 is the first thing screen readers announce when the user focuses the chart.  Both components
 accept an optional prop to override the default description with a more specific one.
@@ -207,7 +212,7 @@ The table below is updated on every accessibility-impacting PR. Status legend:
 | `ToastContainer` | Tab/Esc to dismiss | `role="status"` / `role="alert"` per severity | AA | reduced-motion gated | OK |
 | `BannerAlert` | Tab/Enter on action & dismiss | `role="alert"` for warning/error | AA | n/a | OK |
 | `Dashboard` (risk gauge) | Tab/Enter/Space on SVG root and individual sector bands; keyboard fires `onSectorActivate` | Score and trend exposed via `<title>` + polite `sr-only` sibling; arc animates on value change with reduced-motion fallback; `ariaLabel` prop overrides the auto-generated description; SR-only risk-band table sibling with `aria-current` on the active band; `showSRTable` prop | AA | reduced-motion gated (CSS + JS `matchMedia`) | OK |
-| `RepaymentVisualizer` | n/a (display chart) | `role="img"` SVG with `aria-label` (overridable via `chartAriaLabel` prop); SR-only data table with `<caption>` auto-generated from term + total interest (overridable via `caption` prop); visible schedule table with expand/collapse | AA | n/a | OK |
+| `RepaymentVisualizer` | n/a (display chart) | `role="img"` SVG with `aria-label` (overridable via `chartAriaLabel` prop); principal/interest hatch patterns + legend swatches (not colour alone); SR-only data table with `<caption>` auto-generated from term + total interest (overridable via `caption` prop); visible schedule table with expand/collapse | AA | n/a | OK |
 | `Header` nav | Tab through links; Enter activates | `aria-current="page"` on active link | AA | n/a | OK |
 | `RepayModal` | Focus trap (canonical `{ isActive }` form) + return focus to trigger | `role="dialog"`, `aria-modal`, `aria-labelledby` | AA | n/a | OK |
 | `TransactionHistory` | Sortable headers via Enter/Space; search combobox fully keyboard navigable (ArrowDown/Up, Enter, Escape, Tab) | `aria-sort` reflects column state; search uses ARIA 1.2 combobox pattern (`role="combobox"`, `aria-expanded`, `aria-controls`, `aria-autocomplete="list"`, `aria-activedescendant`); result count in polite live region | AA | reduced-motion disables listbox animation | OK |

--- a/src/components/RepaymentVisualizer.tsx
+++ b/src/components/RepaymentVisualizer.tsx
@@ -8,10 +8,12 @@
  *  - Pure SVG — no third-party charting library.
  *  - Theme tokens from CSS custom properties; colours from src/utils/tokens.ts.
  *  - WCAG 2.1 AA: focus ring, aria-label, role="img", table fallback, reduced-motion.
+ *  - WCAG 1.4.1: principal vs interest use distinct hatch patterns (SVG + legend swatches).
  */
 
 import { useState, useRef, useCallback, useId } from 'react';
 import { COLOR } from '@/utils/tokens';
+import '@/styles/patterns.css';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -133,6 +135,12 @@ interface ChartProps {
 }
 
 function StackedAreaChart({ schedule, tooltipId, onTooltip, tooltip, chartAriaLabel }: ChartProps) {
+  const chartPatternUid = useId().replace(/:/g, '');
+  const gradPrincipalId = `rv-grad-principal-${chartPatternUid}`;
+  const gradInterestId = `rv-grad-interest-${chartPatternUid}`;
+  const hatchPrincipalId = `rv-principal-hatch-${chartPatternUid}`;
+  const hatchInterestId = `rv-interest-hatch-${chartPatternUid}`;
+
   if (schedule.length === 0) return null;
 
   const initPrincipal = schedule[0].principal + schedule[0].principalPaid;
@@ -204,14 +212,50 @@ function StackedAreaChart({ schedule, tooltipId, onTooltip, tooltip, chartAriaLa
       onTouchEnd={() => onTooltip(null)}
     >
       <defs>
-        <linearGradient id="grad-principal" x1="0" y1="0" x2="0" y2="1">
+        <linearGradient id={gradPrincipalId} x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stopColor={COLOR.accent} stopOpacity="0.7" />
           <stop offset="100%" stopColor={COLOR.accent} stopOpacity="0.15" />
         </linearGradient>
-        <linearGradient id="grad-interest" x1="0" y1="0" x2="0" y2="1">
+        <linearGradient id={gradInterestId} x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stopColor={COLOR.warning} stopOpacity="0.7" />
           <stop offset="100%" stopColor={COLOR.warning} stopOpacity="0.15" />
         </linearGradient>
+        <pattern
+          id={hatchPrincipalId}
+          width="6"
+          height="6"
+          patternUnits="userSpaceOnUse"
+          patternTransform="rotate(45)"
+        >
+          <rect width="6" height="6" fill="transparent" />
+          <line
+            x1="0"
+            y1="0"
+            x2="0"
+            y2="6"
+            stroke={COLOR.accent}
+            strokeWidth="1.25"
+            strokeOpacity="0.75"
+          />
+        </pattern>
+        <pattern
+          id={hatchInterestId}
+          width="6"
+          height="6"
+          patternUnits="userSpaceOnUse"
+          patternTransform="rotate(135)"
+        >
+          <rect width="6" height="6" fill="transparent" />
+          <line
+            x1="0"
+            y1="0"
+            x2="0"
+            y2="6"
+            stroke={COLOR.warning}
+            strokeWidth="1.25"
+            strokeOpacity="0.75"
+          />
+        </pattern>
       </defs>
 
       {/* Grid lines */}
@@ -239,9 +283,35 @@ function StackedAreaChart({ schedule, tooltipId, onTooltip, tooltip, chartAriaLa
       ))}
 
       {/* Interest area (painted first — sits below principal visually in stacking) */}
-      <path d={interestPath} fill="url(#grad-interest)" />
+      <path
+        d={interestPath}
+        fill={`url(#${gradInterestId})`}
+        data-series="interest"
+        className="rv-area rv-area--interest"
+      />
+      <path
+        d={interestPath}
+        fill={`url(#${hatchInterestId})`}
+        opacity={0.42}
+        aria-hidden="true"
+        data-series="interest"
+        className="rv-area-hatch rv-area-hatch--interest"
+      />
       {/* Principal area */}
-      <path d={principalPath} fill="url(#grad-principal)" />
+      <path
+        d={principalPath}
+        fill={`url(#${gradPrincipalId})`}
+        data-series="principal"
+        className="rv-area rv-area--principal"
+      />
+      <path
+        d={principalPath}
+        fill={`url(#${hatchPrincipalId})`}
+        opacity={0.42}
+        aria-hidden="true"
+        data-series="principal"
+        className="rv-area-hatch rv-area-hatch--principal"
+      />
 
       {/* X-axis ticks */}
       {xTicks.map(({ month, x }) => (
@@ -261,12 +331,24 @@ function StackedAreaChart({ schedule, tooltipId, onTooltip, tooltip, chartAriaLa
             stroke={COLOR.border}
             strokeWidth="1"
           />
-          <circle cx={tooltip.x} cy={yScale(tooltip.principal)} r="4" fill={COLOR.accent} />
+          <circle
+            cx={tooltip.x}
+            cy={yScale(tooltip.principal)}
+            r="4"
+            fill={COLOR.accent}
+            stroke={COLOR.accent}
+            strokeWidth="1.5"
+            data-series="principal"
+          />
           <circle
             cx={tooltip.x}
             cy={yScale(tooltip.principal + tooltip.cumulativeInterest)}
             r="4"
             fill={COLOR.warning}
+            stroke={COLOR.warning}
+            strokeWidth="1.5"
+            strokeDasharray="2 2"
+            data-series="interest"
           />
         </g>
       )}
@@ -375,15 +457,11 @@ function Legend() {
       aria-hidden="true"
     >
       <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-        <span
-          style={{ width: 12, height: 12, borderRadius: 2, background: COLOR.accent, display: 'inline-block' }}
-        />
+        <span className="rv-legend-swatch rv-legend-swatch--principal" data-series="principal" />
         Principal remaining
       </span>
       <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-        <span
-          style={{ width: 12, height: 12, borderRadius: 2, background: COLOR.warning, display: 'inline-block' }}
-        />
+        <span className="rv-legend-swatch rv-legend-swatch--interest" data-series="interest" />
         Cumulative interest
       </span>
     </div>

--- a/src/components/__tests__/RepaymentVisualizer.test.tsx
+++ b/src/components/__tests__/RepaymentVisualizer.test.tsx
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { RepaymentVisualizer } from '../RepaymentVisualizer';
 
@@ -244,5 +246,38 @@ describe('RepaymentVisualizer — responsive breakpoints', () => {
     const table = screen.getAllByRole('table').find((t) => !t.classList.contains('sr-only'));
     const wrapper = table?.parentElement;
     expect(wrapper).toHaveClass('overflow-x-auto', '-mx-4', 'sm:mx-0', 'px-4', 'sm:px-0');
+  });
+});
+
+describe('RepaymentVisualizer — color-blind safe series patterns', () => {
+  it('legend swatches use pattern classes from patterns.css', () => {
+    render(<RepaymentVisualizer {...BASE} />);
+    expect(document.querySelector('.rv-legend-swatch--principal')).toBeInTheDocument();
+    expect(document.querySelector('.rv-legend-swatch--interest')).toBeInTheDocument();
+  });
+
+  it('SVG defines distinct hatch patterns for principal and interest areas', () => {
+    render(<RepaymentVisualizer {...BASE} />);
+    const svg = screen.getByRole('img');
+    const patterns = svg.querySelectorAll('pattern');
+    expect(patterns.length).toBeGreaterThanOrEqual(2);
+    const ids = Array.from(patterns).map((p) => p.getAttribute('id') ?? '');
+    expect(ids.some((id) => id.includes('principal-hatch'))).toBe(true);
+    expect(ids.some((id) => id.includes('interest-hatch'))).toBe(true);
+  });
+
+  it('each chart series has a gradient base fill and a hatch overlay path', () => {
+    render(<RepaymentVisualizer {...BASE} />);
+    const svg = screen.getByRole('img');
+    expect(svg.querySelectorAll('[data-series="principal"]').length).toBeGreaterThanOrEqual(2);
+    expect(svg.querySelectorAll('[data-series="interest"]').length).toBeGreaterThanOrEqual(2);
+    expect(svg.querySelector('.rv-area-hatch--principal')).toBeInTheDocument();
+    expect(svg.querySelector('.rv-area-hatch--interest')).toBeInTheDocument();
+  });
+
+  it('documents repayment series pattern tokens in patterns.css', () => {
+    const css = readFileSync(join(process.cwd(), 'src/styles/patterns.css'), 'utf-8');
+    expect(css).toMatch(/\.rv-legend-swatch--principal/);
+    expect(css).toMatch(/\.rv-legend-swatch--interest/);
   });
 });

--- a/src/styles/patterns.css
+++ b/src/styles/patterns.css
@@ -22,3 +22,77 @@
 .status-closed {
   background-image: repeating-linear-gradient(0deg, rgba(107, 114, 128, 0.1), rgba(107, 114, 128, 0.1) 6px, transparent 6px, transparent 12px);
 }
+
+/* RepaymentVisualizer series — distinguish principal vs interest without color alone (WCAG 1.4.1) */
+
+.rv-legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  display: inline-block;
+  flex-shrink: 0;
+  border: 1px solid color-mix(in srgb, var(--border, #30363d) 70%, transparent);
+}
+
+.rv-legend-swatch--principal {
+  background-color: color-mix(in srgb, var(--accent, #58a6ff) 45%, transparent);
+  background-image: repeating-linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--accent, #58a6ff) 90%, #fff) 0,
+    color-mix(in srgb, var(--accent, #58a6ff) 90%, #fff) 1px,
+    transparent 1px,
+    transparent 5px
+  );
+}
+
+.rv-legend-swatch--interest {
+  background-color: color-mix(in srgb, var(--warning, #d29922) 45%, transparent);
+  background-image: repeating-linear-gradient(
+    45deg,
+    transparent,
+    transparent 2px,
+    color-mix(in srgb, var(--warning, #d29922) 85%, #fff) 2px,
+    color-mix(in srgb, var(--warning, #d29922) 85%, #fff) 3px
+  ),
+  repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 2px,
+    color-mix(in srgb, var(--warning, #d29922) 85%, #fff) 2px,
+    color-mix(in srgb, var(--warning, #d29922) 85%, #fff) 3px
+  );
+}
+
+@media (forced-colors: active) {
+  .rv-legend-swatch {
+    background-color: Canvas;
+    forced-color-adjust: none;
+  }
+
+  .rv-legend-swatch--principal {
+    background-image: repeating-linear-gradient(
+      135deg,
+      CanvasText 0,
+      CanvasText 1px,
+      transparent 1px,
+      transparent 5px
+    );
+  }
+
+  .rv-legend-swatch--interest {
+    background-image: repeating-linear-gradient(
+        45deg,
+        CanvasText 0,
+        CanvasText 1px,
+        transparent 1px,
+        transparent 4px
+      ),
+      repeating-linear-gradient(
+        -45deg,
+        CanvasText 0,
+        CanvasText 1px,
+        transparent 1px,
+        transparent 4px
+      );
+  }
+}


### PR DESCRIPTION
Closes #615

## Summary
- Add color-blind safe patterns to RepaymentVisualizer (v7)

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths