### PR TITLE
[439] Add tabular-nums to all amounts

### DIFF
--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -100,8 +100,22 @@ loaded; this keeps CLS at zero and removes a third-party request.
 #### Utility: tabular numerals
 
 ```css
-.num-tabular { font-variant-numeric: tabular-nums; }
+.tabular-nums,
+.num-tabular,
+.amount,
+[data-amount] {
+  font-variant-numeric: tabular-nums;
+}
 ```
+
+Apply to any cell that displays money, percentages, or APR so digit widths are fixed and
+columns stay visually stable as values change. Defined in `src/styles/typography.css` and
+used on:
+
+- `AmountInput` — draw field, available limit, validation metrics (`.tabular-nums.amount`)
+- `TransactionHistory` — `tx-amount` / `th-stat-value` via `.num-tabular`
+- `CreditLines` — Limit / Utilized / Available metric values
+- `ConfirmationStep`, `RepayModal`, `RepaySuccessShareCard` — amount summaries
 
 Apply to any cell that displays money, percentages, or APR so digit widths are fixed and
 columns stay visually stable as values change. Currently used on:

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -269,7 +269,7 @@ export function AmountInput({
         <p id={helperId} className="text-sm text-muted leading-[var(--lh-body)]">
           Enter the amount you wish to draw from your available credit.
           Available limit:{" "}
-          <span className="font-semibold text-foreground tabular-nums">
+          <span className="font-semibold text-foreground tabular-nums amount" data-amount>
             {formatMoney(creditLine.available)}
           </span>
         </p>
@@ -303,7 +303,7 @@ export function AmountInput({
             onPaste={handlePaste}
             onKeyDown={handleKeyDown}
             ref={inputRef}
-            className="text-xl sm:text-2xl font-bold bg-transparent outline-none flex-1 text-foreground placeholder:text-muted/50 min-w-0 tabular-nums leading-[var(--lh-display)]"
+            className="text-xl sm:text-2xl font-bold bg-transparent outline-none flex-1 text-foreground placeholder:text-muted/50 min-w-0 tabular-nums amount leading-[var(--lh-display)]"
             min={validation.minAmount}
             max={creditLine.available}
             step={STEP_AMOUNT}

--- a/src/components/__tests__/tabular-nums.test.tsx
+++ b/src/components/__tests__/tabular-nums.test.tsx
@@ -1,12 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import React from 'react';
+import { AmountInput } from '../AmountInput';
 
 describe('tabular-nums CSS utility', () => {
   it('applies tabular-nums class to elements', () => {
     const TestComponent = () => (
       <div>
-        <span className="tabular-nums" data-testid="tabular">$1,234.56</span>
+        <span className="tabular-nums" data-testid="tabular">
+          $1,234.56
+        </span>
         <span data-testid="normal">$1,234.56</span>
       </div>
     );
@@ -23,9 +26,15 @@ describe('tabular-nums CSS utility', () => {
   it('applies tabular-nums to numeric displays in RepayModal', () => {
     const TestComponent = () => (
       <div>
-        <p className="tabular-nums" data-testid="amount">$10,000.00</p>
-        <p className="tabular-nums" data-testid="percentage">75%</p>
-        <p className="tabular-nums" data-testid="utilization">50%</p>
+        <p className="tabular-nums" data-testid="amount">
+          $10,000.00
+        </p>
+        <p className="tabular-nums" data-testid="percentage">
+          75%
+        </p>
+        <p className="tabular-nums" data-testid="utilization">
+          50%
+        </p>
       </div>
     );
 
@@ -39,7 +48,9 @@ describe('tabular-nums CSS utility', () => {
   it('applies tabular-nums to RepaySuccessShareCard amount', () => {
     const TestComponent = () => (
       <div>
-        <span className="repay-value tabular-nums" data-testid="repay-amount">$5,000.00</span>
+        <span className="repay-value tabular-nums" data-testid="repay-amount">
+          $5,000.00
+        </span>
       </div>
     );
 
@@ -51,13 +62,27 @@ describe('tabular-nums CSS utility', () => {
   it('applies tabular-nums to ConfirmationStep amounts', () => {
     const TestComponent = () => (
       <div>
-        <p className="tabular-nums" data-testid="draw-amount">$1,000.00</p>
-        <p className="tabular-nums" data-testid="fee">$10.00</p>
-        <p className="tabular-nums" data-testid="interest">$12.50</p>
-        <p className="tabular-nums" data-testid="new-balance">$1,012.50</p>
-        <p className="tabular-nums" data-testid="available">$8,987.50</p>
-        <span className="tabular-nums" data-testid="utilization">45%</span>
-        <span className="tabular-nums" data-testid="new-utilization">55%</span>
+        <p className="tabular-nums" data-testid="draw-amount">
+          $1,000.00
+        </p>
+        <p className="tabular-nums" data-testid="fee">
+          $10.00
+        </p>
+        <p className="tabular-nums" data-testid="interest">
+          $12.50
+        </p>
+        <p className="tabular-nums" data-testid="new-balance">
+          $1,012.50
+        </p>
+        <p className="tabular-nums" data-testid="available">
+          $8,987.50
+        </p>
+        <span className="tabular-nums" data-testid="utilization">
+          45%
+        </span>
+        <span className="tabular-nums" data-testid="new-utilization">
+          55%
+        </span>
       </div>
     );
 
@@ -70,5 +95,46 @@ describe('tabular-nums CSS utility', () => {
     expect(screen.getByTestId('available')).toHaveClass('tabular-nums');
     expect(screen.getByTestId('utilization')).toHaveClass('tabular-nums');
     expect(screen.getByTestId('new-utilization')).toHaveClass('tabular-nums');
+  });
+
+  it('supports the semantic .amount and [data-amount] aliases', () => {
+    render(
+      <div>
+        <span className="amount" data-testid="by-class">
+          $42.00
+        </span>
+        <span data-amount data-testid="by-attr">
+          $99.00
+        </span>
+      </div>,
+    );
+
+    expect(screen.getByTestId('by-class')).toHaveClass('amount');
+    expect(screen.getByTestId('by-attr')).toHaveAttribute('data-amount');
+  });
+
+  it('AmountInput draw field carries tabular-nums + amount classes', () => {
+    const creditLine = {
+      id: 'cl-001',
+      name: 'Business Line of Credit',
+      limit: 50000,
+      available: 35000,
+      utilization: 30,
+      riskBand: 'Standard' as const,
+      termMonths: 24,
+    };
+
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={() => {}}
+        onNext={() => {}}
+        onBack={() => {}}
+      />,
+    );
+
+    const input = screen.getByLabelText(/draw amount/i);
+    expect(input).toHaveClass('tabular-nums');
+    expect(input).toHaveClass('amount');
   });
 });

--- a/src/pages/CreditLines.tsx
+++ b/src/pages/CreditLines.tsx
@@ -102,14 +102,14 @@ function CreditLineCard({
         <div className="cl-metrics">
           <div className="cl-metric">
             <span className="cl-metric-label">Limit</span>
-            <span className="cl-metric-value" style={{ color: COLOR.accent }}>
+            <span className="cl-metric-value amount tabular-nums" style={{ color: COLOR.accent }}>
               {fmt(line.limit)}
             </span>
           </div>
           <div className="cl-metric">
             <span className="cl-metric-label">Utilized</span>
             <span
-              className="cl-metric-value"
+              className="cl-metric-value amount tabular-nums"
               style={{ color: UTIL_COLOR[level] }}
             >
               {fmt(line.utilized)}
@@ -117,7 +117,7 @@ function CreditLineCard({
           </div>
           <div className="cl-metric">
             <span className="cl-metric-label">Available</span>
-            <span className="cl-metric-value" style={{ color: COLOR.success }}>
+            <span className="cl-metric-value amount tabular-nums" style={{ color: COLOR.success }}>
               {fmt(line.limit - line.utilized)}
             </span>
           </div>

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,6 +1,27 @@
-/* src/styles/typography.css */
+/* src/styles/typography.css
+ *
+ * Numeric typography utilities for money / rate / percent displays.
+ * Tabular numerals keep digit widths fixed so columns do not wobble
+ * when values update (e.g. $1,000 → $9,999).
+ */
 
-/* Add tabular-nums to amount displays for stability */
+/* Canonical utility — preferred class name going forward */
 .tabular-nums {
   font-variant-numeric: tabular-nums;
+}
+
+/* Alias used by TransactionHistory / CreditLines (legacy name) */
+.num-tabular {
+  font-variant-numeric: tabular-nums;
+}
+
+/**
+ * Semantic amount class — apply to any money / APR / utilization figure.
+ * Combines tabular numerals with a consistent numeric weight so AmountInput,
+ * ConfirmationStep, and list cells share one visual contract.
+ */
+.amount,
+[data-amount] {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
 }


### PR DESCRIPTION
## Summary
- Expand `src/styles/typography.css` with `.amount`, `[data-amount]`, and `.num-tabular` aliases
- Apply `tabular-nums` / `amount` to AmountInput draw field and CreditLines metric values
- Document the utility contract in `docs/DESIGN_SYSTEM.md`
- Extend `tabular-nums.test.tsx` (6 passing)

## Test plan
- [x] `npx vitest run src/components/__tests__/tabular-nums.test.tsx` — 6 passed

Closes #439