### PR TITLE
fix: AmountInput reduced-motion

### DIFF
--- a/src/components/AmountInput.css
+++ b/src/components/AmountInput.css
@@ -1,0 +1,36 @@
+/**
+ * AmountInput — reduced-motion styles
+ *
+ * When either the OS/browser `prefers-reduced-motion: reduce` media query
+ * is active OR the in-app reduced-motion override is enabled via
+ * `ReducedMotionContext`, all transition animations on interactive
+ * elements are suppressed.
+ *
+ * Two independent mechanisms:
+ *   1. `@media (prefers-reduced-motion: reduce)` — OS-level preference.
+ *   2. `[data-reduced-motion="true"]` — in-app override set by the React
+ *      component when `useReducedMotion()` reports `isReducedMotionActive`.
+ *
+ * WCAG 2.3.3 (AAA) – Animation from Interactions: suppressing non-essential
+ * animation when the user requests it.
+ */
+
+/* ─── OS-level reduced-motion ────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .amount-input-root *,
+  .amount-input-root *::before,
+  .amount-input-root *::after {
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+  }
+}
+
+/* ─── In-app reduced-motion override ─────────────────────────────────────── */
+
+.amount-input-root[data-reduced-motion="true"] *,
+.amount-input-root[data-reduced-motion="true"] *::before,
+.amount-input-root[data-reduced-motion="true"] *::after {
+  transition-duration: 0s !important;
+  transition-delay: 0s !important;
+}

--- a/src/components/AmountInput.test.tsx
+++ b/src/components/AmountInput.test.tsx
@@ -1,6 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AmountInput, AmountInputSkeleton } from "./AmountInput";
+import * as ReducedMotionContext from "../context/ReducedMotionContext";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 
 describe("AmountInput", () => {
   const creditLine = {
@@ -467,6 +470,117 @@ describe("AmountInput", () => {
 
       const minLabel = screen.getByText("Minimum draw");
       expect(minLabel).toHaveClass("text-[11px]", "font-semibold", "uppercase", "tracking-wider", "text-muted", "leading-[var(--lh-small)]");
+    });
+  });
+
+  describe("Reduced Motion (v7)", () => {
+    it("adds data-reduced-motion=true attribute on root when reduced motion is active", () => {
+      vi.spyOn(ReducedMotionContext, "useReducedMotion").mockReturnValue({
+        motionOverride: "reduced",
+        toggleMotionOverride: vi.fn(),
+        setMotionOverride: vi.fn(),
+        isReducedMotionActive: true,
+      });
+
+      const { container } = render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+        />,
+      );
+
+      const root = container.querySelector(".amount-input-root");
+      expect(root).toHaveAttribute("data-reduced-motion", "true");
+
+      vi.restoreAllMocks();
+    });
+
+    it("omits data-reduced-motion attribute when reduced motion is not active", () => {
+      vi.spyOn(ReducedMotionContext, "useReducedMotion").mockReturnValue({
+        motionOverride: "system",
+        toggleMotionOverride: vi.fn(),
+        setMotionOverride: vi.fn(),
+        isReducedMotionActive: false,
+      });
+
+      const { container } = render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+        />,
+      );
+
+      const root = container.querySelector(".amount-input-root");
+      expect(root).not.toHaveAttribute("data-reduced-motion");
+
+      vi.restoreAllMocks();
+    });
+
+    it("renders transition classes on stepper and action buttons when motion is active", () => {
+      vi.spyOn(ReducedMotionContext, "useReducedMotion").mockReturnValue({
+        motionOverride: "system",
+        toggleMotionOverride: vi.fn(),
+        setMotionOverride: vi.fn(),
+        isReducedMotionActive: false,
+      });
+
+      render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+        />,
+      );
+
+      const decreaseBtn = screen.getByRole("button", { name: /decrease amount/i });
+      const increaseBtn = screen.getByRole("button", { name: /increase amount/i });
+      const continueBtn = screen.getByRole("button", { name: /continue/i });
+
+      expect(decreaseBtn.className).toContain("transition-all");
+      expect(increaseBtn.className).toContain("transition-all");
+      expect(continueBtn.className).toContain("transition-all");
+
+      vi.restoreAllMocks();
+    });
+
+    it("omits transition classes on buttons when reduced motion is active", () => {
+      vi.spyOn(ReducedMotionContext, "useReducedMotion").mockReturnValue({
+        motionOverride: "reduced",
+        toggleMotionOverride: vi.fn(),
+        setMotionOverride: vi.fn(),
+        isReducedMotionActive: true,
+      });
+
+      render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+        />,
+      );
+
+      const decreaseBtn = screen.getByRole("button", { name: /decrease amount/i });
+      const increaseBtn = screen.getByRole("button", { name: /increase amount/i });
+      const continueBtn = screen.getByRole("button", { name: /continue/i });
+
+      expect(decreaseBtn.className).not.toContain("transition-all");
+      expect(increaseBtn.className).not.toContain("transition-all");
+      expect(continueBtn.className).not.toContain("transition-all");
+
+      vi.restoreAllMocks();
+    });
+
+    it("AmountInput CSS file includes prefers-reduced-motion reduce rule", () => {
+      const cssPath = resolve(__dirname, "AmountInput.css");
+      const css = readFileSync(cssPath, "utf-8");
+      expect(css).toContain("prefers-reduced-motion: reduce");
+      expect(css).toContain("transition-duration: 0s");
     });
   });
 });

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -14,11 +14,16 @@ import {
 } from "../utils/amountValidation";
 import { FormMessage } from "./FormMessage";
 import { Skeleton } from "./Skeleton";
+import { useReducedMotion } from "../context/ReducedMotionContext";
+import "./AmountInput.css";
 
 const STEP_AMOUNT = 100;
 
-const stepClasses =
-  "flex items-center justify-center w-11 h-11 rounded-lg border border-border bg-background/60 text-foreground hover:bg-surface hover:border-accent/50 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:opacity-40 disabled:cursor-not-allowed";
+function buildStepClasses(reducedMotion: boolean): string {
+  const base =
+    "flex items-center justify-center w-11 h-11 rounded-lg border border-border bg-background/60 text-foreground hover:bg-surface hover:border-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:opacity-40 disabled:cursor-not-allowed";
+  return reducedMotion ? base : `${base} transition-all`;
+}
 
 const STEP_ICON_CLASS = "h-4 w-4 stroke-[2.5]";
 
@@ -127,6 +132,7 @@ export function AmountInput({
   const [amount, setAmount] = useState("");
   const [pasteAnnouncement, setPasteAnnouncement] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
+  const { isReducedMotionActive: reducedMotion } = useReducedMotion();
   const inputId = "draw-amount-input";
   const helperId = "draw-amount-helper";
   const errorId = "draw-amount-error";
@@ -242,9 +248,13 @@ export function AmountInput({
   const handleMaxClick = () => handlePreset(100);
   const getMessageType = () => validation.feedback.severity;
   const describedBy = `${helperId} ${constraintsId} ${statusId}${hasError ? ` ${errorId}` : ""}`;
+  const stepBtnClasses = buildStepClasses(reducedMotion);
 
   return (
-    <div className="space-y-6 sm:space-y-8">
+    <div
+      className="amount-input-root space-y-6 sm:space-y-8"
+      data-reduced-motion={reducedMotion ? "true" : undefined}
+    >
       <div>
         <h2 className="text-2xl sm:text-3xl font-bold text-foreground leading-[var(--lh-heading)] tracking-tight">
           Enter Amount
@@ -276,12 +286,12 @@ export function AmountInput({
 
         {/* Input field with border styling based on validation state */}
         <div
-          className={`flex items-center gap-2 sm:gap-3 bg-surface p-3.5 sm:p-4 rounded-xl border-2 overflow-hidden transition-colors ${inputStateClassName}`}
+          className={`flex items-center gap-2 sm:gap-3 bg-surface p-3.5 sm:p-4 rounded-xl border-2 overflow-hidden ${reducedMotion ? "" : "transition-colors"} ${inputStateClassName}`}
         >
           <button
             onClick={() => handleStep("down")}
             disabled={numAmount <= 0}
-            className={stepClasses}
+            className={stepBtnClasses}
             aria-label="Decrease amount"
             aria-controls={inputId}
             type="button"
@@ -316,7 +326,7 @@ export function AmountInput({
           <button
             onClick={() => handleStep("up")}
             disabled={numAmount >= creditLine.available}
-            className={stepClasses}
+            className={stepBtnClasses}
             aria-label="Increase amount"
             aria-controls={inputId}
             type="button"
@@ -326,7 +336,7 @@ export function AmountInput({
           {/* Max button for quick-fill with accessible label */}
           <button
             onClick={handleMaxClick}
-            className="px-3 py-2 text-sm font-semibold text-accent hover:bg-accent/10 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface flex-shrink-0 min-h-[44px]"
+            className={`px-3 py-2 text-sm font-semibold text-accent hover:bg-accent/10 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface flex-shrink-0 min-h-[44px]${reducedMotion ? "" : " transition-colors"}`}
             aria-label="Set amount to maximum available credit"
             type="button"
           >
@@ -398,7 +408,7 @@ export function AmountInput({
                   Math.floor((creditLine.available * percent) / 100).toString(),
                 )
               }
-              className="py-2.5 px-3 border-2 border-border rounded-lg hover:border-accent hover:bg-surface transition-all text-foreground font-medium text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px] flex items-center justify-center"
+              className={`py-2.5 px-3 border-2 border-border rounded-lg hover:border-accent hover:bg-surface text-foreground font-medium text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px] flex items-center justify-center${reducedMotion ? "" : " transition-all"}`}
               aria-label={`Set amount to ${percent} percent of available credit`}
               type="button"
             >
@@ -436,7 +446,7 @@ export function AmountInput({
       <div className="flex gap-3 pt-4">
         <button
           onClick={onBack}
-          className="flex-1 py-3 px-4 border-2 border-border text-foreground rounded-lg hover:bg-surface transition-colors font-semibold text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px]"
+          className={`flex-1 py-3 px-4 border-2 border-border text-foreground rounded-lg hover:bg-surface font-semibold text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px]${reducedMotion ? "" : " transition-colors"}`}
           type="button"
         >
           Back
@@ -444,7 +454,7 @@ export function AmountInput({
         <button
           onClick={() => onNext(numAmount)}
           disabled={!isValid}
-          className="flex-1 py-3 px-4 bg-accent text-background rounded-lg hover:bg-accent/90 transition-all font-semibold text-sm disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px]"
+          className={`flex-1 py-3 px-4 bg-accent text-background rounded-lg hover:bg-accent/90 font-semibold text-sm disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px]${reducedMotion ? "" : " transition-all"}`}
           type="button"
         >
           Continue

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -55,7 +55,7 @@ type SkeletonProps = React.HTMLAttributes<HTMLDivElement> & {
  * (the runtime JS toggle managed by ReducedMotionContext).
  * See the loading-state policy in `docs/ARCHITECTURE.md` §5.
  */
-export const Skeleton: React.FC<SkeletonProps> = ({ width, height, shape = 'rectangular', style, className, 'aria-hidden': ariaHidden = true, ...rest }) => (
+export const Skeleton: React.FC<SkeletonProps> = ({ width, height, shape = 'rectangular', variant, style, className, 'aria-hidden': ariaHidden = true, ...rest }) => (
   <div
     className={[
       'skeleton',


### PR DESCRIPTION
Closes #624

## Summary
Adds reduced-motion fallback for AmountInput (v7).

## Changes
- Added `useReducedMotion` hook to detect OS/in-app reduced-motion preference
- Added `data-reduced-motion` attribute to root wrapper for CSS targeting
- Conditionally suppresses `transition-*` classes on stepper buttons, Max button, preset chips, and action buttons
- Created `AmountInput.css` with `@media (prefers-reduced-motion: reduce)` and `[data-reduced-motion="true"]` CSS fallback rules
- Fixed Skeleton.tsx variant destructuring bug
- Added 5 reduced-motion tests (31 total pass)

## Test Results
```
✓ 31 tests passed in AmountInput.test.tsx
✓ All RepaymentVisualizer tests pass (53 total)
```