### PR TITLE
[427] Add per-credit-line health-factor chart

### DIFF
--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -143,6 +143,7 @@ Every component below lives in `src/components/`.
 | `FormField` | Labelled input/textarea/custom child with help and error slots | `htmlFor` linkage, `aria-describedby`, `aria-invalid`, `aria-required` set automatically; required indicator announced |
 | `FormMessage` | Tone-coded helper/error text | `role="alert"` for `danger`; live region wrapping for transient feedback |
 | `AmountInput` | Currency input with preset chips (25/50/75/100%) and per-severity feedback | `aria-describedby` aggregates helper + constraint + status + error IDs |
+| `HealthFactorChart` | Per-credit-line health-factor trend (SVG + SR table) | `role="img"` + labelledby; band label pairs colour with text |
 | `PendingButton` | Submit button with inline spinner | `aria-busy="true"` while loading; spinner `aria-hidden` so label-change communicates state |
 
 ### Status, feedback, success

--- a/src/components/HealthFactorChart.css
+++ b/src/components/HealthFactorChart.css
@@ -1,0 +1,88 @@
+/* HealthFactorChart — compact per-line HF trend */
+
+.hf-chart {
+  margin: 0.75rem 0 0;
+  padding: 0.75rem;
+  border: 1px solid var(--border, #30363d);
+  border-radius: var(--radius-md, 8px);
+  background: var(--surface, #161b22);
+}
+
+.hf-chart--empty {
+  color: var(--muted, #8b949e);
+  font-size: 0.8rem;
+}
+
+.hf-chart__caption {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.hf-chart__title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted, #8b949e);
+}
+
+.hf-chart__badge {
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+
+.hf-chart__badge--safe {
+  color: var(--success, #3fb950);
+  background: rgba(63, 185, 80, 0.12);
+  border-color: rgba(63, 185, 80, 0.35);
+}
+
+.hf-chart__badge--caution {
+  color: var(--warning, #d29922);
+  background: rgba(210, 153, 34, 0.12);
+  border-color: rgba(210, 153, 34, 0.35);
+}
+
+.hf-chart__badge--risk {
+  color: var(--error, #f85149);
+  background: rgba(248, 81, 73, 0.12);
+  border-color: rgba(248, 81, 73, 0.35);
+}
+
+.hf-chart__svg {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+}
+
+.hf-chart__line {
+  animation: hf-draw 0.6s ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hf-chart__line {
+    animation: none;
+  }
+}
+
+[data-motion='reduced'] .hf-chart__line {
+  animation: none;
+}
+
+@keyframes hf-draw {
+  from {
+    stroke-dasharray: 600;
+    stroke-dashoffset: 600;
+  }
+  to {
+    stroke-dasharray: 600;
+    stroke-dashoffset: 0;
+  }
+}

--- a/src/components/HealthFactorChart.test.tsx
+++ b/src/components/HealthFactorChart.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import {
+  HealthFactorChart,
+  healthBand,
+  healthBandLabel,
+  deriveHealthFactor,
+  buildHealthHistory,
+} from './HealthFactorChart';
+
+describe('healthBand helpers', () => {
+  it('classifies safe / caution / risk thresholds', () => {
+    expect(healthBand(2.5)).toBe('safe');
+    expect(healthBand(1.5)).toBe('caution');
+    expect(healthBand(1.0)).toBe('risk');
+  });
+
+  it('labels bands for accessible text', () => {
+    expect(healthBandLabel('safe')).toBe('Safe');
+    expect(healthBandLabel('caution')).toBe('Caution');
+    expect(healthBandLabel('risk')).toBe('At risk');
+  });
+});
+
+describe('deriveHealthFactor', () => {
+  it('returns 3 when nothing is utilized', () => {
+    expect(deriveHealthFactor(10000, 0)).toBe(3);
+  });
+
+  it('is limit / utilized when drawn', () => {
+    expect(deriveHealthFactor(10000, 5000)).toBe(2);
+  });
+
+  it('floors near zero for overdrawn / empty limit', () => {
+    expect(deriveHealthFactor(0, 100)).toBe(0.5);
+  });
+});
+
+describe('buildHealthHistory', () => {
+  it('ends with the current value', () => {
+    const series = buildHealthHistory(1.8, 8);
+    expect(series).toHaveLength(8);
+    expect(series[series.length - 1].value).toBe(1.8);
+  });
+
+  it('is deterministic for the same inputs', () => {
+    expect(buildHealthHistory(2.0, 5)).toEqual(buildHealthHistory(2.0, 5));
+  });
+});
+
+describe('HealthFactorChart', () => {
+  const data = [
+    { date: '2026-01-01', value: 2.4 },
+    { date: '2026-01-08', value: 2.1 },
+    { date: '2026-01-15', value: 1.8 },
+  ];
+
+  it('renders the current badge and accessible SVG', () => {
+    render(
+      <HealthFactorChart data={data} current={1.8} lineName="Builder line" />,
+    );
+
+    expect(screen.getByText(/1\.80 · Caution/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', { name: /health factor trend for builder line/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('exposes an SR-only history table', () => {
+    render(
+      <HealthFactorChart data={data} current={1.8} lineName="Builder line" />,
+    );
+
+    expect(
+      screen.getByRole('table', {
+        name: /health factor history for builder line/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('2026-01-01')).toBeInTheDocument();
+  });
+
+  it('shows empty state when there is no data', () => {
+    render(
+      <HealthFactorChart data={[]} current={2} lineName="Empty line" />,
+    );
+    expect(
+      screen.getByText(/no health-factor history yet for empty line/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/HealthFactorChart.tsx
+++ b/src/components/HealthFactorChart.tsx
@@ -1,0 +1,235 @@
+/**
+ * HealthFactorChart — per-credit-line health-factor trend.
+ *
+ * Renders a compact SVG line chart of historical health-factor samples
+ * for one credit line, with a colour-coded current value and an SR-only
+ * data table fallback (WCAG 1.1.1).
+ *
+ * Health factor convention (Creditra):
+ *   HF = limit / utilized when utilized > 0, else a sentinel "healthy" 3.0.
+ *   Bands:  ≥ 2.0 safe (success) · 1.25–2.0 caution (warning) · < 1.25 risk (danger)
+ *
+ * Accessibility:
+ *   - role="img" + aria-labelledby on the SVG
+ *   - sr-only table mirrors every data point
+ *   - prefers-reduced-motion disables the entrance stroke animation
+ *   - Colour is paired with a text label (WCAG 1.4.1)
+ *
+ * Design tokens: stroke colours come from COLOR in utils/tokens.ts.
+ */
+
+import { useId, useMemo } from 'react';
+import { COLOR } from '../utils/tokens';
+import './HealthFactorChart.css';
+
+export interface HealthFactorPoint {
+  /** ISO date or label for the sample. */
+  date: string;
+  /** Health factor value (typically 0.5–5). */
+  value: number;
+}
+
+export interface HealthFactorChartProps {
+  /** Ordered oldest → newest samples. */
+  data: HealthFactorPoint[];
+  /** Current health factor — shown as a badge. */
+  current: number;
+  /** Credit line name for accessible labelling. */
+  lineName: string;
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+export type HealthBand = 'safe' | 'caution' | 'risk';
+
+export function healthBand(value: number): HealthBand {
+  if (value >= 2) return 'safe';
+  if (value >= 1.25) return 'caution';
+  return 'risk';
+}
+
+export function healthBandColor(band: HealthBand): string {
+  if (band === 'safe') return COLOR.success;
+  if (band === 'caution') return COLOR.warning;
+  return COLOR.danger;
+}
+
+export function healthBandLabel(band: HealthBand): string {
+  if (band === 'safe') return 'Safe';
+  if (band === 'caution') return 'Caution';
+  return 'At risk';
+}
+
+/**
+ * Derive a health factor from credit-line utilisation.
+ * Used when no historical series is supplied by the backend yet.
+ */
+export function deriveHealthFactor(limit: number, utilized: number): number {
+  if (utilized <= 0) return 3;
+  if (limit <= 0) return 0.5;
+  return Math.max(0.1, Number((limit / utilized).toFixed(2)));
+}
+
+/**
+ * Build a short synthetic history ending at `current` for demo / offline use.
+ */
+export function buildHealthHistory(
+  current: number,
+  points = 12,
+): HealthFactorPoint[] {
+  const out: HealthFactorPoint[] = [];
+  const now = Date.now();
+  for (let i = points - 1; i >= 0; i--) {
+    // Deterministic wobble — no Math.random (stable SSR + tests)
+    const wobble = Math.sin(i * 0.7) * 0.12;
+    const value = Math.max(
+      0.5,
+      Number((current + wobble * (i / Math.max(points - 1, 1))).toFixed(2)),
+    );
+    const d = new Date(now - i * 7 * 24 * 60 * 60 * 1000);
+    out.push({ date: d.toISOString().slice(0, 10), value });
+  }
+  out[out.length - 1] = {
+    ...out[out.length - 1],
+    value: current,
+  };
+  return out;
+}
+
+const W_DEFAULT = 220;
+const H_DEFAULT = 64;
+const PAD = { top: 8, right: 8, bottom: 8, left: 8 };
+
+export function HealthFactorChart({
+  data,
+  current,
+  lineName,
+  width = W_DEFAULT,
+  height = H_DEFAULT,
+  className = '',
+}: HealthFactorChartProps) {
+  const titleId = useId();
+  const descId = useId();
+  const band = healthBand(current);
+  const stroke = healthBandColor(band);
+
+  const { path, area, min, max } = useMemo(() => {
+    if (!data.length) {
+      return { path: '', area: '', min: 0, max: 1 };
+    }
+    const values = data.map((d) => d.value);
+    const minV = Math.min(...values, 1);
+    const maxV = Math.max(...values, 2.5);
+    const range = maxV - minV || 1;
+    const innerW = width - PAD.left - PAD.right;
+    const innerH = height - PAD.top - PAD.bottom;
+
+    const coords = data.map((d, i) => {
+      const x =
+        PAD.left +
+        (data.length === 1 ? innerW / 2 : (i / (data.length - 1)) * innerW);
+      const y = PAD.top + innerH - ((d.value - minV) / range) * innerH;
+      return [x, y] as const;
+    });
+
+    const line = coords
+      .map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x},${y}`)
+      .join(' ');
+    const areaPath =
+      line +
+      ` L${coords[coords.length - 1][0]},${PAD.top + innerH}` +
+      ` L${coords[0][0]},${PAD.top + innerH} Z`;
+
+    return { path: line, area: areaPath, min: minV, max: maxV };
+  }, [data, width, height]);
+
+  if (!data.length) {
+    return (
+      <div className={`hf-chart hf-chart--empty ${className}`} role="status">
+        No health-factor history yet for {lineName}.
+      </div>
+    );
+  }
+
+  return (
+    <figure className={`hf-chart ${className}`}>
+      <figcaption className="hf-chart__caption">
+        <span className="hf-chart__title">Health factor</span>
+        <span
+          className={`hf-chart__badge hf-chart__badge--${band} tabular-nums`}
+          title={`Band: ${healthBandLabel(band)}`}
+        >
+          {current.toFixed(2)} · {healthBandLabel(band)}
+        </span>
+      </figcaption>
+
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        role="img"
+        aria-labelledby={`${titleId} ${descId}`}
+        className="hf-chart__svg"
+      >
+        <title id={titleId}>
+          Health factor trend for {lineName}
+        </title>
+        <desc id={descId}>
+          Current health factor {current.toFixed(2)} ({healthBandLabel(band)}).
+          Range {min.toFixed(2)} to {max.toFixed(2)} across {data.length} samples.
+        </desc>
+
+        {/* Caution threshold guide at HF = 1.25 */}
+        <line
+          className="hf-chart__guide"
+          x1={PAD.left}
+          x2={width - PAD.right}
+          y1={PAD.top + ((max - 1.25) / (max - min || 1)) * (height - PAD.top - PAD.bottom)}
+          y2={PAD.top + ((max - 1.25) / (max - min || 1)) * (height - PAD.top - PAD.bottom)}
+          stroke={COLOR.warning}
+          strokeDasharray="4 3"
+          strokeWidth={1}
+          opacity={0.45}
+          aria-hidden="true"
+        />
+
+        <path
+          d={area}
+          fill={stroke}
+          fillOpacity={0.12}
+          aria-hidden="true"
+          className="hf-chart__area"
+        />
+        <path
+          d={path}
+          fill="none"
+          stroke={stroke}
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="hf-chart__line"
+        />
+      </svg>
+
+      <table className="sr-only" aria-label={`Health factor history for ${lineName}`}>
+        <thead>
+          <tr>
+            <th scope="col">Date</th>
+            <th scope="col">Health factor</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((p) => (
+            <tr key={p.date}>
+              <td>{p.date}</td>
+              <td>{p.value.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </figure>
+  );
+}
+
+export default HealthFactorChart;

--- a/src/pages/CreditLines.tsx
+++ b/src/pages/CreditLines.tsx
@@ -2,6 +2,11 @@ import { useState, useMemo, useRef } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { StatusBadge } from '../components/StatusBadge';
 import { RepaymentPlanChart } from '../components/RepaymentPlanChart';
+import {
+  HealthFactorChart,
+  buildHealthHistory,
+  deriveHealthFactor,
+} from '../components/HealthFactorChart';
 import { MOCK_CREDIT_LINES } from '../data/mockData';
 import type { CreditLineStatus, SortField, SortDirection } from '../types/creditLine';
 import {
@@ -158,6 +163,17 @@ function CreditLineCard({
             <NextAccrualChip target={line.nextInterestAccrualDate} />
           </div>
         )}
+
+        {(() => {
+          const hf = deriveHealthFactor(line.limit, line.utilized);
+          return (
+            <HealthFactorChart
+              lineName={line.name}
+              current={hf}
+              data={buildHealthHistory(hf)}
+            />
+          );
+        })()}
       </div>
 
       <div className="cl-card-detail">


### PR DESCRIPTION
## Summary
- Add `src/components/HealthFactorChart.tsx` — SVG health-factor trend with band badge and SR-only table
- Helpers: `deriveHealthFactor`, `buildHealthHistory`, `healthBand`
- Wire into CreditLines cards
- Document in `docs/DESIGN_SYSTEM.md`

## Test plan
- [x] `npx vitest run src/components/HealthFactorChart.test.tsx` — 10 passed

Closes #427