### PR TITLE
fix: RepayPage reduced-motion fallback (Closes #514)

### DIFF
--- a/src/pages/RepayPage.css
+++ b/src/pages/RepayPage.css
@@ -1,0 +1,45 @@
+/**
+ * RepayPage reduced-motion fallback (GrantFox FWC26, buffer #18 / issue #514)
+ *
+ * Suppresses transitions and animations when the user has
+ * `prefers-reduced-motion: reduce` active via their OS, or when the in-app
+ * ReducedMotionContext override (`data-motion="reduced"` on <html>) is set.
+ *
+ * This avoids disorientation for users who are sensitive to movement.
+ */
+
+/* ── OS-level detection ───────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .repay-page *,
+  .repay-page *::before,
+  .repay-page *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ── In-app override via ReducedMotionContext (data-motion="reduced") ─────── */
+
+[data-motion="reduced"] .repay-page *,
+[data-motion="reduced"] .repay-page *::before,
+[data-motion="reduced"] .repay-page *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}
+
+/* Explicitly remove the toggle thumb translate transform under reduced motion
+   so the switch snaps rather than sliding. */
+@media (prefers-reduced-motion: reduce) {
+  .repay-page .repay-page__toggle-thumb {
+    transition: none !important;
+  }
+}
+
+[data-motion="reduced"] .repay-page .repay-page__toggle-thumb {
+  transition: none !important;
+}

--- a/src/pages/RepayPage.tsx
+++ b/src/pages/RepayPage.tsx
@@ -9,6 +9,8 @@ import { NoOutstandingDebt } from '@/components/illustrations';
 import { formatMoney, getRepayAmountValidation } from '@/utils/amountValidation';
 import type { CreditLine } from '@/types/creditLine';
 import { MOCK_CREDIT_LINES } from '@/data/mockData';
+import { useReducedMotion } from '@/context/ReducedMotionContext';
+import './RepayPage.css';
 
 type RepayStep = 'input' | 'review' | 'success';
 
@@ -39,6 +41,15 @@ const SEVERITY_CONFIG = {
   },
 } as const;
 
+/**
+ * Returns the given Tailwind classes only when reduced motion is inactive.
+ * When reduced motion is preferred, returns an empty string so transition
+ * and hover classes are stripped.
+ */
+function motionClasses(reduced: boolean, classes: string): string {
+  return reduced ? '' : classes;
+}
+
 export default function RepayPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -51,6 +62,7 @@ export default function RepayPage() {
   const [isAutoSchedule, setIsAutoSchedule] = useState(false);
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const helpTriggerRef = useRef<HTMLButtonElement>(null);
+  const { isReducedMotionActive } = useReducedMotion();
 
   const creditLines = useMemo(
     () => MOCK_CREDIT_LINES.filter((cl) => cl.status === 'Active' && cl.utilized > 0),
@@ -136,11 +148,11 @@ export default function RepayPage() {
 
   if (!selectedLine) {
     return (
-      <div className="mx-auto max-w-2xl space-y-6 px-4 py-8">
+      <div className="repay-page mx-auto max-w-2xl space-y-6 px-4 py-8">
         <button
           type="button"
           onClick={() => navigate(-1)}
-          className="inline-flex items-center gap-1.5 rounded-md text-sm text-muted transition-colors hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          className={`inline-flex items-center gap-1.5 rounded-md text-sm text-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${motionClasses(isReducedMotionActive, 'transition-colors hover:text-foreground')}`}
         >
           <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           Back
@@ -154,9 +166,6 @@ export default function RepayPage() {
         </header>
 
         {creditLines.length === 0 ? (
-          // Themed empty state (issue #581): no repayable balances yet.
-          // The illustration + headline announce the situation; CTAs nudge
-          // the user toward either opening a new line or returning home.
           <EmptyState
             data-testid="repay-empty-state"
             tone="success"
@@ -184,7 +193,7 @@ export default function RepayPage() {
                   key={cl.id}
                   type="button"
                   onClick={() => setSelectedId(cl.id)}
-                  className="w-full rounded-lg border border-border bg-surface p-4 text-left transition-all hover:border-accent hover:bg-accent/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                  className={`w-full rounded-lg border border-border bg-surface p-4 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${motionClasses(isReducedMotionActive, 'transition-all hover:border-accent hover:bg-accent/5')}`}
                 >
                   <div className="flex items-center justify-between">
                     <div>
@@ -224,11 +233,11 @@ export default function RepayPage() {
   const newPct = Math.round((remainingDebt / selectedLine.limit) * 100);
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-6 sm:py-8">
+    <div className="repay-page mx-auto max-w-4xl px-4 py-6 sm:py-8">
       <button
         type="button"
         onClick={handleBack}
-        className="mb-4 inline-flex items-center gap-1.5 rounded-md text-sm text-muted transition-colors hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+        className={`mb-4 inline-flex items-center gap-1.5 rounded-md text-sm text-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${motionClasses(isReducedMotionActive, 'transition-colors hover:text-foreground')}`}
       >
         <ArrowLeft className="h-4 w-4" aria-hidden="true" />
         {step === 'input' ? 'Back to credit lines' : 'Back to input'}
@@ -300,7 +309,7 @@ export default function RepayPage() {
                         key={pct}
                         type="button"
                         onClick={() => handlePercent(pct)}
-                        className="flex-1 rounded-md border border-accent/30 px-2 py-1.5 text-xs font-medium text-accent transition-colors hover:bg-accent/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                        className={`flex-1 rounded-md border border-accent/30 px-2 py-1.5 text-xs font-medium text-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${motionClasses(isReducedMotionActive, 'transition-colors hover:bg-accent/10')}`}
                         aria-label={`Set amount to ${pct === 100 ? 'maximum' : `${pct} percent`}`}
                       >
                         {pct === 100 ? 'MAX' : `${pct}%`}
@@ -309,7 +318,7 @@ export default function RepayPage() {
                     <button
                       type="button"
                       onClick={handleSmartPay}
-                      className="flex-1 rounded-md border border-success/30 px-2 py-1.5 text-xs font-medium text-success transition-colors hover:bg-success/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-success"
+                      className={`flex-1 rounded-md border border-success/30 px-2 py-1.5 text-xs font-medium text-success focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-success ${motionClasses(isReducedMotionActive, 'transition-colors hover:bg-success/10')}`}
                       aria-label={`Smart Pay suggested repayment of ${formatMoney(suggestedAmount)}`}
                     >
                       Smart Pay
@@ -332,7 +341,7 @@ export default function RepayPage() {
                       min={1}
                       step={0.01}
                       aria-invalid={validation?.feedback.severity === 'danger' || undefined}
-                      className="w-full rounded-lg border bg-background px-3 py-3 pl-8 text-lg font-semibold text-foreground outline-none transition-colors focus:ring-2 focus:ring-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                      className={`w-full rounded-lg border bg-background px-3 py-3 pl-8 text-lg font-semibold text-foreground outline-none focus:ring-2 focus:ring-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${motionClasses(isReducedMotionActive, 'transition-colors')}`}
                       style={{
                         borderColor:
                           validation?.feedback.severity === 'danger'
@@ -398,15 +407,15 @@ export default function RepayPage() {
                     </div>
                     <div className="h-2 w-full overflow-hidden rounded-full bg-border">
                       <div
-                        className="h-full rounded-full bg-red-500/30 transition-all"
+                        className={`h-full rounded-full bg-red-500/30 ${motionClasses(isReducedMotionActive, 'transition-all')}`}
                         style={{ width: `${oldPct}%` }}
                       />
                     </div>
                     <div className="h-2 w-full overflow-hidden rounded-full bg-border">
                       <div
-                        className={`h-full rounded-full transition-all ${
+                        className={`h-full rounded-full ${
                           remainingDebt === 0 ? 'bg-green-500' : 'bg-yellow-500'
-                        }`}
+                        } ${motionClasses(isReducedMotionActive, 'transition-all')}`}
                         style={{ width: `${newPct}%` }}
                       />
                     </div>
@@ -429,15 +438,15 @@ export default function RepayPage() {
                       role="switch"
                       aria-checked={isAutoSchedule}
                       onClick={() => setIsAutoSchedule(!isAutoSchedule)}
-                      className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                      className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                         isAutoSchedule ? 'bg-accent' : 'bg-border'
-                      }`}
+                      } ${motionClasses(isReducedMotionActive, 'transition-colors duration-200 ease-in-out')}`}
                     >
                       <span
                         aria-hidden="true"
-                        className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                        className={`repay-page__toggle-thumb pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 ${
                           isAutoSchedule ? 'translate-x-5' : 'translate-x-0'
-                        }`}
+                        } ${motionClasses(isReducedMotionActive, 'transition duration-200 ease-in-out')}`}
                       />
                     </button>
                   </div>
@@ -446,7 +455,7 @@ export default function RepayPage() {
                     type="button"
                     onClick={handleReview}
                     disabled={isInvalid || amount <= 0}
-                    className="mt-4 w-full rounded-lg bg-accent px-4 py-3 text-sm font-semibold text-background transition-all hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-50"
+                    className={`mt-4 w-full rounded-lg bg-accent px-4 py-3 text-sm font-semibold text-background focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-50 ${motionClasses(isReducedMotionActive, 'transition-all hover:brightness-110')}`}
                   >
                     Review Repayment
                   </button>
@@ -481,14 +490,14 @@ export default function RepayPage() {
                 ref={helpTriggerRef}
                 type="button"
                 onClick={() => setIsHelpOpen(true)}
-                className="rounded-md text-sm font-semibold text-blue-300 underline-offset-4 transition-colors hover:text-blue-200 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400"
+                className={`rounded-md text-sm font-semibold text-blue-300 underline-offset-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 ${motionClasses(isReducedMotionActive, 'transition-colors hover:text-blue-200 hover:underline')}`}
               >
                 I need help
               </button>
               <button
                 type="button"
                 onClick={() => navigate('/')}
-                className="rounded-md text-sm font-semibold text-foreground underline-offset-4 hover:text-accent hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                className={`rounded-md text-sm font-semibold text-foreground underline-offset-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${motionClasses(isReducedMotionActive, 'hover:text-accent hover:underline')}`}
               >
                 Cancel
               </button>
@@ -553,7 +562,7 @@ export default function RepayPage() {
               <button
                 type="button"
                 onClick={handleBack}
-                className="flex-1 rounded-lg border border-border bg-surface px-4 py-3 text-sm font-semibold text-foreground transition-all hover:bg-border focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                className={`flex-1 rounded-lg border border-border bg-surface px-4 py-3 text-sm font-semibold text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${motionClasses(isReducedMotionActive, 'transition-all hover:bg-border')}`}
               >
                 Back
               </button>
@@ -562,7 +571,7 @@ export default function RepayPage() {
                 onClick={handleConfirm}
                 disabled={isConfirmDisabled}
                 aria-disabled={isConfirmDisabled || undefined}
-                className="flex-[2] rounded-lg bg-accent px-4 py-3 text-sm font-semibold text-background transition-all hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-50"
+                className={`flex-[2] rounded-lg bg-accent px-4 py-3 text-sm font-semibold text-background focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-50 ${motionClasses(isReducedMotionActive, 'transition-all hover:brightness-110')}`}
               >
                 Confirm Repayment
               </button>
@@ -618,14 +627,14 @@ export default function RepayPage() {
               <button
                 type="button"
                 onClick={() => navigate('/')}
-                className="flex-1 rounded-lg bg-accent px-4 py-3 text-sm font-semibold text-background transition-all hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                className={`flex-1 rounded-lg bg-accent px-4 py-3 text-sm font-semibold text-background focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${motionClasses(isReducedMotionActive, 'transition-all hover:brightness-110')}`}
               >
                 Back to Dashboard
               </button>
               <button
                 type="button"
                 onClick={handleNewRepay}
-                className="flex-1 rounded-lg border border-border bg-surface px-4 py-3 text-sm font-semibold text-foreground transition-all hover:bg-border focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                className={`flex-1 rounded-lg border border-border bg-surface px-4 py-3 text-sm font-semibold text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${motionClasses(isReducedMotionActive, 'transition-all hover:bg-border')}`}
               >
                 Make another repayment
               </button>

--- a/src/pages/__tests__/RepayPage.reduced-motion.test.tsx
+++ b/src/pages/__tests__/RepayPage.reduced-motion.test.tsx
@@ -1,0 +1,308 @@
+/**
+ * RepayPage reduced-motion tests (GrantFox FWC26, buffer #18 / issue #514)
+ *
+ * Covers:
+ *  1. RepayPage root container has `repay-page` class for CSS targeting.
+ *  2. When OS prefers-reduced-motion is active, the toggle thumb has
+ *     `repay-page__toggle-thumb` class and no transition classes.
+ *  3. When OS prefers-reduced-motion is NOT active, the toggle thumb has
+ *     transition classes applied.
+ *  4. Primary action buttons drop `transition-all hover:brightness-110`
+ *     when reduced motion is active.
+ *  5. Primary action buttons include `transition-all hover:brightness-110`
+ *     when reduced motion is NOT active.
+ *  6. The auto-schedule toggle track drops `transition-colors duration-200`
+ *     when reduced motion is active.
+ *  7. RepayPage.css contains @media (prefers-reduced-motion: reduce) rules
+ *     for .repay-page.
+ *  8. RepayPage.css contains [data-motion="reduced"] rules for .repay-page.
+ *  9. When in-app ReducedMotionContext override is active (data-motion="reduced"
+ *     on <html>), the toggle thumb has no transition classes.
+ * 10. Back button drops transition classes under reduced motion.
+ */
+
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import RepayPage from '../RepayPage';
+import { ReducedMotionProvider } from '../../context/ReducedMotionContext';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('@/data/mockData', () => ({
+  MOCK_CREDIT_LINES: [
+    {
+      id: 'CL-2024-001',
+      name: 'Primary Business Line',
+      status: 'Active',
+      limit: 500000,
+      utilized: 187500,
+      apr: 8.5,
+      riskScore: 720,
+      collateral: 'Commercial Real Estate',
+      openedAt: '2024-03-15',
+      updatedAt: '2025-02-20T14:32:00Z',
+      nextPaymentDate: '2025-03-01',
+      nextPaymentAmount: 3200,
+      transactions: [],
+      statusHistory: [],
+    },
+  ],
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Stub window.matchMedia so (prefers-reduced-motion: reduce) returns the given
+ * value. Returns a teardown function to restore the original.
+ */
+function stubMatchMedia(matches: boolean) {
+  const original = window.matchMedia;
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)' ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+  return () => {
+    Object.defineProperty(window, 'matchMedia', { writable: true, value: original });
+  };
+}
+
+/**
+ * Stub matchMedia so we can fire change events to test live preference changes.
+ */
+function stubMatchMediaWithListener(initialMatches: boolean) {
+  const listeners: Array<(e: MediaQueryListEvent) => void> = [];
+  const original = window.matchMedia;
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)' ? initialMatches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn((_event: string, cb: (e: MediaQueryListEvent) => void) => {
+        if (query === '(prefers-reduced-motion: reduce)') listeners.push(cb);
+      }),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+  return {
+    restore: () => {
+      Object.defineProperty(window, 'matchMedia', { writable: true, value: original });
+    },
+    fireChange: (newMatches: boolean) => {
+      listeners.forEach((cb) => cb({ matches: newMatches } as MediaQueryListEvent));
+    },
+  };
+}
+
+function renderPage(initialEntries = ['/repay?line=CL-2024-001']) {
+  return render(
+    <ReducedMotionProvider>
+      <MemoryRouter initialEntries={initialEntries}>
+        <RepayPage />
+      </MemoryRouter>
+    </ReducedMotionProvider>,
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('RepayPage reduced-motion — container', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // 1
+  it('root container has repay-page class for CSS targeting', () => {
+    const restore = stubMatchMedia(false);
+    renderPage();
+    const container = document.querySelector('.repay-page');
+    expect(container).toBeInTheDocument();
+    restore();
+  });
+});
+
+describe('RepayPage reduced-motion — toggle thumb', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // 2
+  it('toggle thumb has no transition classes when OS prefers-reduced-motion is active', () => {
+    const restore = stubMatchMedia(true);
+    renderPage();
+    const thumb = document.querySelector('.repay-page__toggle-thumb');
+    expect(thumb).toBeInTheDocument();
+    expect(thumb?.className).not.toMatch(/transition/);
+    restore();
+  });
+
+  // 3
+  it('toggle thumb has transition classes when OS prefers-reduced-motion is not active', () => {
+    const restore = stubMatchMedia(false);
+    renderPage();
+    const thumb = document.querySelector('.repay-page__toggle-thumb');
+    expect(thumb).toBeInTheDocument();
+    expect(thumb?.className).toMatch(/transition/);
+    restore();
+  });
+});
+
+describe('RepayPage reduced-motion — primary action buttons', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // 4
+  it('Review Repayment button drops transition classes under reduced motion', () => {
+    const restore = stubMatchMedia(true);
+    renderPage();
+    const reviewBtn = screen.getByRole('button', { name: /review repayment/i });
+    expect(reviewBtn.className).not.toMatch(/transition-all/);
+    expect(reviewBtn.className).not.toMatch(/hover:brightness-110/);
+    restore();
+  });
+
+  // 5
+  it('Review Repayment button includes transition classes when motion is normal', () => {
+    const restore = stubMatchMedia(false);
+    renderPage();
+    const reviewBtn = screen.getByRole('button', { name: /review repayment/i });
+    expect(reviewBtn.className).toMatch(/transition-all/);
+    expect(reviewBtn.className).toMatch(/hover:brightness-110/);
+    restore();
+  });
+});
+
+describe('RepayPage reduced-motion — toggle track', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // 6
+  it('auto-schedule toggle track drops transition-colors under reduced motion', () => {
+    const restore = stubMatchMedia(true);
+    renderPage();
+    const toggle = screen.getByRole('switch', { name: /auto-schedule/i });
+    expect(toggle.className).not.toMatch(/transition-colors/);
+    restore();
+  });
+});
+
+describe('RepayPage reduced-motion — back button', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // 10
+  it('back button drops transition classes under reduced motion', () => {
+    const restore = stubMatchMedia(true);
+    renderPage();
+    const backBtn = screen.getByRole('button', { name: /back to credit lines/i });
+    expect(backBtn.className).not.toMatch(/transition-colors/);
+    expect(backBtn.className).not.toMatch(/hover:text-foreground/);
+    restore();
+  });
+});
+
+describe('RepayPage reduced-motion — live preference change', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('toggle thumb loses transition classes when OS enables reduced-motion at runtime', () => {
+    const { restore, fireChange } = stubMatchMediaWithListener(false);
+
+    renderPage();
+    const thumb = document.querySelector('.repay-page__toggle-thumb');
+    expect(thumb).toBeInTheDocument();
+    // Initially has transitions
+    expect(thumb?.className).toMatch(/transition/);
+
+    // Simulate OS enabling reduced-motion
+    act(() => {
+      fireChange(true);
+    });
+
+    // Should now have dropped transition classes
+    expect(thumb?.className).not.toMatch(/transition/);
+
+    restore();
+  });
+});
+
+// ── CSS source assertions ─────────────────────────────────────────────────────
+//
+// jsdom does not compute CSS from stylesheets, so we assert directly against
+// the stylesheet source. This mirrors the pattern used in RiskGauge.test.tsx
+// and Dashboard.reduced-motion.test.tsx.
+
+describe('RepayPage.css — prefers-reduced-motion rules', () => {
+  const cssPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'RepayPage.css');
+  const css = readFileSync(cssPath, 'utf-8');
+
+  // 7
+  it('contains @media (prefers-reduced-motion: reduce) block targeting .repay-page', () => {
+    expect(css).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[^}]*\.repay-page/m,
+    );
+  });
+
+  it('OS-level block disables animation-duration on .repay-page descendants', () => {
+    expect(css).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)[^}]*animation-duration:\s*0\.01ms.*!important/m,
+    );
+  });
+
+  it('OS-level block disables transition-duration on .repay-page descendants', () => {
+    expect(css).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)[^}]*transition-duration:\s*0\.01ms.*!important/m,
+    );
+  });
+
+  it('OS-level block sets scroll-behavior to auto', () => {
+    expect(css).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)[^}]*scroll-behavior:\s*auto.*!important/m,
+    );
+  });
+
+  // 8
+  it('contains [data-motion="reduced"] block targeting .repay-page', () => {
+    expect(css).toMatch(
+      /\[data-motion=["']reduced["']\]\s*\.repay-page\s*\*/m,
+    );
+  });
+
+  it('[data-motion="reduced"] block disables animation-duration on .repay-page descendants', () => {
+    expect(css).toMatch(
+      /\[data-motion=["']reduced["']\][^}]*animation-duration:\s*0\.01ms.*!important/m,
+    );
+  });
+
+  it('[data-motion="reduced"] block disables transition-duration on .repay-page descendants', () => {
+    expect(css).toMatch(
+      /\[data-motion=["']reduced["']\][^}]*transition-duration:\s*0\.01ms.*!important/m,
+    );
+  });
+
+  it('toggle thumb has explicit transition: none under prefers-reduced-motion', () => {
+    expect(css).toMatch(
+      /repay-page__toggle-thumb[^}]*transition:\s*none\s*!important/m,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #514. This PR provides a static fallback for all RepayPage animations when the user has `prefers-reduced-motion: reduce` active (OS-level) or has enabled the in-app reduced-motion override via `ReducedMotionContext`. Every interactive transition — from hover effects to the auto-schedule toggle switch — is suppressed, delivering an instant, movement-free experience for users sensitive to motion.

## What changed

### New files

| File | Purpose |
|------|---------|
| `src/pages/RepayPage.css` | Component-scoped CSS that suppresses all transitions, animations, and scroll-behavior inside `.repay-page` containers via `@media (prefers-reduced-motion: reduce)` and `[data-motion="reduced"]` selectors. Also includes explicit `transition: none` rules for the auto-schedule toggle thumb to ensure a snap rather than a slide. |
| `src/pages/__tests__/RepayPage.reduced-motion.test.tsx` | 16 focused tests covering container class presence, toggle thumb transition toggling (on/off), primary action button transitions, back button transitions, live OS preference changes at runtime, and CSS source assertions for both OS-level and in-app override rules. |

### Modified files

| File | Change summary |
|------|---------------|
| `src/pages/RepayPage.tsx` | Integrated `useReducedMotion()` from `ReducedMotionContext`, imported the new CSS file, and introduced a `motionClasses()` helper that conditionally strips Tailwind transition classes (`transition-colors`, `transition-all`, `transition`, `hover:` variants) from all interactive elements when reduced motion is active. Added `repay-page` class to root containers and `repay-page__toggle-thumb` class to the toggle thumb span for CSS targeting. |

### Elements covered (JS-level conditional transitions)

Every interactive element on the page is handled:

| Element | Transition classes stripped |
|---------|---------------------------|
| Back button (both selection & main views) | `transition-colors hover:text-foreground` |
| Credit line selection cards | `transition-all hover:border-accent hover:bg-accent/5` |
| Percentage quick-buttons (25%, 50%, 75%, MAX) | `transition-colors hover:bg-accent/10` |
| Smart Pay button | `transition-colors hover:bg-success/10` |
| Amount input field | `transition-colors` |
| Progress bars (old debt + new utilization) | `transition-all` |
| Auto-schedule toggle track | `transition-colors duration-200 ease-in-out` |
| Auto-schedule toggle thumb | `transition duration-200 ease-in-out` |
| "Review Repayment" button | `transition-all hover:brightness-110` |
| Review step "Back" button | `transition-all hover:bg-border` |
| Review step "Confirm Repayment" button | `transition-all hover:brightness-110` |
| "I need help" link | `transition-colors hover:text-blue-200 hover:underline` |
| "Cancel" link | `hover:text-accent hover:underline` |
| Success step "Back to Dashboard" button | `transition-all hover:brightness-110` |
| Success step "Make another repayment" button | `transition-all hover:bg-border` |

### CSS safety net (catch-all)

Beyond the JS-level conditional class stripping, `RepayPage.css` provides a belt-and-suspenders CSS layer that forces `transition-duration: 0.01ms !important` and `animation-duration: 0.01ms !important` on **all** descendants of `.repay-page` when reduced motion is active. This covers:
- Any transition we might have missed at the JS level
- Transitions on child components rendered inside `.repay-page` (e.g., `PayoffProjection`, `RepaymentVisualizer`)
- Future additions that might inadvertently add transitions

### Dual-path detection

The implementation respects **both** motion-reduction signals:

1. **OS-level**: `@media (prefers-reduced-motion: reduce)` — detected natively by the browser; no JS needed.
2. **In-app override**: `[data-motion="reduced"]` — set on `<html>` by `ReducedMotionContext` when the user toggles "Reduced Motion Preview" in Settings. Persisted across sessions via `storage.ts`.

The `useReducedMotion()` hook returns `isReducedMotionActive` as `true` when **either** signal is present, and the `motionClasses()` helper gates all Tailwind transitions on this single boolean.

## Why

Per WCAG 2.1 Success Criterion 2.3.3 (Animation from Interactions), users must be able to disable non-essential motion. The RepayPage previously had hardcoded `transition-colors`, `transition-all`, and `hover:` classes on 15+ interactive elements with no way to suppress them. This PR ensures:

- Users with vestibular disorders or motion sensitivity aren't disoriented by animated hover states, sliding toggles, or transitioning progress bars.
- The auto-schedule toggle snaps instantly rather than sliding.
- Scroll behavior (e.g., `smooth` scrolling inherited from parent contexts) is forced to `auto`.
- The experience degrades gracefully: all functionality remains; only the visual transitions are removed.

## Testing / Accessibility

### Test results

```
TypeScript: ✅ No errors in RepayPage.tsx
CSS source assertion tests: 8/8 passed
Rendering tests: affected by pre-existing test environment issue (node_modules)
```

### Test coverage breakdown

| Test group | Tests | What's tested |
|-----------|-------|---------------|
| Container | 1 | `.repay-page` class present for CSS targeting |
| Toggle thumb | 2 | Transition classes absent when reduced-motion is active; present when inactive |
| Primary action buttons | 2 | `transition-all hover:brightness-110` stripped/retained based on motion preference |
| Toggle track | 1 | `transition-colors` stripped from auto-schedule switch under reduced motion |
| Back button | 1 | `transition-colors hover:text-foreground` stripped under reduced motion |
| Live preference change | 1 | Toggle thumb reacts to runtime OS preference changes (media query listener) |
| CSS source assertions | 8 | Both `@media` and `[data-motion="reduced"]` blocks exist in the stylesheet; animation-duration, transition-duration, scroll-behavior all set correctly; toggle thumb has explicit `transition: none` |

### Edge cases covered
- **Live OS preference changes**: Tests verify the `ReducedMotionContext` media query listener propagates changes to the component at runtime.
- **Both detection paths**: CSS source assertions cover both the `@media` path and the `[data-motion="reduced"]` path.
- **Toggle snap**: The explicit `.repay-page__toggle-thumb { transition: none !important }` rule ensures the switch snaps rather than sliding, even if the wildcard `transition-duration: 0.01ms` were somehow insufficient.

## Accessibility Check Checklist

- [x] Keyboard navigation works (Tab, Shift+Tab, Enter, Escape) — unchanged; all buttons retain their existing `focus-visible:outline` rings
- [x] Focus indicators are clearly visible (2px outline, 2px offset) — unchanged
- [x] Contrast ratios meet WCAG AA (4.5:1 text, 3:1 large text/icons) — unchanged
- [x] Touch targets are at least 44×44 px — unchanged
- [x] Semantic HTML and ARIA roles/labels are used — unchanged; `role="switch"` with `aria-checked` retained on toggle
- [x] `prefers-reduced-motion` is respected — ✅ **this PR implements this**
- [x] `[data-motion="reduced"]` in-app override is respected — ✅ implemented via CSS selector
- [x] Scroll behavior forced to `auto` under reduced motion — ✅ `scroll-behavior: auto !important`

## Design decisions

### Why a `motionClasses()` helper instead of inline ternaries everywhere?

The helper (`motionClasses(reduced, classes)`) is defined once at module scope (no per-render cost) and makes the intent explicit: "these classes are motion-dependent." It avoids the visual noise of repeating `${isReducedMotionActive ? '' : 'transition-...'}` across 15+ elements and makes it trivial to audit which classes are gated on motion preference.

### Why both JS-level stripping AND CSS wildcard rules?

- **JS-level** handles the primary interactive elements explicitly, making the behavior testable via `className` assertions.
- **CSS wildcard** acts as a safety net for anything inside `.repay-page` that we might have missed or that might be added later (including child components).

### Why `repay-page__toggle-thumb` explicit rules in addition to the wildcard?

The wildcard rules set `transition-duration: 0.01ms !important`, which effectively neuters the toggle animation. The explicit `transition: none !important` on the toggle thumb class provides an additional guarantee and serves as documentation that the toggle snap behavior was intentionally designed, not just a side effect.

## Commit message

```
fix: RepayPage reduced-motion

Add static fallback when prefers-reduced-motion is set. All
interactive transitions (hover, toggle, progress bars, buttons)
are suppressed via both JS (motionClasses helper) and CSS
(@media / [data-motion="reduced"] wildcard rules).

Closes #514
```

## Reviewer notes

- The `motionClasses()` helper is intentionally module-scoped (not inside the component) to avoid re-creation on every render.
- The `<RepaymentVisualizer>` is rendered **inside** the `.repay-page` wrapper, so the CSS wildcard will also affect its internal elements. RepaymentVisualizer has its own reduced-motion handling (`fix: RepaymentVisualizer reduced-motion` in git history). Both approaches suppress motion, so they should be compatible — but if conflicts arise, we can move the visualizer outside `.repay-page` or scope the CSS more narrowly.
- The test file follows the exact pattern established by `Dashboard.reduced-motion.test.tsx` (GrantFox FWC26 campaign).
- Rendering tests are affected by a pre-existing `node_modules` environment issue (the original `RepayPage.test.tsx` also fails). CSS source assertion tests (8/8) pass clean.