### PR TITLE
feat: pull-to-refresh

### DIFF
--- a/src/hooks/usePullToRefresh.test.ts
+++ b/src/hooks/usePullToRefresh.test.ts
@@ -1,0 +1,145 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePullToRefresh } from './usePullToRefresh';
+import { describe, it, expect, vi } from 'vitest';
+
+describe('usePullToRefresh', () => {
+  it('should initialize with default values', () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+    expect(result.current.pullDistance).toBe(0);
+    expect(result.current.isRefreshing).toBe(false);
+    expect(typeof result.current.handlers.onTouchStart).toBe('function');
+    expect(typeof result.current.handlers.onTouchMove).toBe('function');
+    expect(typeof result.current.handlers.onTouchEnd).toBe('function');
+  });
+
+  it('should not allow pulling if disabled is true', () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      usePullToRefresh({ onRefresh, disabled: true })
+    );
+
+    const mockEventStart = {
+      touches: [{ clientY: 100 }],
+      currentTarget: { scrollTop: 0 }
+    } as unknown as React.TouchEvent;
+
+    act(() => {
+      result.current.handlers.onTouchStart(mockEventStart);
+    });
+
+    const mockEventMove = {
+      touches: [{ clientY: 200 }],
+      cancelable: true,
+      preventDefault: vi.fn(),
+    } as unknown as React.TouchEvent;
+
+    act(() => {
+      result.current.handlers.onTouchMove(mockEventMove);
+    });
+
+    expect(result.current.pullDistance).toBe(0);
+  });
+
+  it('should calculate pull distance correctly', () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+    const mockEventStart = {
+      touches: [{ clientY: 100 }],
+      currentTarget: { scrollTop: 0 }
+    } as unknown as React.TouchEvent;
+
+    act(() => {
+      result.current.handlers.onTouchStart(mockEventStart);
+    });
+
+    const preventDefault = vi.fn();
+    const mockEventMove = {
+      touches: [{ clientY: 200 }], // 100px pull
+      cancelable: true,
+      preventDefault,
+    } as unknown as React.TouchEvent;
+
+    act(() => {
+      result.current.handlers.onTouchMove(mockEventMove);
+    });
+
+    // Distance is diff * 0.5 = 100 * 0.5 = 50
+    expect(result.current.pullDistance).toBe(50);
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it('should trigger refresh if pulled past threshold', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      usePullToRefresh({ onRefresh, pullThreshold: 50 })
+    );
+
+    const mockEventStart = {
+      touches: [{ clientY: 100 }],
+      currentTarget: { scrollTop: 0 }
+    } as unknown as React.TouchEvent;
+
+    act(() => {
+      result.current.handlers.onTouchStart(mockEventStart);
+    });
+
+    const mockEventMove = {
+      touches: [{ clientY: 300 }], // 200px pull -> 100 resistance
+      cancelable: true,
+      preventDefault: vi.fn(),
+    } as unknown as React.TouchEvent;
+
+    act(() => {
+      result.current.handlers.onTouchMove(mockEventMove);
+    });
+
+    expect(result.current.pullDistance).toBe(100);
+
+    await act(async () => {
+      await result.current.handlers.onTouchEnd();
+    });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(result.current.isRefreshing).toBe(false);
+    expect(result.current.pullDistance).toBe(0);
+  });
+
+  it('should not trigger refresh if not pulled past threshold', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      usePullToRefresh({ onRefresh, pullThreshold: 80 })
+    );
+
+    const mockEventStart = {
+      touches: [{ clientY: 100 }],
+      currentTarget: { scrollTop: 0 }
+    } as unknown as React.TouchEvent;
+
+    act(() => {
+      result.current.handlers.onTouchStart(mockEventStart);
+    });
+
+    const mockEventMove = {
+      touches: [{ clientY: 150 }], // 50px pull -> 25 resistance
+      cancelable: true,
+      preventDefault: vi.fn(),
+    } as unknown as React.TouchEvent;
+
+    act(() => {
+      result.current.handlers.onTouchMove(mockEventMove);
+    });
+
+    expect(result.current.pullDistance).toBe(25);
+
+    await act(async () => {
+      await result.current.handlers.onTouchEnd();
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(result.current.isRefreshing).toBe(false);
+    expect(result.current.pullDistance).toBe(0);
+  });
+});

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,93 @@
+import { useState, useCallback, useRef } from 'react';
+
+interface UsePullToRefreshProps {
+  onRefresh: () => Promise<void>;
+  pullThreshold?: number;
+  maxPullDistance?: number;
+  disabled?: boolean;
+}
+
+export function usePullToRefresh({
+  onRefresh,
+  pullThreshold = 80,
+  maxPullDistance = 150,
+  disabled = false,
+}: UsePullToRefreshProps) {
+  const [pullDistance, setPullDistance] = useState(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const startYRef = useRef(0);
+  const currentYRef = useRef(0);
+  const isPullingRef = useRef(false);
+
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent | TouchEvent) => {
+      if (disabled || isRefreshing) return;
+      
+      // Ensure we are at the top of the container/window before allowing pull
+      const scrollTop =
+        (e.currentTarget as HTMLElement).scrollTop ||
+        document.documentElement.scrollTop;
+        
+      if (scrollTop > 0) return;
+
+      startYRef.current = e.touches[0].clientY;
+      currentYRef.current = startYRef.current;
+      isPullingRef.current = true;
+    },
+    [disabled, isRefreshing]
+  );
+
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent | TouchEvent) => {
+      if (!isPullingRef.current || disabled || isRefreshing) return;
+
+      const currentY = e.touches[0].clientY;
+      currentYRef.current = currentY;
+      const diff = currentY - startYRef.current;
+
+      // Only allow pulling down
+      if (diff > 0) {
+        // Prevent default to avoid browser's native pull-to-refresh
+        if (e.cancelable) {
+          e.preventDefault();
+        }
+        // Add some resistance
+        const resistance = diff * 0.5;
+        const newDistance = Math.min(resistance, maxPullDistance);
+        setPullDistance(newDistance);
+      } else {
+        setPullDistance(0);
+      }
+    },
+    [disabled, isRefreshing, maxPullDistance]
+  );
+
+  const handleTouchEnd = useCallback(async () => {
+    if (!isPullingRef.current || disabled || isRefreshing) return;
+    isPullingRef.current = false;
+
+    if (pullDistance >= pullThreshold) {
+      setIsRefreshing(true);
+      setPullDistance(pullThreshold); // keep it at threshold during refresh
+
+      try {
+        await onRefresh();
+      } finally {
+        setIsRefreshing(false);
+        setPullDistance(0);
+      }
+    } else {
+      setPullDistance(0);
+    }
+  }, [disabled, isRefreshing, onRefresh, pullDistance, pullThreshold]);
+
+  return {
+    pullDistance,
+    isRefreshing,
+    handlers: {
+      onTouchStart: handleTouchStart,
+      onTouchMove: handleTouchMove,
+      onTouchEnd: handleTouchEnd,
+    },
+  };
+}


### PR DESCRIPTION
Closes #469 


This PR resolves the UI/UX issue for mobile lists by introducing a `usePullToRefresh` hook that enables pull-to-refresh gestures.

## Changes
- **Added `src/hooks/usePullToRefresh.ts`:** 
  - Tracks `onTouchStart`, `onTouchMove`, and `onTouchEnd` events.
  - Calculates pull distance and applies resistance when pulling down.
  - Prevents native browser refresh and triggers the provided `onRefresh` callback when the `pullThreshold` is met.
  - Verifies the user is at the top of the scrolling container (`scrollTop === 0`) before initiating the gesture.
- **Added `src/hooks/usePullToRefresh.test.ts`:** 
  - Vitest suite covering default values, disabled state, resistance calculations, and threshold boundaries.

## Acceptance Criteria
- [x] Implementation matches issue description.
- [x] Unit tests added and passing.
- [x] Code adheres to repository linting and style guidelines.
- [x] Secure and robust against edge cases (e.g. scroll position, rapid swiping).

## Testing
- Tests run and verified locally via `npx vitest run src/hooks/usePullToRefresh.test.ts`. 
- Hook simulates gestures accurately and intercepts touch events conditionally.