### PR TITLE
fix: AmountInput responsive

### DIFF
--- a/src/components/AmountInput.test.tsx
+++ b/src/components/AmountInput.test.tsx
@@ -469,4 +469,81 @@ describe("AmountInput", () => {
       expect(minLabel).toHaveClass("text-[11px]", "font-semibold", "uppercase", "tracking-wider", "text-muted", "leading-[var(--lh-small)]");
     });
   });
+
+  describe("Responsive Breakpoints (v7)", () => {
+    it("uses grid-cols-2 on narrow viewports and xs:grid-cols-4 for preset chips", () => {
+      render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+        />,
+      );
+
+      const presetButton = screen.getByRole("button", { name: /25 percent/i });
+      const presetGrid = presetButton.closest(".grid");
+      expect(presetGrid).toHaveClass("grid-cols-2");
+      expect(presetGrid).toHaveClass("xs:grid-cols-4");
+    });
+
+    it("stacks action buttons vertically on narrow and row on wider viewports", () => {
+      render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+        />,
+      );
+
+      const backButton = screen.getByRole("button", { name: /back/i });
+      const actionRow = backButton.closest(".flex.flex-col");
+      expect(actionRow).toHaveClass("flex-col");
+      expect(actionRow).toHaveClass("xs:flex-row");
+    });
+
+    it("constraint cards use single-column grid on narrow viewports with sm:grid-cols-3", () => {
+      render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+        />,
+      );
+
+      const constraintsGrid = document.getElementById("draw-amount-constraints");
+      expect(constraintsGrid).toHaveClass("grid");
+      expect(constraintsGrid).toHaveClass("sm:grid-cols-3");
+    });
+
+    it("stepper buttons resize from w-10/h-10 on narrow to xs:w-11/xs:h-11", () => {
+      render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+        />,
+      );
+
+      const decreaseBtn = screen.getByRole("button", { name: /decrease amount/i });
+      expect(decreaseBtn).toHaveClass("w-10", "h-10");
+      expect(decreaseBtn).toHaveClass("xs:w-11", "xs:h-11");
+    });
+
+    it("action buttons are full width on narrow and auto on wider viewports", () => {
+      render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+        />,
+      );
+
+      const continueBtn = screen.getByRole("button", { name: /continue/i });
+      expect(continueBtn).toHaveClass("w-full");
+      expect(continueBtn).toHaveClass("xs:w-auto");
+    });
+  });
 });

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -18,7 +18,7 @@ import { Skeleton } from "./Skeleton";
 const STEP_AMOUNT = 100;
 
 const stepClasses =
-  "flex items-center justify-center w-11 h-11 rounded-lg border border-border bg-background/60 text-foreground hover:bg-surface hover:border-accent/50 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:opacity-40 disabled:cursor-not-allowed";
+  "flex items-center justify-center w-10 h-10 xs:w-11 xs:h-11 rounded-lg border border-border bg-background/60 text-foreground hover:bg-surface hover:border-accent/50 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:opacity-40 disabled:cursor-not-allowed";
 
 const STEP_ICON_CLASS = "h-4 w-4 stroke-[2.5]";
 
@@ -276,7 +276,7 @@ export function AmountInput({
 
         {/* Input field with border styling based on validation state */}
         <div
-          className={`flex items-center gap-2 sm:gap-3 bg-surface p-3.5 sm:p-4 rounded-xl border-2 overflow-hidden transition-colors ${inputStateClassName}`}
+          className={`flex flex-wrap items-center gap-1.5 xs:gap-2 sm:gap-3 bg-surface p-3 xs:p-3.5 sm:p-4 rounded-xl border-2 overflow-hidden transition-colors ${inputStateClassName}`}
         >
           <button
             onClick={() => handleStep("down")}
@@ -326,7 +326,7 @@ export function AmountInput({
           {/* Max button for quick-fill with accessible label */}
           <button
             onClick={handleMaxClick}
-            className="px-3 py-2 text-sm font-semibold text-accent hover:bg-accent/10 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface flex-shrink-0 min-h-[44px]"
+            className="px-2 xs:px-3 py-2 text-xs xs:text-sm font-semibold text-accent hover:bg-accent/10 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface flex-shrink-0 min-h-[44px]"
             aria-label="Set amount to maximum available credit"
             type="button"
           >
@@ -389,7 +389,7 @@ export function AmountInput({
         <p className="text-sm font-semibold text-foreground mb-3 leading-[var(--lh-body)]">
           Quick amount
         </p>
-        <div className="grid grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 xs:grid-cols-4 gap-2">
           {[25, 50, 75, 100].map((percent) => (
             <button
               key={percent}
@@ -409,7 +409,7 @@ export function AmountInput({
       </div>
 
       {/* Summary display showing available, requested, and remaining */}
-      <div className="bg-surface p-4 sm:p-5 rounded-xl border border-border space-y-3">
+      <div className="bg-surface p-3.5 xs:p-4 sm:p-5 rounded-xl border border-border space-y-2.5 xs:space-y-3">
         <div className="flex justify-between text-sm leading-[var(--lh-body)]">
           <span className="text-muted">Available:</span>
           <span className="font-semibold text-foreground tabular-nums">
@@ -433,10 +433,10 @@ export function AmountInput({
       </div>
 
       {/* Action buttons */}
-      <div className="flex gap-3 pt-4">
+      <div className="flex flex-col xs:flex-row gap-3 pt-4">
         <button
           onClick={onBack}
-          className="flex-1 py-3 px-4 border-2 border-border text-foreground rounded-lg hover:bg-surface transition-colors font-semibold text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px]"
+          className="flex-1 py-3 px-4 border-2 border-border text-foreground rounded-lg hover:bg-surface transition-colors font-semibold text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px] w-full xs:w-auto"
           type="button"
         >
           Back
@@ -444,7 +444,7 @@ export function AmountInput({
         <button
           onClick={() => onNext(numAmount)}
           disabled={!isValid}
-          className="flex-1 py-3 px-4 bg-accent text-background rounded-lg hover:bg-accent/90 transition-all font-semibold text-sm disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px]"
+          className="flex-1 py-3 px-4 bg-accent text-background rounded-lg hover:bg-accent/90 transition-all font-semibold text-sm disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px] w-full xs:w-auto"
           type="button"
         >
           Continue

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -55,7 +55,7 @@ type SkeletonProps = React.HTMLAttributes<HTMLDivElement> & {
  * (the runtime JS toggle managed by ReducedMotionContext).
  * See the loading-state policy in `docs/ARCHITECTURE.md` §5.
  */
-export const Skeleton: React.FC<SkeletonProps> = ({ width, height, shape = 'rectangular', style, className, 'aria-hidden': ariaHidden = true, ...rest }) => (
+export const Skeleton: React.FC<SkeletonProps> = ({ width, height, shape = 'rectangular', variant, style, className, 'aria-hidden': ariaHidden = true, ...rest }) => (
   <div
     className={[
       'skeleton',


### PR DESCRIPTION
Closes #618

## Summary
Responsive breakpoint audit for AmountInput (v7).

## Changes
- Stepper buttons: `w-10 h-10 xs:w-11 xs:h-11` for narrow viewports
- Input box: `flex-wrap`, `gap-1.5 xs:gap-2 sm:gap-3` for better wrapping
- Max button: `px-2 xs:px-3 text-xs xs:text-sm` for narrow screens
- Preset chips: `grid-cols-2 xs:grid-cols-4` (2-col on narrow, 4-col on wider)
- Summary card: responsive padding and spacing
- Action buttons: `flex-col xs:flex-row`, `w-full xs:w-auto` (stack on narrow, row on wider)
- Fixed Skeleton.tsx variant destructuring bug
- Added 5 responsive breakpoint tests (31 total pass)

## Test Results
```
✓ 31 tests passed in AmountInput.test.tsx
```