### PR TITLE
Add reduced-motion fallback for RiskGauge (v7)

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -33,6 +33,8 @@ import { WhatChanged } from "../components/WhatChanged";
 import { HealthTipsPanel } from "../components/HealthTipsPanel";
 import { RiskGauge } from "./RiskGauge";
 
+export { RiskGauge };
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const relativeTime = (iso: string): string => {

--- a/src/pages/RiskGauge.tsx
+++ b/src/pages/RiskGauge.tsx
@@ -50,6 +50,8 @@ export function RiskGauge({
   const { isReducedMotionActive } = useReducedMotion();
   const [displayedScore, setDisplayedScore] = useState(normalizedScore);
   const prevScoreRef = useRef(normalizedScore);
+  const titleId = useRef(`risk-gauge-title-${Math.random().toString(36).slice(2)}`).current;
+  const trendLabel = trend.charAt(0).toUpperCase() + trend.slice(1);
 
   useEffect(() => {
     if (isReducedMotionActive) {
@@ -90,9 +92,24 @@ export function RiskGauge({
 
   const scoreFormatter = useMemo(() => new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }), []);
 
+  const srDescription = `Risk score ${normalizedScore} of 850. Trend: ${trendLabel}.`;
+
   return (
     <div className="risk-gauge-container">
-      <svg className="risk-gauge-svg" viewBox="0 0 160 100" preserveAspectRatio="xMidYMid meet">
+      {/* Screen-reader description outside the SVG for AT that skip inline <title>. */}
+      <p className="sr-only" aria-live="polite" aria-atomic="true">
+        {srDescription}
+      </p>
+      <svg
+        className="risk-gauge-svg"
+        viewBox="0 0 160 100"
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        aria-label={srDescription}
+        data-testid="risk-gauge-svg"
+        data-reduced-motion={isReducedMotionActive ? "true" : "false"}
+      >
+        <title id={titleId}>{srDescription}</title>
         <path
           className="risk-gauge-bg"
           d={`M ${cx - radius} ${cy} A ${radius} ${radius} 0 0 1 ${cx + radius} ${cy}`}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,20 @@
 import "@testing-library/jest-dom";
 import "../index.css";
-import { beforeEach } from "vitest";
+import { beforeEach, vi } from "vitest";
 
+beforeEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});


### PR DESCRIPTION
## Summary
The Dashboard's inline `RiskGauge` (`src/pages/RiskGauge.tsx`) already gated its score-tween animation behind `isReducedMotionActive`, but had no accessible description and no way to inspect/test the reduced-motion state from the rendered DOM. This PR:

- Adds `role="img"`, `aria-label`, an in-SVG `<title>`, and a `data-testid="risk-gauge-svg"` to the gauge SVG
- Adds `data-reduced-motion="true"/"false"` reflecting `useReducedMotion().isReducedMotionActive`
- Adds a matching `<p className="sr-only" aria-live="polite">` sibling paragraph for AT that skip inline SVG titles
- Re-exports `RiskGauge` from `Dashboard.tsx` so it's importable as the "Dashboard inline RiskGauge"
- Adds a default `window.matchMedia` stub to the global vitest setup (`src/test/setup.ts`), which was completely missing and crashed any component reading `prefers-reduced-motion` without a per-test stub

## Test plan
`src/pages/Dashboard.reduced-motion.test.tsx` is the pre-existing GrantFox FWC26 spec for this issue — it covers the OS-preference attribute, in-app override, tween vs. snap behavior, live preference-change updates, and the accessibility markup above.

- `npx vitest run src/pages/Dashboard.reduced-motion.test.tsx` — 20/20 passing (0/20 passing before this change)
- `npx vitest run src/components/RiskGauge.test.tsx` — 51/51 passing, unaffected
- Verified `Dashboard.test.tsx`'s pre-existing failures (stale snapshots, unrelated skeleton/dialog tests) are present on unmodified `main` too — this change doesn't introduce them, and fixes 2 of them incidentally

Closes #604