### PR TITLE
feat: RepaymentVisualizer empty state

### DIFF
--- a/src/components/RepaymentVisualizer.test.tsx
+++ b/src/components/RepaymentVisualizer.test.tsx
@@ -17,7 +17,7 @@ describe('RepaymentVisualizer', () => {
     expect(screen.getByText('Repayment Plan')).toBeInTheDocument();
   });
 
-  it('renders EmptyState when inputs are missing or zero', () => {
+  it('renders themed EmptyState when inputs are missing or zero', () => {
     render(
       <ReducedMotionProvider>
         <RepaymentVisualizer
@@ -27,6 +27,8 @@ describe('RepaymentVisualizer', () => {
         />
       </ReducedMotionProvider>
     );
-    expect(screen.getByText('Enter a valid principal, APR, and monthly payment to see the repayment plan.')).toBeInTheDocument();
+    expect(screen.getByTestId('repayment-visualizer-empty')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'No repayment data yet' })).toBeInTheDocument();
+    expect(screen.getByText(/Enter a valid principal, APR, and monthly payment/)).toBeInTheDocument();
   });
 });

--- a/src/components/RepaymentVisualizer.tsx
+++ b/src/components/RepaymentVisualizer.tsx
@@ -29,6 +29,8 @@ import React, { useState, useRef, useCallback, useId } from 'react';
 import { COLOR } from '@/utils/tokens';
 import { KbdHint } from './KbdHint';
 import { useReducedMotion } from '@/context/ReducedMotionContext';
+import { EmptyState } from './EmptyState';
+import { NoDataGraph } from './illustrations';
 import './RepaymentVisualizer.css';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -581,14 +583,15 @@ function VisibleTable({ schedule, limit = 12 }: VisibleTableProps) {
 
 // ─── Empty state ───────────────────────────────────────────────────────────────
 
-function EmptyState() {
+function EmptyStatePrompt() {
   return (
-    <p
-      className="text-center p-4 sm:p-8"
-      style={{ color: `var(--muted, ${COLOR.muted})`, fontSize: 'var(--text-sm)' }}
-    >
-      Enter a valid principal, APR, and monthly payment to see the repayment plan.
-    </p>
+    <EmptyState
+      data-testid="repayment-visualizer-empty"
+      illustration={<NoDataGraph />}
+      eyebrow="Repayment Plan"
+      title="No repayment data yet"
+      description="Enter a valid principal, APR, and monthly payment to see your projected repayment plan, including monthly breakdowns and interest calculations."
+    />
   );
 }
 
@@ -699,7 +702,7 @@ export function RepaymentVisualizer({
       </header>
 
       {schedule.length === 0 ? (
-        <EmptyState />
+        <EmptyStatePrompt />
       ) : (
         <>
           {/* Chart wrapper — carries data-reduced-motion for CSS targeting */}

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -55,7 +55,7 @@ type SkeletonProps = React.HTMLAttributes<HTMLDivElement> & {
  * (the runtime JS toggle managed by ReducedMotionContext).
  * See the loading-state policy in `docs/ARCHITECTURE.md` §5.
  */
-export const Skeleton: React.FC<SkeletonProps> = ({ width, height, shape = 'rectangular', style, className, 'aria-hidden': ariaHidden = true, ...rest }) => (
+export const Skeleton: React.FC<SkeletonProps> = ({ width, height, shape = 'rectangular', variant, style, className, 'aria-hidden': ariaHidden = true, ...rest }) => (
   <div
     className={[
       'skeleton',


### PR DESCRIPTION
Closes #611

## Summary
Adds themed empty-state illustration for RepaymentVisualizer (v7).

## Changes
- Imported `EmptyState` component and `NoDataGraph` illustration
- Replaced plain-text empty state with themed `EmptyState` component
- Renamed local `EmptyState` function to `EmptyStatePrompt` to avoid naming conflict
- Empty state now includes illustration, eyebrow, title, and description
- Fixed Skeleton.tsx variant destructuring bug
- Updated tests to match new themed empty state (53 total pass)

## Test Results
```
✓ 2 tests passed in RepaymentVisualizer.test.tsx
✓ 51 tests passed in __tests__/RepaymentVisualizer.test.tsx
```