### PR TITLE
Task/repaypage reduced v7

### DIFF
--- a/src/pages/RepayPage.tsx
+++ b/src/pages/RepayPage.tsx
@@ -42,6 +42,16 @@ const SEVERITY_CONFIG = {
   },
 } as const;
 
+/**
+ * RepayPage — reduced-motion strategy
+ *
+ * All CSS transitions are neutralised globally by the
+ * `prefers-reduced-motion: reduce` reset in src/index.css (animation/transition
+ * durations collapsed to 0.01 ms on `*`).  The `motion-reduce:transition-none`
+ * and `motion-reduce:duration-0` Tailwind classes on the toggle switch and
+ * progress-bar fills below are defence-in-depth: they make the intent
+ * self-documenting and ensure correctness even if the global reset is removed.
+ */
 export default function RepayPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -383,13 +393,13 @@ export default function RepayPage() {
                     </div>
                     <div className="h-2 w-full overflow-hidden rounded-full bg-border">
                       <div
-                        className="h-full rounded-full bg-red-500/30 transition-all"
+                        className="h-full rounded-full bg-red-500/30 transition-all motion-reduce:transition-none"
                         style={{ width: `${oldPct}%` }}
                       />
                     </div>
                     <div className="h-2 w-full overflow-hidden rounded-full bg-border">
                       <div
-                        className={`h-full rounded-full transition-all ${
+                        className={`h-full rounded-full transition-all motion-reduce:transition-none ${
                           remainingDebt === 0 ? 'bg-green-500' : 'bg-yellow-500'
                         }`}
                         style={{ width: `${newPct}%` }}
@@ -414,13 +424,13 @@ export default function RepayPage() {
                       role="switch"
                       aria-checked={isAutoSchedule}
                       onClick={() => setIsAutoSchedule(!isAutoSchedule)}
-                      className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                      className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out motion-reduce:transition-none motion-reduce:duration-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                         isAutoSchedule ? 'bg-accent' : 'bg-border'
                       }`}
                     >
                       <span
                         aria-hidden="true"
-                        className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                        className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out motion-reduce:transition-none motion-reduce:duration-0 ${
                           isAutoSchedule ? 'translate-x-5' : 'translate-x-0'
                         }`}
                       />

--- a/src/pages/__tests__/RepayPage.test.tsx
+++ b/src/pages/__tests__/RepayPage.test.tsx
@@ -119,6 +119,32 @@ describe('RepayPage', () => {
     expect(reviewBtn).not.toBeDisabled();
   });
 
+  describe('Reduced motion', () => {
+    it('toggle track has motion-reduce:transition-none and motion-reduce:duration-0', () => {
+      renderPage(['/repay?line=CL-2024-001']);
+      const toggle = screen.getByRole('switch', { name: /auto-schedule/i });
+      expect(toggle).toHaveClass('motion-reduce:transition-none');
+      expect(toggle).toHaveClass('motion-reduce:duration-0');
+    });
+
+    it('toggle knob has motion-reduce:transition-none and motion-reduce:duration-0', () => {
+      renderPage(['/repay?line=CL-2024-001']);
+      const toggle = screen.getByRole('switch', { name: /auto-schedule/i });
+      const knob = toggle.querySelector('span[aria-hidden="true"]');
+      expect(knob).toHaveClass('motion-reduce:transition-none');
+      expect(knob).toHaveClass('motion-reduce:duration-0');
+    });
+
+    it('progress bar fills have motion-reduce:transition-none', () => {
+      renderPage(['/repay?line=CL-2024-001']);
+      // Both preview progress bars carry transition-all + motion-reduce:transition-none
+      const fills = document
+        .querySelectorAll('.motion-reduce\\:transition-none');
+      // toggle track, toggle knob, old bar fill, new bar fill = at least 4
+      expect(fills.length).toBeGreaterThanOrEqual(4);
+    });
+  });
+
   describe('Focus-visible outline accessibility', () => {
     it('applies focus-visible classes on selection view back button and credit line options', () => {
       renderPage(['/repay']);

--- a/src/test/__mocks__/react-router-dom.tsx
+++ b/src/test/__mocks__/react-router-dom.tsx
@@ -13,8 +13,36 @@
 
 import { createElement, Fragment } from "react";
 
+/*
+ * Module-level "current location", set by BrowserRouter/MemoryRouter when they
+ * render and read back by useLocation/useSearchParams. Tests render
+ * synchronously and read immediately after, so a shared variable is sufficient
+ * for this stub (no reactive updates needed).
+ */
+let currentPathname = "/";
+let currentSearch = "";
+
+function applyEntry(entry: string) {
+  const qIndex = entry.indexOf("?");
+  currentPathname = qIndex >= 0 ? entry.slice(0, qIndex) : entry;
+  currentSearch = qIndex >= 0 ? entry.slice(qIndex) : "";
+}
+
 // BrowserRouter — renders children directly
 export function BrowserRouter({ children }: { children: React.ReactNode }) {
+  return createElement(Fragment, null, children);
+}
+
+// MemoryRouter — parses initialEntries[0] into the current location, then
+// renders children. Supports the `initialEntries={['/path?query']}` pattern.
+export function MemoryRouter({
+  children,
+  initialEntries,
+}: {
+  children: React.ReactNode;
+  initialEntries?: string[];
+}) {
+  applyEntry(initialEntries?.[0] ?? "/");
   return createElement(Fragment, null, children);
 }
 
@@ -44,13 +72,19 @@ export function Navigate(_props: Record<string, unknown>) {
   return null;
 }
 
+// useSearchParams — parses currentSearch into a URLSearchParams-like object
+export function useSearchParams() {
+  const params = new URLSearchParams(currentSearch);
+  return [params, (_: URLSearchParams) => {}] as const;
+}
+
 // Hooks
 export function useNavigate() {
   return () => {};
 }
 
 export function useLocation() {
-  return { pathname: "/", search: "", hash: "", state: null };
+  return { pathname: currentPathname, search: currentSearch, hash: "", state: null };
 }
 
 export function useParams() {


### PR DESCRIPTION
Closes #584 
## Summary

Adds a reduced-motion fallback for `RepayPage` using `motion-reduce:transition-none` and `motion-reduce:duration-0` on the toggle switch (track + knob) and both progress-bar fills.

The global reduced-motion reset in `src/index.css` already handles WCAG 2.1 AA compliance; these Tailwind utilities are defence-in-depth and make the intent self-documenting at the component level.

## Changes

- **`src/pages/RepayPage.tsx`** — added `motion-reduce:` classes to the toggle track, toggle knob, and progress-bar fills; doc comment explaining the strategy
- **`src/pages/__tests__/RepayPage.test.tsx`** — new `Reduced motion` describe block (3 assertions)
- **`src/test/__mocks__/react-router-dom.tsx`** — added `MemoryRouter` and `useSearchParams` exports

## Testing

- `npm test -- src/pages/__tests__/RepayPage.test.tsx` → 21/21 passing
- `npm run lint` → clean

## Note on test infrastructure

The RepayPage test suite was already broken on `main` (18/18 tests failing with `Element type is invalid: got undefined`) because the `react-router-dom` test stub was missing `MemoryRouter` and `useSearchParams` — both required by `RepayPage.tsx` and its test file. Added both exports to unblock the suite. Happy to split this into a separate PR if preferred.