### PR TITLE
[456] Add Command Palette (Cmd/Ctrl+K)

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -10,6 +10,17 @@ expected to behave.
 
 ---
 
+### Command palette (Cmd/Ctrl+K)
+
+Global keyboard navigation overlay (`src/components/CommandPalette.tsx`):
+
+- **Open:** `Cmd/Ctrl+K` anywhere, or the header **Search ⌘K** button
+- **Navigate:** Arrow keys; **Enter** activates; **Esc** closes and restores focus
+- Uses `useFocusTrap`, `useBodyScrollLock`, and `useInertBackdrop` (same modal contract)
+- Default registry covers Dashboard, Transactions, Credit Lines, Repay, Draw, Linked Accounts, Help, and notification preferences
+
+---
+
 ## 1. Why AA, not A or AAA
 
 - **AA is the legal baseline** under most public-procurement, EU, and US accessibility

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -190,6 +190,19 @@ function App() {
                   >
                     Settings
                   </button>
+                  <button
+                    type="button"
+                    className="header-nav-link header-cmdk-btn"
+                    aria-label="Open command palette"
+                    aria-keyshortcuts="Control+K Meta+K"
+                    onClick={(e) => {
+                      paletteTriggerRef.current = e.currentTarget;
+                      setIsPaletteOpen(true);
+                    }}
+                  >
+                    <span aria-hidden="true">Search</span>
+                    <kbd className="header-cmdk-kbd" aria-hidden="true">⌘K</kbd>
+                  </button>
                   <KycTriggerButton
                     triggerRef={kycTriggerRef}
                     onClick={() => setIsKycDrawerOpen(true)}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -82,9 +82,13 @@ const DEFAULT_ITEMS: CommandItem[] = [
   { id: 'nav-draw-credit',  label: 'Draw',                 icon: '⬇️',  action: '/draw-credit',               description: 'Draw from a credit line' },
   { id: 'nav-open-credit',  label: 'Request Evaluation',   icon: '📝',  action: '/open-credit',               description: 'Apply for a new credit line' },
   { id: 'nav-auctions',     label: 'Dutch Auctions',       icon: '🔨',  action: '/dutch-auctions',            description: 'View active auctions' },
+  { id: 'nav-linked',       label: 'Linked Accounts',      icon: '🔗',  action: '/linked-accounts',           description: 'Manage linked external accounts' },
   { id: 'nav-help',         label: 'Help Center',          icon: '❓',  action: '/help',                      description: 'Browse help articles' },
   { id: 'nav-notif-prefs',  label: 'Notification Settings',icon: '🔔',  action: '/notification-preferences',  description: 'Manage notification preferences' },
 ];
+
+/** Exported for tests and documentation of the default registry. */
+export { DEFAULT_ITEMS as COMMAND_PALETTE_DEFAULT_ITEMS };
 
 // ─── Fuzzy-search helpers ─────────────────────────────────────────────────────
 

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -400,4 +400,16 @@ describe('CommandPalette', () => {
     expect(secondBtn).toHaveClass('cp-item--active');
     expect(options[0].querySelector('button')).not.toHaveClass('cp-item--active');
   });
+
+  it('includes Linked Accounts in the default registry', () => {
+    render(<Wrapper />);
+    expect(screen.getByText('Linked Accounts')).toBeInTheDocument();
+  });
+
+  it('navigates to /linked-accounts when Linked Accounts is activated', async () => {
+    const user = userEvent.setup();
+    render(<Wrapper />);
+    await user.click(screen.getByRole('button', { name: /linked accounts/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/linked-accounts');
+  });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -246,6 +246,21 @@ button.header-nav-link {
   cursor: pointer;
 }
 
+.header-cmdk-btn {
+  gap: 0.4rem;
+  border: 1px solid var(--border) !important;
+  background: var(--surface) !important;
+}
+
+.header-cmdk-kbd {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  background: var(--bg, #0d1117);
+}
+
 .main {
   flex: 1;
   padding: 2rem 1.5rem;

--- a/src/test/__mocks__/react-router-dom.tsx
+++ b/src/test/__mocks__/react-router-dom.tsx
@@ -1,24 +1,21 @@
 /**
  * react-router-dom stub for the test environment.
  *
- * Creditra-Frontend does not have react-router-dom installed in the test
- * node_modules (the CI/offline environment uses a shared node_modules symlink
- * from another project that lacks this package). This stub provides the
- * minimum surface needed by the existing tests (ErrorBoundary.test.tsx,
- * NotFound.test.tsx) so the full suite can run.
- *
- * DrawCreditPage itself has no router dependency — its tests require nothing
- * from this module.
+ * Provides the minimum surface needed by suite tests when the real package
+ * is unavailable or aliased away in vitest.config.ts.
  */
 
-import { createElement, Fragment } from "react";
+import { createElement, Fragment } from 'react';
 
-// BrowserRouter — renders children directly
 export function BrowserRouter({ children }: { children: React.ReactNode }) {
   return createElement(Fragment, null, children);
 }
 
-// Link — renders a plain <a>
+/** Alias used by CommandPalette and other overlay tests. */
+export function MemoryRouter({ children }: { children: React.ReactNode }) {
+  return createElement(Fragment, null, children);
+}
+
 export function Link({
   to,
   children,
@@ -28,10 +25,28 @@ export function Link({
   children: React.ReactNode;
   [key: string]: unknown;
 }) {
-  return createElement("a", { href: to, ...props }, children);
+  return createElement('a', { href: to, ...props }, children);
 }
 
-// Route / Routes / Navigate — pass-through stubs
+export function NavLink({
+  to,
+  children,
+  className,
+  end: _end,
+  ...props
+}: {
+  to: string;
+  children: React.ReactNode | ((args: { isActive: boolean }) => React.ReactNode);
+  className?: string | ((args: { isActive: boolean }) => string);
+  end?: boolean;
+  [key: string]: unknown;
+}) {
+  const isActive = false;
+  const cls = typeof className === 'function' ? className({ isActive }) : className;
+  const content = typeof children === 'function' ? children({ isActive }) : children;
+  return createElement('a', { href: to, className: cls, ...props }, content);
+}
+
 export function Routes({ children }: { children: React.ReactNode }) {
   return createElement(Fragment, null, children);
 }
@@ -44,15 +59,20 @@ export function Navigate(_props: Record<string, unknown>) {
   return null;
 }
 
-// Hooks
 export function useNavigate() {
   return () => {};
 }
 
 export function useLocation() {
-  return { pathname: "/", search: "", hash: "", state: null };
+  return { pathname: '/', search: '', hash: '', state: null };
 }
 
 export function useParams() {
   return {};
+}
+
+export function useSearchParams() {
+  const params = new URLSearchParams();
+  const setParams = () => {};
+  return [params, setParams] as const;
 }


### PR DESCRIPTION
## Summary
- Extend Command Palette default registry with Linked Accounts
- Add header Search (⌘K) button to open the palette without a keyboard
- Document Cmd/Ctrl+K contract in docs/ACCESSIBILITY.md
- Fix react-router-dom test stub (MemoryRouter/NavLink) for palette tests

## Test plan
- [x] `npx vitest run src/components/__tests__/CommandPalette.test.tsx` — 35 passed

Closes #456