### PR TITLE
fix: RepaymentVisualizer focus

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -175,6 +175,10 @@ The `KbdHint` component (`src/components/KbdHint.tsx`) provides standardized vis
 ### Focus management
 
 - Global `:focus-visible` rule in `src/index.css` is `outline: 2px solid var(--accent); outline-offset: 2px`.
+- `RepaymentVisualizer` applies `.repayment-visualizer-focus` to its interactive
+  chart, schedule disclosure, and row-expansion control. The class uses shared
+  focus tokens and `:focus-visible`, so keyboard users receive a consistent
+  outline without adding a focus ring on pointer clicks.
 - Active nav links keep focus styling distinct from active styling (see the comment block
   around `.header-nav-link.active` in `src/index.css`).
 - Modal close returns focus to the trigger via `useFocusTrap`'s `triggerRef`.

--- a/src/components/RepaymentVisualizer.tsx
+++ b/src/components/RepaymentVisualizer.tsx
@@ -275,8 +275,8 @@ function StackedAreaChart({ schedule, tooltipId, onTooltip, tooltip, chartAriaLa
           ? `Month ${tooltip.month}: Principal remaining $${Math.round(tooltip.principal)}, cumulative interest $${Math.round(tooltip.cumulativeInterest)}`
           : undefined
       }
-      style={{ width: '100%', height: 'auto', overflow: 'visible', outline: 'none' }}
-      className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+      style={{ width: '100%', height: 'auto', overflow: 'visible' }}
+      className="repayment-visualizer-focus"
       onMouseMove={handleMouseMove}
       onMouseLeave={() => onTooltip(null)}
       onTouchEnd={() => onTooltip(null)}
@@ -560,6 +560,7 @@ function VisibleTable({ schedule, limit = 12 }: VisibleTableProps) {
         <button
           type="button"
           onClick={() => setShowAll((s) => !s)}
+          className="repayment-visualizer-focus"
           style={{
             marginTop: '0.5rem',
             fontSize: '0.75rem',
@@ -747,9 +748,8 @@ export function RepaymentVisualizer({
                 color: `var(--accent, ${COLOR.accent})`,
                 userSelect: 'none',
                 padding: '4px 0',
-                outline: 'none',
               }}
-              className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+              className="repayment-visualizer-focus"
             >
               Schedule table
             </summary>

--- a/src/components/__tests__/RepaymentVisualizer.test.tsx
+++ b/src/components/__tests__/RepaymentVisualizer.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import { RepaymentVisualizer } from '../RepaymentVisualizer';
 import * as ReducedMotionContext from '../../context/ReducedMotionContext';
 
@@ -39,6 +41,30 @@ describe('RepaymentVisualizer', () => {
     const svg = screen.getByRole('img');
     expect(svg).toBeInTheDocument();
     expect(svg).toHaveAttribute('tabindex', '0');
+  });
+
+  it('marks every keyboard target with the tokenized focus-visible class', () => {
+    render(<RepaymentVisualizer {...BASE} maxMonths={24} />);
+
+    expect(screen.getByRole('img')).toHaveClass('repayment-visualizer-focus');
+    expect(screen.getByText(/Schedule table/i)).toHaveClass('repayment-visualizer-focus');
+
+    fireEvent.click(screen.getByText(/Schedule table/i));
+    expect(screen.getByRole('button', { name: /Show all 24 months/i })).toHaveClass(
+      'repayment-visualizer-focus',
+    );
+  });
+
+  it('uses the shared focus tokens only for keyboard-visible focus', () => {
+    const css = readFileSync(resolve(__dirname, '../../styles/focus.css'), 'utf-8');
+    const selectorIndex = css.indexOf('.repayment-visualizer-focus:focus-visible');
+    expect(selectorIndex).toBeGreaterThanOrEqual(0);
+
+    const rule = css.slice(selectorIndex, css.indexOf('}', selectorIndex) + 1);
+    expect(rule).toContain('--focus-ring-width');
+    expect(rule).toContain('--focus-ring-color');
+    expect(rule).toContain('--focus-ring-offset');
+    expect(css).not.toMatch(/\.repayment-visualizer-focus:focus(?!-visible)/);
   });
 
   it('renders term and total interest summary', () => {

--- a/src/styles/focus.css
+++ b/src/styles/focus.css
@@ -133,6 +133,21 @@
   border-radius: var(--focus-ring-radius, 6px);
 }
 
+/**
+ * RepaymentVisualizer keyboard targets.
+ *
+ * Applied to the interactive SVG chart, schedule disclosure, and table
+ * expansion button. `:focus-visible` keeps pointer interactions unchanged,
+ * while the shared tokens preserve contrast across default, dark, and
+ * high-contrast themes.
+ */
+.repayment-visualizer-focus:focus-visible {
+  outline: var(--focus-ring-width, 2px) solid
+    var(--focus-ring-color, var(--accent, #58a6ff));
+  outline-offset: var(--focus-ring-offset, 3px);
+  border-radius: var(--focus-ring-radius, 6px);
+}
+
 /* ── Reduced-motion ──────────────────────────────────────────────────────── */
 /*
   Focus indicators must remain visible even under prefers-reduced-motion;


### PR DESCRIPTION
## Summary
- add a tokenized `:focus-visible` outline to every keyboard-reachable RepaymentVisualizer control
- replace outline-suppressing inline/Tailwind styles with the shared focus contract
- add focused structural and CSS regression tests
- document the visible accessibility behavior

Closes #612

## Validation
- `npm test -- --run src/components/__tests__/RepaymentVisualizer.test.tsx` — passed (51/51)
- `npm run lint` — blocked: the current lockfile install does not provide the declared ESLint executable
- `npm run build` — blocked by existing upstream TypeScript errors, including undefined `DashboardTour`, `ContinuePrompt`, and `SyncIndicator`
- broader related test run — RepaymentVisualizer component tests pass; existing failures remain in Dashboard focus tests (`DashboardTour` undefined) and the page re-export test (`window.matchMedia` missing)