### PR TITLE
feat: AmountInput empty state

### DIFF
--- a/src/components/AmountInput.test.tsx
+++ b/src/components/AmountInput.test.tsx
@@ -374,8 +374,19 @@ describe("AmountInput", () => {
       expect(screen.queryByLabelText(/draw amount/i)).not.toBeInTheDocument();
     });
 
-    it("renders skeleton when creditLine is not yet provided", () => {
-      render(<AmountInput isLoading={false} />);
+    it("renders themed empty state when creditLine is not yet provided and not loading", () => {
+      const onBack = vi.fn();
+      render(<AmountInput isLoading={false} onBack={onBack} />);
+
+      const emptyRegion = screen.getByTestId("amount-input-empty");
+      expect(emptyRegion).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "No credit line selected" })).toBeInTheDocument();
+      expect(screen.getByText(/Select a credit line from the dashboard/)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Go back" })).toBeInTheDocument();
+    });
+
+    it("renders skeleton when creditLine is not yet provided but loading", () => {
+      render(<AmountInput isLoading={true} />);
 
       const skeletonRegion = screen.getByTestId("amount-input-skeleton");
       expect(skeletonRegion).toBeInTheDocument();

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -14,6 +14,8 @@ import {
 } from "../utils/amountValidation";
 import { FormMessage } from "./FormMessage";
 import { Skeleton } from "./Skeleton";
+import { EmptyState } from "./EmptyState";
+import { NoDataGraph } from "./illustrations";
 
 const STEP_AMOUNT = 100;
 
@@ -199,8 +201,21 @@ export function AmountInput({
     setAmount(preset.toString());
   };
 
-  if (isLoading || !creditLine) {
+  if (isLoading) {
     return <AmountInputSkeleton />;
+  }
+
+  if (!creditLine) {
+    return (
+      <EmptyState
+        data-testid="amount-input-empty"
+        illustration={<NoDataGraph />}
+        eyebrow="Draw Credit"
+        title="No credit line selected"
+        description="Select a credit line from the dashboard to get started. Once a line is available, you can set the draw amount and submit your request."
+        primaryAction={onBack ? { label: "Go back", onClick: onBack } : undefined}
+      />
+    );
   }
 
   const numAmount = parseFloat(amount) || 0;

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -55,7 +55,7 @@ type SkeletonProps = React.HTMLAttributes<HTMLDivElement> & {
  * (the runtime JS toggle managed by ReducedMotionContext).
  * See the loading-state policy in `docs/ARCHITECTURE.md` §5.
  */
-export const Skeleton: React.FC<SkeletonProps> = ({ width, height, shape = 'rectangular', style, className, 'aria-hidden': ariaHidden = true, ...rest }) => (
+export const Skeleton: React.FC<SkeletonProps> = ({ width, height, shape = 'rectangular', variant, style, className, 'aria-hidden': ariaHidden = true, ...rest }) => (
   <div
     className={[
       'skeleton',


### PR DESCRIPTION
Closes #621

## Summary
Adds themed empty-state illustration for AmountInput (v7).

## Changes
- Imported `EmptyState` component and `NoDataGraph` illustration
- Differentiated loading (skeleton) vs empty (no credit line) states
- Shows themed EmptyState with illustration, eyebrow, title, description, and "Go back" CTA when no credit line is selected
- Fixed Skeleton.tsx variant destructuring bug
- Updated tests to cover new empty-state behavior (27 total pass)

## Test Results
```
✓ 27 tests passed in AmountInput.test.tsx
```