### PR TITLE
Polish draw amount buffer guidance

### DIFF
--- a/src/components/AmountInput.test.tsx
+++ b/src/components/AmountInput.test.tsx
@@ -134,7 +134,9 @@ describe("AmountInput", () => {
     });
 
     expect(screen.getByText("Draw amount looks good")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /continue/i }),
+    ).not.toBeDisabled();
   });
 
   it("enables continue button only when amount is valid", () => {
@@ -179,7 +181,9 @@ describe("AmountInput", () => {
     });
 
     expect(input.value).toBe("1500.00");
-    expect(screen.getByText("Pasted value sanitized to $1,500.00")).toBeInTheDocument();
+    expect(
+      screen.getByText("Pasted value sanitized to $1,500.00"),
+    ).toBeInTheDocument();
   });
 
   it("rejects non-numeric pasted text and announces the error", () => {
@@ -207,6 +211,20 @@ describe("AmountInput", () => {
     expect(
       screen.getByText("Invalid amount pasted. Please enter a numeric value."),
     ).toBeInTheDocument();
+  });
+
+  it("renders a suggested buffer hint to make reserve guidance clearer", () => {
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={vi.fn()}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Suggested buffer")).toBeInTheDocument();
+    expect(screen.getByText(/keep a small safety buffer/i)).toBeInTheDocument();
   });
 
   it("renders explicit +/- stepper buttons with accessible labels", () => {
@@ -360,17 +378,15 @@ describe("AmountInput", () => {
 
   describe("Skeleton Loading State (v7)", () => {
     it("renders loading skeleton on first paint when isLoading is true", () => {
-      render(
-        <AmountInput
-          creditLine={creditLine}
-          isLoading={true}
-        />,
-      );
+      render(<AmountInput creditLine={creditLine} isLoading={true} />);
 
       const skeletonRegion = screen.getByTestId("amount-input-skeleton");
       expect(skeletonRegion).toBeInTheDocument();
       expect(skeletonRegion).toHaveAttribute("aria-busy", "true");
-      expect(skeletonRegion).toHaveAttribute("aria-label", "Loading amount input");
+      expect(skeletonRegion).toHaveAttribute(
+        "aria-label",
+        "Loading amount input",
+      );
       expect(screen.queryByLabelText(/draw amount/i)).not.toBeInTheDocument();
     });
 
@@ -389,45 +405,46 @@ describe("AmountInput", () => {
       expect(skeletonRegion).toBeInTheDocument();
       expect(skeletonRegion).toHaveAttribute("role", "region");
       expect(skeletonRegion).toHaveAttribute("aria-busy", "true");
-      expect(skeletonRegion).toHaveAttribute("aria-label", "Loading amount input");
+      expect(skeletonRegion).toHaveAttribute(
+        "aria-label",
+        "Loading amount input",
+      );
     });
   });
 
   describe("Design Tokens & Typography Spacing (v7)", () => {
     it("pins root container spacing and header typography to design tokens", () => {
-      render(
-        <AmountInput
-          creditLine={creditLine}
-          onAmountChange={vi.fn()}
-        />,
-      );
+      render(<AmountInput creditLine={creditLine} onAmountChange={vi.fn()} />);
 
       const heading = screen.getByRole("heading", { name: /enter amount/i });
-      expect(heading).toHaveClass("text-2xl", "sm:text-3xl", "font-bold", "text-foreground", "leading-[var(--lh-heading)]", "tracking-tight");
+      expect(heading).toHaveClass(
+        "text-2xl",
+        "sm:text-3xl",
+        "font-bold",
+        "text-foreground",
+        "leading-[var(--lh-heading)]",
+        "tracking-tight",
+      );
     });
 
     it("applies design token classes to input box, dollar prefix, and stepper controls", () => {
-      render(
-        <AmountInput
-          creditLine={creditLine}
-          onAmountChange={vi.fn()}
-        />,
-      );
+      render(<AmountInput creditLine={creditLine} onAmountChange={vi.fn()} />);
 
       const input = screen.getByLabelText(/draw amount/i);
       expect(input).toHaveClass("tabular-nums", "leading-[var(--lh-display)]");
 
-      const maxButton = screen.getByRole("button", { name: /set amount to maximum/i });
-      expect(maxButton).toHaveClass("text-accent", "focus-visible:ring-accent", "min-h-[44px]");
+      const maxButton = screen.getByRole("button", {
+        name: /set amount to maximum/i,
+      });
+      expect(maxButton).toHaveClass(
+        "text-accent",
+        "focus-visible:ring-accent",
+        "min-h-[44px]",
+      );
     });
 
     it("maps severity validation tones to semantic status color tokens", () => {
-      render(
-        <AmountInput
-          creditLine={creditLine}
-          onAmountChange={vi.fn()}
-        />,
-      );
+      render(<AmountInput creditLine={creditLine} onAmountChange={vi.fn()} />);
 
       const input = screen.getByLabelText(/draw amount/i);
 
@@ -448,25 +465,41 @@ describe("AmountInput", () => {
       );
 
       const presetButton = screen.getByRole("button", { name: /25 percent/i });
-      expect(presetButton).toHaveClass("border-border", "hover:border-accent", "focus-visible:ring-accent", "min-h-[44px]");
+      expect(presetButton).toHaveClass(
+        "border-border",
+        "hover:border-accent",
+        "focus-visible:ring-accent",
+        "min-h-[44px]",
+      );
 
       const continueButton = screen.getByRole("button", { name: /continue/i });
-      expect(continueButton).toHaveClass("bg-accent", "focus-visible:ring-accent", "min-h-[44px]");
+      expect(continueButton).toHaveClass(
+        "bg-accent",
+        "focus-visible:ring-accent",
+        "min-h-[44px]",
+      );
 
       const backButton = screen.getByRole("button", { name: /back/i });
-      expect(backButton).toHaveClass("border-border", "text-foreground", "focus-visible:ring-accent", "min-h-[44px]");
+      expect(backButton).toHaveClass(
+        "border-border",
+        "text-foreground",
+        "focus-visible:ring-accent",
+        "min-h-[44px]",
+      );
     });
 
     it("renders constraint boxes with typography rhythm tokens and tabular numerals", () => {
-      render(
-        <AmountInput
-          creditLine={creditLine}
-          onAmountChange={vi.fn()}
-        />,
-      );
+      render(<AmountInput creditLine={creditLine} onAmountChange={vi.fn()} />);
 
       const minLabel = screen.getByText("Minimum draw");
-      expect(minLabel).toHaveClass("text-[11px]", "font-semibold", "uppercase", "tracking-wider", "text-muted", "leading-[var(--lh-small)]");
+      expect(minLabel).toHaveClass(
+        "text-[11px]",
+        "font-semibold",
+        "uppercase",
+        "tracking-wider",
+        "text-muted",
+        "leading-[var(--lh-small)]",
+      );
     });
   });
 });

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -52,11 +52,27 @@ export function AmountInputSkeleton() {
 
         {/* Input box with stepper buttons skeleton */}
         <div className="flex items-center gap-2 bg-surface p-4 rounded-xl border border-border">
-          <Skeleton width="44px" height="44px" className="rounded-lg shrink-0" />
-          <Skeleton width="24px" height="32px" className="rounded-md shrink-0" />
+          <Skeleton
+            width="44px"
+            height="44px"
+            className="rounded-lg shrink-0"
+          />
+          <Skeleton
+            width="24px"
+            height="32px"
+            className="rounded-md shrink-0"
+          />
           <Skeleton width="100%" height="40px" className="rounded-lg flex-1" />
-          <Skeleton width="44px" height="44px" className="rounded-lg shrink-0" />
-          <Skeleton width="56px" height="36px" className="rounded-lg shrink-0" />
+          <Skeleton
+            width="44px"
+            height="44px"
+            className="rounded-lg shrink-0"
+          />
+          <Skeleton
+            width="56px"
+            height="36px"
+            className="rounded-lg shrink-0"
+          />
         </div>
 
         {/* Constraint cards skeleton */}
@@ -74,7 +90,12 @@ export function AmountInputSkeleton() {
 
         {/* Inline message placeholder skeleton */}
         <div className="h-[60px] rounded-lg border border-border/40 bg-surface/30 p-3 flex items-center gap-3">
-          <Skeleton width="20px" height="20px" shape="circular" className="shrink-0" />
+          <Skeleton
+            width="20px"
+            height="20px"
+            shape="circular"
+            className="shrink-0"
+          />
           <div className="space-y-1 flex-1">
             <Skeleton width="40%" height="0.875rem" className="rounded-sm" />
             <Skeleton width="70%" height="0.75rem" className="rounded-sm" />
@@ -145,9 +166,10 @@ export function AmountInput({
       if (!creditLine) return;
       setAmount((prev) => {
         const current = parseFloat(prev) || 0;
-        const next = direction === "up"
-          ? Math.min(current + STEP_AMOUNT, creditLine.available)
-          : Math.max(current - STEP_AMOUNT, 0);
+        const next =
+          direction === "up"
+            ? Math.min(current + STEP_AMOUNT, creditLine.available)
+            : Math.max(current - STEP_AMOUNT, 0);
         return next.toString();
       });
     },
@@ -157,16 +179,18 @@ export function AmountInput({
   const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
     e.preventDefault();
     const pastedText = e.clipboardData.getData("text");
-    
+
     // Sanitize: Strip $, commas, and whitespace
     const sanitized = pastedText.replace(/[$,\s]/g, "");
-    
+
     // Validate if it's a valid number
     if (sanitized === "" || isNaN(parseFloat(sanitized))) {
-      setPasteAnnouncement("Invalid amount pasted. Please enter a numeric value.");
+      setPasteAnnouncement(
+        "Invalid amount pasted. Please enter a numeric value.",
+      );
       return;
     }
-    
+
     const numValue = parseFloat(sanitized);
     setAmount(sanitized);
     setPasteAnnouncement(`Pasted value sanitized to ${formatMoney(numValue)}`);
@@ -210,28 +234,48 @@ export function AmountInput({
       bg: "bg-accent/10",
       border: "border-accent/30",
       text: "text-foreground",
-      icon: <Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-accent" aria-hidden="true" />,
+      icon: (
+        <Info
+          className="mt-0.5 h-4 w-4 flex-shrink-0 text-accent"
+          aria-hidden="true"
+        />
+      ),
       input: "border-border focus-within:border-accent",
     },
     success: {
       bg: "bg-success/10",
       border: "border-success/30",
       text: "text-foreground",
-      icon: <CheckCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-success" aria-hidden="true" />,
+      icon: (
+        <CheckCircle
+          className="mt-0.5 h-4 w-4 flex-shrink-0 text-success"
+          aria-hidden="true"
+        />
+      ),
       input: "border-success/60 focus-within:border-success",
     },
     warning: {
       bg: "bg-warning/10",
       border: "border-warning/30",
       text: "text-foreground",
-      icon: <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-warning" aria-hidden="true" />,
+      icon: (
+        <AlertTriangle
+          className="mt-0.5 h-4 w-4 flex-shrink-0 text-warning"
+          aria-hidden="true"
+        />
+      ),
       input: "border-warning/60 focus-within:border-warning",
     },
     danger: {
       bg: "bg-error/10",
       border: "border-error/30",
       text: "text-foreground",
-      icon: <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-error" aria-hidden="true" />,
+      icon: (
+        <AlertCircle
+          className="mt-0.5 h-4 w-4 flex-shrink-0 text-error"
+          aria-hidden="true"
+        />
+      ),
       input: "border-error/70 focus-within:border-error",
     },
   };
@@ -266,10 +310,16 @@ export function AmountInput({
         </label>
 
         {/* Helper text explaining the input */}
-        <p id={helperId} className="text-sm text-muted leading-[var(--lh-body)]">
+        <p
+          id={helperId}
+          className="text-sm text-muted leading-[var(--lh-body)]"
+        >
           Enter the amount you wish to draw from your available credit.
           Available limit:{" "}
-          <span className="font-semibold text-foreground tabular-nums amount" data-amount>
+          <span
+            className="font-semibold text-foreground tabular-nums amount"
+            data-amount
+          >
             {formatMoney(creditLine.available)}
           </span>
         </p>
@@ -334,7 +384,7 @@ export function AmountInput({
           </button>
         </div>
 
-        {/* Constraint boxes showing min, available, and reserve */}
+        {/* Constraint boxes showing min, available, and suggested buffer */}
         <div id={constraintsId} className="grid gap-2 sm:grid-cols-3">
           <div className="rounded-lg border border-border bg-background/60 px-3 py-2.5 space-y-0.5">
             <p className="text-[11px] font-semibold uppercase tracking-wider text-muted leading-[var(--lh-small)]">
@@ -354,10 +404,32 @@ export function AmountInput({
           </div>
           <div className="rounded-lg border border-border bg-background/60 px-3 py-2.5 space-y-0.5">
             <p className="text-[11px] font-semibold uppercase tracking-wider text-muted leading-[var(--lh-small)]">
-              Reserve
+              Buffer
             </p>
             <p className="text-sm font-semibold text-foreground tabular-nums leading-[var(--lh-body)]">
               {formatMoney(validation.recommendedReserve)}
+            </p>
+          </div>
+        </div>
+
+        <div
+          className="flex items-start gap-2 rounded-lg border border-accent/30 bg-accent/10 px-3 py-3"
+          role="note"
+        >
+          <Info
+            className="mt-0.5 h-4 w-4 shrink-0 text-accent"
+            aria-hidden="true"
+          />
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-foreground">
+              Suggested buffer
+            </p>
+            <p className="text-sm text-muted leading-[var(--lh-body)]">
+              Keep a small safety buffer in reserve for fees and urgent
+              liquidity.
+            </p>
+            <p className="text-sm font-medium text-foreground tabular-nums">
+              Recommended reserve: {formatMoney(validation.recommendedReserve)}
             </p>
           </div>
         </div>


### PR DESCRIPTION
Closes #660 


## PR Summary
This PR improves the draw amount experience by making the reserve/buffer guidance clearer and more actionable for users in the credit draw flow.

## What changed
- Updated the amount input summary to label the reserve guidance as a “Buffer” instead of “Reserve”.
- Added a dedicated “Suggested buffer” callout to explain why keeping a small safety reserve is helpful for fees and urgent liquidity.
- Kept the existing validation logic and flow intact while improving clarity and confidence in the UI.
- Added a regression test to cover the new buffer guidance messaging.

## Why
The previous copy made the reserve concept feel slightly abstract. This polish makes the guidance easier to understand at a glance and better aligned with the user’s decision-making during the draw flow.

## Validation
- Reviewed the updated component and associated tests
- Verified the changed files are free of editor-reported errors