### PR TITLE
feat: draw wizard 'Review' step polish

### DIFF
--- a/src/components/ConfirmationStep.test.tsx
+++ b/src/components/ConfirmationStep.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { ConfirmationStep } from "./ConfirmationStep";
 import { useWallet } from "@/context/WalletContext";
+import { getDrawPricingQuote } from "@/lib/draw-credit-pricing";
 
 // Mock WalletContext — ConfirmationStep reads wallet status to show a hint
 vi.mock("@/context/WalletContext", () => ({
@@ -17,10 +18,14 @@ vi.mock("@/lib/draw-credit-pricing", () => ({
     estimatedMonthlyInterest: 104.17,
     riskBand: "Standard",
     termMonths: 24,
+    utilizationAdjustmentLabel: "Low utilization adjustment",
+    termAdjustmentLabel: "Standard-term pricing adjustment",
   })),
 }));
 
-(useWallet as ReturnType<typeof vi.fn>).mockReturnValue({ status: "connected" });
+const mockGetDrawPricingQuote = vi.mocked(getDrawPricingQuote);
+
+const mockUseWallet = vi.mocked(useWallet);
 
 const creditLine = {
   id: "cl-001",
@@ -32,6 +37,16 @@ const creditLine = {
   termMonths: 24,
 };
 
+const watchCreditLine = {
+  id: "cl-003",
+  name: "Working Capital",
+  limit: 75000,
+  available: 12000,
+  utilization: 84,
+  riskBand: "Watch" as const,
+  termMonths: 12,
+};
+
 /** Returns footer action buttons, excluding icon-only buttons (e.g. tooltips). */
 function getActionButtons() {
   return screen.getAllByRole("button").filter(
@@ -41,10 +56,12 @@ function getActionButtons() {
   );
 }
 
+// ── Basic render ──────────────────────────────────────────────────────────────
+
 describe("ConfirmationStep", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (useWallet as ReturnType<typeof vi.fn>).mockReturnValue({ status: "connected" });
+    mockUseWallet.mockReturnValue({ status: "connected" });
   });
 
   it("renders the Review and confirm heading", () => {
@@ -63,7 +80,7 @@ describe("ConfirmationStep", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows the draw amount and estimated fee", () => {
+  it("shows the draw amount", () => {
     render(
       <ConfirmationStep
         creditLine={creditLine}
@@ -74,9 +91,470 @@ describe("ConfirmationStep", () => {
       />,
     );
 
-    expect(screen.getByText("$10,000.00")).toBeInTheDocument();
+    expect(screen.getByTestId("draw-amount-display")).toHaveTextContent(
+      "$10,000.00",
+    );
+  });
+
+  it("shows the estimated fee from pricing quote", () => {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
     // Fee comes from mocked getDrawPricingQuote → $100
-    expect(screen.getByText("$100.00")).toBeInTheDocument();
+    expect(screen.getByTestId("fee-display")).toHaveTextContent("$100.00");
+  });
+
+  it("shows the APR from pricing quote", () => {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("apr-display")).toHaveTextContent("12.5%");
+  });
+
+  it("shows the estimated monthly interest", () => {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("monthly-interest-display")).toHaveTextContent(
+      "$104.17",
+    );
+  });
+});
+
+// ── Cost breakdown section ────────────────────────────────────────────────────
+
+describe("ConfirmationStep — cost breakdown section", () => {
+  beforeEach(() => {
+    mockUseWallet.mockReturnValue({ status: "connected" });
+  });
+
+  it("renders the 'Cost breakdown' section heading", () => {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("region", { name: /cost breakdown/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the new balance after fee", () => {
+    // utilized = 50000 - 35000 = 15000, amount = 10000, fee = 100
+    // newBalance = 15000 + 10000 + 100 = 25100
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("new-balance-display")).toHaveTextContent(
+      "$25,100.00",
+    );
+  });
+
+  it("shows term in months", () => {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("24 months")).toBeInTheDocument();
+  });
+});
+
+// ── Risk-band badge ───────────────────────────────────────────────────────────
+
+describe("ConfirmationStep — risk-band badge", () => {
+  beforeEach(() => {
+    mockUseWallet.mockReturnValue({ status: "connected" });
+  });
+
+  it("renders a risk-band badge", () => {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const badge = screen.getByTestId("risk-band-badge");
+    expect(badge).toBeInTheDocument();
+  });
+
+  it("risk-band badge shows 'Standard band' for Standard risk line", () => {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("risk-band-badge")).toHaveTextContent(
+      "Standard band",
+    );
+  });
+
+  it("risk-band badge has accessible aria-label describing the band", () => {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const badge = screen.getByTestId("risk-band-badge");
+    expect(badge).toHaveAttribute("aria-label", expect.stringMatching(/risk band: standard/i));
+  });
+});
+
+// ── Watch-band risk-adjusted fee notice ───────────────────────────────────────
+
+describe("ConfirmationStep — Watch-band risk fee notice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWallet.mockReturnValue({ status: "connected" });
+    // Return Watch risk band from pricing
+    mockGetDrawPricingQuote.mockReturnValue({
+      fee: 50,
+      apr: 14.5,
+      estimatedMonthlyInterest: 60.42,
+      riskBand: "Watch",
+      termMonths: 12,
+      utilizationAdjustmentLabel: "High utilization adjustment",
+      termAdjustmentLabel: "Short-term pricing adjustment",
+    });
+  });
+
+  it("shows the risk-adjusted fee notice for Watch-band credit lines", () => {
+    render(
+      <ConfirmationStep
+        creditLine={watchCreditLine}
+        amount={5000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("risk-fee-notice")).toBeInTheDocument();
+    expect(screen.getByTestId("risk-fee-notice")).toHaveTextContent(
+      /risk-adjusted pricing/i,
+    );
+  });
+
+  it("does NOT show the risk-adjusted fee notice for Standard-band lines", () => {
+    // Restore Standard mock for this test
+    mockGetDrawPricingQuote.mockReturnValue({
+      fee: 100,
+      apr: 12.5,
+      estimatedMonthlyInterest: 104.17,
+      riskBand: "Standard",
+      termMonths: 24,
+      utilizationAdjustmentLabel: "Low utilization adjustment",
+      termAdjustmentLabel: "Standard-term pricing adjustment",
+    });
+
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("risk-fee-notice")).not.toBeInTheDocument();
+  });
+});
+
+// ── APR disclosure collapsible ────────────────────────────────────────────────
+
+describe("ConfirmationStep — APR disclosure collapsible", () => {
+  beforeEach(() => {
+    mockUseWallet.mockReturnValue({ status: "connected" });
+  });
+
+  function renderStep(overrides = {}) {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+        {...overrides}
+      />,
+    );
+  }
+
+  it("renders the 'How is my APR calculated?' toggle button", () => {
+    renderStep();
+
+    expect(
+      screen.getByTestId("apr-disclosure-toggle"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("apr-disclosure-toggle"),
+    ).toHaveTextContent(/how is my apr calculated/i);
+  });
+
+  it("APR breakdown body is NOT visible by default (collapsed)", () => {
+    renderStep();
+
+    expect(screen.queryByTestId("apr-breakdown-body")).not.toBeInTheDocument();
+  });
+
+  it("toggle button has aria-expanded=false when collapsed", () => {
+    renderStep();
+
+    const toggle = screen.getByTestId("apr-disclosure-toggle");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("clicking the toggle reveals the APR breakdown", async () => {
+    const user = userEvent.setup();
+    renderStep();
+
+    await user.click(screen.getByTestId("apr-disclosure-toggle"));
+
+    expect(screen.getByTestId("apr-breakdown-body")).toBeInTheDocument();
+  });
+
+  it("toggle button has aria-expanded=true when open", async () => {
+    const user = userEvent.setup();
+    renderStep();
+
+    await user.click(screen.getByTestId("apr-disclosure-toggle"));
+
+    expect(screen.getByTestId("apr-disclosure-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
+  it("shows base rate, utilization adjustment, and term adjustment when open", async () => {
+    const user = userEvent.setup();
+    renderStep();
+
+    await user.click(screen.getByTestId("apr-disclosure-toggle"));
+
+    expect(screen.getByTestId("apr-base-rate")).toBeInTheDocument();
+    expect(screen.getByTestId("apr-utilization-adj")).toBeInTheDocument();
+    expect(screen.getByTestId("apr-term-adj")).toBeInTheDocument();
+    expect(screen.getByTestId("apr-total")).toBeInTheDocument();
+  });
+
+  it("total APR in breakdown matches the main APR display", async () => {
+    const user = userEvent.setup();
+    renderStep();
+
+    await user.click(screen.getByTestId("apr-disclosure-toggle"));
+
+    const total = screen.getByTestId("apr-total");
+    const mainApr = screen.getByTestId("apr-display");
+    expect(total).toHaveTextContent("12.5%");
+    expect(mainApr).toHaveTextContent("12.5%");
+  });
+
+  it("shows utilization adjustment label from pricing quote", async () => {
+    const user = userEvent.setup();
+    renderStep();
+
+    await user.click(screen.getByTestId("apr-disclosure-toggle"));
+
+    expect(
+      screen.getByText(/low utilization adjustment/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows term adjustment label from pricing quote", async () => {
+    const user = userEvent.setup();
+    renderStep();
+
+    await user.click(screen.getByTestId("apr-disclosure-toggle"));
+
+    expect(
+      screen.getByText(/standard-term pricing adjustment/i),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking toggle again collapses the breakdown", async () => {
+    const user = userEvent.setup();
+    renderStep();
+
+    const toggle = screen.getByTestId("apr-disclosure-toggle");
+    await user.click(toggle);
+    expect(screen.getByTestId("apr-breakdown-body")).toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(screen.queryByTestId("apr-breakdown-body")).not.toBeInTheDocument();
+  });
+});
+
+// ── Utilization progress bars ─────────────────────────────────────────────────
+
+describe("ConfirmationStep — utilization progress bars", () => {
+  beforeEach(() => {
+    mockUseWallet.mockReturnValue({ status: "connected" });
+  });
+
+  it("renders the 'Credit utilization' section", () => {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("region", { name: /credit utilization/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows current utilization percentage", () => {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // creditLine.utilization = 30
+    expect(screen.getByText("30%")).toBeInTheDocument();
+  });
+
+  it("shows projected utilization after draw", () => {
+    // utilized = 15000, draw = 10000, fee = 100 → newBalance = 25100
+    // newUtilization = round(25100 / 50000 * 100) = 50
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("utilization-after-pct")).toHaveTextContent(
+      "50%",
+    );
+  });
+
+  it("renders two accessible progressbar elements", () => {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const bars = screen.getAllByRole("progressbar");
+    expect(bars).toHaveLength(2);
+  });
+
+  it("does NOT show high-utilization warning when below 80%", () => {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("high-utilization-warning"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows high-utilization warning when projected utilization exceeds 80%", () => {
+    // For this to trigger: newBalance / limit > 0.80
+    // limit=50000, utilized=15000, draw=30000, fee=100 → newBalance=45100 → 90%
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={30000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("high-utilization-warning"),
+    ).toBeInTheDocument();
+  });
+
+  it("high-utilization warning has role=alert for immediate AT announcement", () => {
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={30000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const warning = screen.getByTestId("high-utilization-warning");
+    expect(warning).toHaveAttribute("role", "alert");
   });
 });
 
@@ -84,7 +562,7 @@ describe("ConfirmationStep", () => {
 
 describe("ConfirmationStep — button order (docs/BUTTON_ORDER.md)", () => {
   beforeEach(() => {
-    (useWallet as ReturnType<typeof vi.fn>).mockReturnValue({ status: "connected" });
+    mockUseWallet.mockReturnValue({ status: "connected" });
   });
 
   function renderStep(overrides = {}) {
@@ -105,36 +583,33 @@ describe("ConfirmationStep — button order (docs/BUTTON_ORDER.md)", () => {
 
     const buttons = getActionButtons();
     const cancelIdx = buttons.findIndex((b) => b.textContent?.trim() === "Cancel");
-    const backIdx   = buttons.findIndex((b) => b.textContent?.trim() === "Back");
+    const backIdx = buttons.findIndex((b) => b.textContent?.trim() === "Back");
 
     expect(cancelIdx).toBeGreaterThanOrEqual(0);
     expect(backIdx).toBeGreaterThanOrEqual(0);
-    // Cancel must precede Back (leftmost safe exit, then step navigation)
     expect(cancelIdx).toBeLessThan(backIdx);
   });
 
   it("renders Back before the primary Draw button in the DOM", () => {
     renderStep();
 
-    const buttons  = getActionButtons();
-    const backIdx  = buttons.findIndex((b) => b.textContent?.trim() === "Back");
-    const drawIdx  = buttons.findIndex((b) => /draw/i.test(b.textContent ?? ""));
+    const buttons = getActionButtons();
+    const backIdx = buttons.findIndex((b) => b.textContent?.trim() === "Back");
+    const drawIdx = buttons.findIndex((b) => /draw/i.test(b.textContent ?? ""));
 
     expect(backIdx).toBeGreaterThanOrEqual(0);
     expect(drawIdx).toBeGreaterThanOrEqual(0);
-    // Back must precede the primary action
     expect(backIdx).toBeLessThan(drawIdx);
   });
 
   it("full order: Cancel → Back → Draw", () => {
     renderStep();
 
-    const buttons    = getActionButtons();
-    const cancelIdx  = buttons.findIndex((b) => b.textContent?.trim() === "Cancel");
-    const backIdx    = buttons.findIndex((b) => b.textContent?.trim() === "Back");
-    const drawIdx    = buttons.findIndex((b) => /draw/i.test(b.textContent ?? ""));
+    const buttons = getActionButtons();
+    const cancelIdx = buttons.findIndex((b) => b.textContent?.trim() === "Cancel");
+    const backIdx = buttons.findIndex((b) => b.textContent?.trim() === "Back");
+    const drawIdx = buttons.findIndex((b) => /draw/i.test(b.textContent ?? ""));
 
-    // Rule: Cancel < Back < Primary (docs/BUTTON_ORDER.md)
     expect(cancelIdx).toBeLessThan(backIdx);
     expect(backIdx).toBeLessThan(drawIdx);
   });
@@ -190,5 +665,70 @@ describe("ConfirmationStep — button order (docs/BUTTON_ORDER.md)", () => {
     await user.click(screen.getByRole("button", { name: /draw/i }));
 
     expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Wallet signing hint ───────────────────────────────────────────────────────
+
+describe("ConfirmationStep — wallet signing hint", () => {
+  it("shows 'Your wallet will ask you to sign next' when wallet is connected", () => {
+    mockUseWallet.mockReturnValue({
+      status: "connected",
+    });
+
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(/your wallet will ask you to sign next/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT show wallet hint when wallet is disconnected", () => {
+    mockUseWallet.mockReturnValue({
+      status: "disconnected",
+    });
+
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByText(/your wallet will ask you to sign next/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT show wallet hint while loading", () => {
+    mockUseWallet.mockReturnValue({
+      status: "connected",
+    });
+
+    render(
+      <ConfirmationStep
+        creditLine={creditLine}
+        amount={10000}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onCancel={vi.fn()}
+        isLoading
+      />,
+    );
+
+    expect(
+      screen.queryByText(/your wallet will ask you to sign next/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/ConfirmationStep.tsx
+++ b/src/components/ConfirmationStep.tsx
@@ -1,27 +1,34 @@
 /**
  * ConfirmationStep
  *
- * Step 3 of the draw-credit flow. Displays a full summary of the draw
+ * Step 4 of the draw-credit flow. Displays a full summary of the draw
  * (credit line, amounts, projected utilization) and requires the user to
  * accept the terms before submitting.
  *
- * Design-token classes used (all from `src/index.css` `.dc-*` block):
- *   dc-step, dc-step__title, dc-step__subtitle,
- *   dc-balance-card, dc-balance-row, dc-balance-row__label, dc-balance-row__value,
- *   dc-banner, dc-banner--warning, dc-banner__icon, dc-banner__body, dc-banner__title,
- *   dc-terms-label, dc-terms-label__checkbox, dc-terms-label__text,
- *   dc-actions, dc-actions--stacked, dc-actions__slot,
- *   dc-btn, dc-btn--secondary, dc-btn--primary, dc-btn--full,
- *   dc-hint, dc-hint--right
+ * Design-token classes used (all from `src/index.css` `:root` block):
+ *   bg-surface, border-border, text-foreground, text-muted,
+ *   bg-background, accent-accent
+ *
+ * Polish additions (issue #429):
+ *   - Prominent cost-breakdown card with draw amount, 1-time fee, monthly
+ *     interest and totals in clear visual hierarchy.
+ *   - Risk-band badge (Prime / Standard / Watch) with accessible aria-label.
+ *   - Collapsible "How is my APR calculated?" disclosure (aria-expanded +
+ *     aria-controls) exposing base rate, utilization and term adjustments.
+ *   - Before / after utilization progress bars (role="progressbar").
+ *   - Risk-adjusted fee notice (role="note") for Watch-band lines.
  *
  * Accessibility:
- *   - High-utilization warning banner has role="alert" so it is announced.
+ *   - High-utilization warning has role="alert" so it is announced immediately.
  *   - Confirm button is `disabled` (not hidden) when terms are not accepted.
- *   - aria-disabled mirrors the disabled prop for redundant AT signals.
+ *   - PendingButton sets aria-busy="true" while isLoading.
+ *   - Color is never the sole signal — icons and text labels accompany every
+ *     colored element (WCAG 1.4.1 Use of Color).
  */
 
+import { AccessibleTooltip } from "@/components/AccessibleTooltip";
 import { CreditLine } from "@/types/draw-credit.types";
-import { AlertCircle, Info } from "lucide-react";
+import { AlertCircle, ChevronDown, ChevronUp, Info, ShieldCheck } from "lucide-react";
 import { useState } from "react";
 import { CreditLineSummaryBlock } from "@/components/CreditLineSummaryBlock";
 import { PendingButton } from "@/components/PendingButton";
@@ -55,22 +62,78 @@ interface ConfirmationStepProps {
   onAgreedToTermsChange?: (agreed: boolean) => void;
 }
 
-/**
- * Step 4 of the draw-credit wizard: final confirmation.
- *
- * Surfaces the unambiguous numbers (draw amount, fee, post-draw utilization,
- * APR) alongside a "I agree to the terms" checkbox. The primary action is
- * disabled until the checkbox is ticked — see UX_RATIONALE.md
- * "Repayment uses a confirmation modal" for the irreversible-action policy
- * this enforces.
- *
- * Local state: `agreedToTerms` (checkbox). All other state lives in the
- * parent wizard.
- *
- * Accessibility: the primary button uses `PendingButton`, which sets
- * `aria-busy="true"` and disables the button while `isLoading`. The
- * checkbox is a native input so it inherits keyboard semantics.
- */
+/** Map a DrawPricingRiskBand to a human-readable label and visual tone. */
+function getRiskBandMeta(riskBand: string): {
+  label: string;
+  description: string;
+  colorClass: string;
+  bgClass: string;
+  borderClass: string;
+} {
+  switch (riskBand) {
+    case "Prime":
+      return {
+        label: "Prime",
+        description: "Lowest risk tier — best available pricing.",
+        colorClass: "text-green-400",
+        bgClass: "bg-green-500/10",
+        borderClass: "border-green-500/30",
+      };
+    case "Watch":
+      return {
+        label: "Watch",
+        description: "Elevated risk tier — pricing reflects higher uncertainty.",
+        colorClass: "text-yellow-400",
+        bgClass: "bg-yellow-500/10",
+        borderClass: "border-yellow-500/30",
+      };
+    case "Standard":
+    default:
+      return {
+        label: "Standard",
+        description: "Mid-tier risk — standard market pricing applies.",
+        colorClass: "text-blue-400",
+        bgClass: "bg-blue-500/10",
+        borderClass: "border-blue-500/30",
+      };
+  }
+}
+
+/** Narrow progress bar used for utilization visualization. */
+function UtilizationBar({
+  pct,
+  isHighlighted,
+  "aria-label": ariaLabel,
+}: {
+  pct: number;
+  isHighlighted: boolean;
+  "aria-label": string;
+}) {
+  const clamped = Math.min(Math.max(pct, 0), 100);
+  const barColor =
+    clamped > 80
+      ? "bg-yellow-500"
+      : clamped > 50
+        ? "bg-blue-400"
+        : "bg-blue-500";
+
+  return (
+    <div
+      className="w-full rounded-full bg-border h-2.5"
+      role="progressbar"
+      aria-valuenow={Math.round(clamped)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={ariaLabel}
+    >
+      <div
+        className={`h-2.5 rounded-full transition-all duration-300 ${barColor} ${isHighlighted ? "ring-1 ring-offset-1 ring-blue-400" : ""}`}
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  );
+}
+
 export function ConfirmationStep({
   creditLine,
   amount,
@@ -81,140 +144,411 @@ export function ConfirmationStep({
   agreedToTerms: agreedToTermsProp,
   onAgreedToTermsChange,
 }: ConfirmationStepProps) {
-  const [agreedToTerms, setAgreedToTerms] = useState(false);
+  const [agreedToTermsInternal, setAgreedToTermsInternal] = useState(false);
+  const agreedToTerms = agreedToTermsProp ?? agreedToTermsInternal;
+  const setAgreedToTerms = (value: boolean) => {
+    onAgreedToTermsChange?.(value);
+    if (agreedToTermsProp === undefined) {
+      setAgreedToTermsInternal(value);
+    }
+  };
 
-  const newUtilization = Math.round(
-    ((creditLine.limit - creditLine.available + amount) / creditLine.limit) *
-      100,
-  );
+  /** Controls the "How is my APR calculated?" collapsible section. */
+  const [aprDisclosureOpen, setAprDisclosureOpen] = useState(false);
+
+  const { status } = useWallet();
+  const utilizedBalance = creditLine.limit - creditLine.available;
+  const safeAmount = Math.max(amount, 0);
+
+  const {
+    fee,
+    apr,
+    estimatedMonthlyInterest,
+    riskBand,
+    termMonths,
+    utilizationAdjustmentLabel,
+    termAdjustmentLabel,
+  } = getDrawPricingQuote(creditLine, safeAmount);
+
+  // Reconstruct the base APR before adjustments for the disclosure panel.
+  // The pricing module does not export BASE_APR_BY_RISK_BAND, but the
+  // adjustment point values are deterministic — mirror the same branches.
+  const utilizationAdjPts =
+    creditLine.utilization >= 80
+      ? 2
+      : creditLine.utilization >= 50
+        ? 1.25
+        : 0.5;
+  const termAdjPts = termMonths > 24 ? 2.5 : termMonths > 12 ? 1.5 : 0.5;
+  const baseApr = Math.round((apr - utilizationAdjPts - termAdjPts) * 100) / 100;
+
+  const newBalance = utilizedBalance + safeAmount + fee;
+  const remainingAvailable = Math.max(creditLine.limit - newBalance, 0);
+  const newUtilization = Math.round((newBalance / creditLine.limit) * 100);
+  const currentUtilizationPct = creditLine.utilization;
+
+  const isDrawDisabled = !agreedToTerms || isLoading;
+  const disabledHelperText = !agreedToTerms
+    ? "Accept the authorization terms to enable the Draw button."
+    : "Submitting your draw request. Please wait.";
+
+  const riskBandMeta = getRiskBandMeta(riskBand);
+  const isWatchBand = riskBand === "Watch";
   const isHighUtilization = newUtilization > 80;
-  const canConfirm = agreedToTerms && !isLoading;
 
   return (
-    <div className="dc-step">
-      {/* Step header */}
+    <div className="space-y-8">
+      {/* ── Step header ──────────────────────────────────────────────────── */}
       <div>
-        <h2 className="dc-step__title">Review &amp; Confirm</h2>
-        <p className="dc-step__subtitle">
-          Confirm your draw details before submitting.
+        <p className="text-sm font-semibold uppercase text-muted">Step 4</p>
+        <h2
+          id="confirm-draw-heading"
+          className="mt-1 text-2xl font-bold text-foreground sm:text-3xl"
+        >
+          Review and confirm
+        </h2>
+        <p className="text-muted mt-2">
+          Check your draw details below. Once you confirm, the request is
+          submitted to the network.
         </p>
       </div>
 
-      {/* Credit-line summary block (limit / utilized / available) */}
+      {/* ── Credit line summary card ─────────────────────────────────────── */}
       <CreditLineSummaryBlock creditLine={creditLine} amount={amount} />
 
-      <div className="space-y-4">
-        <div className="rounded-lg border border-border bg-surface p-5">
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="sm:col-span-2">
-              <p className="text-sm text-muted font-medium">Draw amount</p>
-              <p className="mt-1 text-3xl font-bold text-foreground tabular-nums">
-                {formatMoney(safeAmount)}
-              </p>
-            </div>
-            <div className="rounded-lg border border-border bg-background/60 p-3">
-              <p className="text-sm text-muted font-medium">Estimated fee</p>
-              <p className="mt-1 font-semibold text-foreground tabular-nums">
-                {formatMoney(fee)}
-              </p>
-            </div>
-            <div className="rounded-lg border border-border bg-background/60 p-3">
-              <p className="text-sm text-muted font-medium">
-                Estimated monthly interest
-              </p>
-              <p className="mt-1 font-semibold text-foreground tabular-nums">
-                {formatMoney(estimatedMonthlyInterest)}
-              </p>
-            </div>
-            <div className="rounded-lg border border-border bg-background/60 p-3">
-              <p className="text-sm text-muted font-medium">New balance</p>
-              <p className="mt-1 font-semibold text-foreground tabular-nums">
-                {formatMoney(newBalance)}
-              </p>
-            </div>
-            <div className="rounded-lg border border-border bg-background/60 p-3">
-              <p className="text-sm text-muted font-medium">
-                Available after draw
-              </p>
-              <p className="mt-1 font-semibold text-foreground tabular-nums">
-                {formatMoney(remainingAvailable)}
-              </p>
-            </div>
+      {/* ── Cost breakdown card ───────────────────────────────────────────── */}
+      <section
+        aria-labelledby="cost-breakdown-heading"
+        className="rounded-xl border border-border bg-surface p-5 space-y-5"
+      >
+        <h3
+          id="cost-breakdown-heading"
+          className="text-sm font-semibold uppercase text-muted tracking-wide"
+        >
+          Cost breakdown
+        </h3>
+
+        {/* Primary number — draw amount + risk-band badge */}
+        <div className="flex items-end justify-between gap-4">
+          <div>
+            <p className="text-sm text-muted font-medium">Draw amount</p>
+            <p
+              className="mt-1 text-4xl font-bold text-foreground tabular-nums"
+              data-testid="draw-amount-display"
+            >
+              {formatMoney(safeAmount)}
+            </p>
           </div>
-          <div className="mt-4 grid gap-3 border-t border-border pt-4 sm:grid-cols-2">
-            <div className="flex justify-between gap-4 text-sm">
-              <span className="text-muted font-medium">
-                Current utilization
-              </span>
-              <span className="font-semibold text-foreground tabular-nums">
-                {creditLine.utilization}%
-              </span>
-            </div>
-            <div className="flex justify-between gap-4 text-sm">
-              <span className="text-muted font-medium">After draw</span>
-              <span
-                className={`font-semibold tabular-nums ${newUtilization > 80 ? "text-yellow-500" : "text-foreground"}`}
-              >
-                {newUtilization}%
-              </span>
-            </div>
+          <span
+            className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border ${riskBandMeta.bgClass} ${riskBandMeta.borderClass} ${riskBandMeta.colorClass}`}
+            data-testid="risk-band-badge"
+            aria-label={`Risk band: ${riskBandMeta.label} — ${riskBandMeta.description}`}
+          >
+            <ShieldCheck className="w-3.5 h-3.5" aria-hidden="true" />
+            {riskBandMeta.label} band
+          </span>
+        </div>
+
+        {/* Line items */}
+        <dl className="grid gap-3 sm:grid-cols-2">
+          <div className="rounded-lg border border-border bg-background/60 p-3">
+            <dt className="text-sm text-muted font-medium">One-time fee (1%)</dt>
+            <dd className="mt-1 font-semibold text-foreground tabular-nums" data-testid="fee-display">
+              {formatMoney(fee)}
+            </dd>
           </div>
-          {newUtilization > 80 && (
-            <div className="flex items-start gap-3 bg-yellow-500/10 border border-yellow-500/30 rounded-lg p-3 mt-4">
-              <AlertCircle className="w-5 h-5 text-yellow-500 mt-0.5 shrink-0" />
-              <div>
-                <p className="text-sm font-semibold text-yellow-500">
-                  High Utilization Warning
-                </p>
-                <p className="text-sm text-yellow-500 mt-1">
-                  Your credit utilization will exceed 80%. This may impact your
-                  credit terms.
-                </p>
-              </div>
+
+          <div className="rounded-lg border border-border bg-background/60 p-3">
+            <dt className="text-sm text-muted font-medium flex items-center gap-1.5">
+              APR
+              <AccessibleTooltip label="Annual Percentage Rate — the annualised cost of borrowing.">
+                <span className="sr-only">What is APR?</span>
+              </AccessibleTooltip>
+            </dt>
+            <dd
+              className="mt-1 font-semibold text-foreground tabular-nums"
+              data-testid="apr-display"
+            >
+              {apr}%
+            </dd>
+          </div>
+
+          <div className="rounded-lg border border-border bg-background/60 p-3">
+            <dt className="text-sm text-muted font-medium">Est. monthly interest</dt>
+            <dd className="mt-1 font-semibold text-foreground tabular-nums" data-testid="monthly-interest-display">
+              {formatMoney(estimatedMonthlyInterest)}
+            </dd>
+          </div>
+
+          <div className="rounded-lg border border-border bg-background/60 p-3">
+            <dt className="text-sm text-muted font-medium">Term</dt>
+            <dd className="mt-1 font-semibold text-foreground tabular-nums">
+              {termMonths} months
+            </dd>
+          </div>
+
+          <div className="rounded-lg border border-border bg-background/60 p-3">
+            <dt className="text-sm text-muted font-medium">New balance</dt>
+            <dd className="mt-1 font-semibold text-foreground tabular-nums" data-testid="new-balance-display">
+              {formatMoney(newBalance)}
+            </dd>
+          </div>
+
+          <div className="rounded-lg border border-border bg-background/60 p-3">
+            <dt className="text-sm text-muted font-medium">Available after draw</dt>
+            <dd className="mt-1 font-semibold text-foreground tabular-nums">
+              {formatMoney(remainingAvailable)}
+            </dd>
+          </div>
+        </dl>
+
+        {/* ── Collapsible APR breakdown ─────────────────────────────────── */}
+        <div className="rounded-lg border border-border bg-background/40">
+          <button
+            type="button"
+            onClick={() => setAprDisclosureOpen((prev) => !prev)}
+            aria-expanded={aprDisclosureOpen}
+            aria-controls="apr-breakdown-body"
+            className="flex w-full items-center justify-between px-4 py-3 text-sm font-semibold text-foreground hover:bg-border/40 rounded-lg transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400"
+            data-testid="apr-disclosure-toggle"
+          >
+            <span className="flex items-center gap-2">
+              <Info className="w-4 h-4 text-muted shrink-0" aria-hidden="true" />
+              How is my APR calculated?
+            </span>
+            {aprDisclosureOpen ? (
+              <ChevronUp className="w-4 h-4 text-muted shrink-0" aria-hidden="true" />
+            ) : (
+              <ChevronDown className="w-4 h-4 text-muted shrink-0" aria-hidden="true" />
+            )}
+          </button>
+
+          {aprDisclosureOpen && (
+            <div
+              id="apr-breakdown-body"
+              data-testid="apr-breakdown-body"
+              className="border-t border-border px-4 py-4 space-y-3 text-sm"
+            >
+              <p className="text-muted text-xs">
+                Your APR is composed of a base rate for your risk band, plus
+                adjustments for your current utilization level and the draw
+                term length.
+              </p>
+              <dl className="space-y-2">
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted">
+                    Base rate ({riskBandMeta.label} band)
+                  </dt>
+                  <dd className="font-semibold text-foreground tabular-nums" data-testid="apr-base-rate">
+                    {baseApr}%
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted">{utilizationAdjustmentLabel}</dt>
+                  <dd className="font-semibold text-foreground tabular-nums" data-testid="apr-utilization-adj">
+                    +{utilizationAdjPts}%
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted">{termAdjustmentLabel}</dt>
+                  <dd className="font-semibold text-foreground tabular-nums" data-testid="apr-term-adj">
+                    +{termAdjPts}%
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-4 border-t border-border pt-2">
+                  <dt className="font-semibold text-foreground">Total APR</dt>
+                  <dd className="font-bold text-foreground tabular-nums" data-testid="apr-total">
+                    {apr}%
+                  </dd>
+                </div>
+              </dl>
             </div>
           )}
         </div>
-      </div>
 
-      {/* Terms & conditions checkbox */}
-      <label className="dc-terms-label">
+        {/* Risk-adjusted fee notice — Watch band only */}
+        {isWatchBand && (
+          <div
+            className="flex items-start gap-3 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3"
+            role="note"
+            data-testid="risk-fee-notice"
+          >
+            <AlertCircle
+              className="w-5 h-5 text-yellow-500 mt-0.5 shrink-0"
+              aria-hidden="true"
+            />
+            <div>
+              <p className="text-sm font-semibold text-yellow-500">
+                Risk-adjusted pricing
+              </p>
+              <p className="text-sm text-yellow-500/90 mt-1">
+                Your credit line is in the Watch risk band. A higher APR applies
+                to reflect elevated risk. Improving your on-chain repayment
+                history may move you to a better band.
+              </p>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* ── Utilization progress bars ─────────────────────────────────────── */}
+      <section
+        aria-labelledby="utilization-heading"
+        className="rounded-xl border border-border bg-surface p-5 space-y-5"
+      >
+        <h3
+          id="utilization-heading"
+          className="text-sm font-semibold uppercase text-muted tracking-wide"
+        >
+          Credit utilization
+        </h3>
+
+        {/* Before */}
+        <div className="space-y-2">
+          <div className="flex justify-between text-sm">
+            <span className="text-muted font-medium">Current utilization</span>
+            <span className="font-semibold text-foreground tabular-nums">
+              {currentUtilizationPct}%
+            </span>
+          </div>
+          <UtilizationBar
+            pct={currentUtilizationPct}
+            isHighlighted={false}
+            aria-label={`Current credit utilization: ${currentUtilizationPct} percent`}
+          />
+        </div>
+
+        {/* After */}
+        <div className="space-y-2" data-testid="utilization-after-section">
+          <div className="flex justify-between text-sm">
+            <span className="text-muted font-medium">After this draw</span>
+            <span
+              className={`font-semibold tabular-nums ${isHighUtilization ? "text-yellow-500" : "text-foreground"}`}
+              data-testid="utilization-after-pct"
+            >
+              {newUtilization}%
+            </span>
+          </div>
+          <UtilizationBar
+            pct={newUtilization}
+            isHighlighted
+            aria-label={`Projected credit utilization after draw: ${newUtilization} percent`}
+          />
+        </div>
+
+        {/* High utilization warning */}
+        {isHighUtilization && (
+          <div
+            className="flex items-start gap-3 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3"
+            role="alert"
+            data-testid="high-utilization-warning"
+          >
+            <AlertCircle
+              className="w-5 h-5 text-yellow-500 mt-0.5 shrink-0"
+              aria-hidden="true"
+            />
+            <div>
+              <p className="text-sm font-semibold text-yellow-500">
+                High utilization warning
+              </p>
+              <p className="text-sm text-yellow-500/90 mt-1">
+                Your utilization will exceed 80% after this draw. High
+                utilization may impact your credit terms and future pricing.
+              </p>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* ── Terms checkbox ───────────────────────────────────────────────── */}
+      <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-border bg-surface p-4 transition-colors hover:bg-border">
         <input
           type="checkbox"
           checked={agreedToTerms}
           onChange={(e) => setAgreedToTerms(e.target.checked)}
-          className="dc-terms-label__checkbox"
-          aria-label="I agree to the terms and conditions and authorise this draw"
+          className="mt-1 w-5 h-5 rounded accent-accent"
+          data-testid="terms-checkbox"
         />
-        <span className="dc-terms-label__text">
-          I agree to the terms and conditions and authorize this draw. The funds
-          will be deposited within 1-2 business days.
+        <span className="text-sm text-foreground">
+          I agree to the{" "}
+          <AccessibleTooltip label="A term is a defined period or condition of your credit agreement.">
+            <span>terms</span>
+          </AccessibleTooltip>{" "}
+          and conditions and authorize this draw. The funds will be deposited
+          within 1–2 business days.
         </span>
       </label>
 
-      {/* Back / Confirm actions */}
-      <div className="dc-actions dc-actions--stacked">
-        <button
-          onClick={onBack}
-          disabled={isLoading}
-          className="dc-btn dc-btn--secondary dc-actions__slot"
+      {/* ── Wallet signing hint ───────────────────────────────────────────── */}
+      {status === "connected" && !isLoading && (
+        <div
+          className="flex items-start gap-3 rounded-lg border p-4"
+          style={{
+            backgroundColor: "rgba(88,166,255,0.08)",
+            borderColor: "rgba(88,166,255,0.3)",
+          }}
+          role="status"
         >
-          Back
-        </button>
-        <div className="dc-actions__slot">
+          <Info
+            className="w-5 h-5 shrink-0 mt-0.5"
+            style={{ color: "#58a6ff" }}
+            aria-hidden="true"
+          />
+          <span className="text-sm font-medium" style={{ color: "#e6edf3" }}>
+            Your wallet will ask you to sign next
+          </span>
+        </div>
+      )}
+
+      {/* ── Sticky footer actions ─────────────────────────────────────────── */}
+      <div className="sticky bottom-0 z-10 -mx-6 border-t border-border bg-surface/95 px-6 py-4 backdrop-blur sm:-mx-8 sm:px-8">
+        {/* Button order rule (docs/BUTTON_ORDER.md):
+            Cancel (exit flow) — Back (previous step) — Draw (primary/confirm)
+            flex-col-reverse reverses this on mobile so the primary stacks on top. */}
+        <div className="flex flex-col-reverse gap-3 sm:flex-row">
+          {/* Cancel: leftmost — exits the wizard entirely */}
           <button
-            onClick={onConfirm}
-            disabled={!canConfirm}
-            aria-disabled={!canConfirm}
-            className="dc-btn dc-btn--primary dc-btn--full"
+            type="button"
+            onClick={onCancel}
+            disabled={isLoading}
+            className="rounded-lg border-2 border-border px-4 py-3 font-semibold text-foreground transition-colors hover:bg-background disabled:opacity-50 sm:w-auto"
           >
-            {isLoading ? "Processing…" : "Confirm draw"}
+            Cancel
           </button>
-          {/* Hint shown only when terms not yet accepted */}
-          {!agreedToTerms && !isLoading && (
-            <p className="dc-hint dc-hint--right">
-              Accept terms to enable confirmation.
-            </p>
-          )}
+          {/* Back: adjacent to primary — returns to the previous step */}
+          <button
+            type="button"
+            onClick={onBack}
+            disabled={isLoading}
+            className="rounded-lg border-2 border-border px-4 py-3 font-semibold text-foreground transition-colors hover:bg-background disabled:opacity-50 sm:w-auto"
+          >
+            Back
+          </button>
+          {/* Primary: rightmost — the forward/confirm action */}
+          <div className="space-y-2 sm:ml-auto sm:min-w-64">
+            <PendingButton
+              type="button"
+              onClick={onConfirm}
+              pending={isLoading}
+              pendingLabel="Processing draw..."
+              disabled={isDrawDisabled}
+              className="w-full rounded-lg bg-blue-600 px-4 py-3 font-semibold text-white transition-all hover:bg-blue-500 hover:shadow-lg hover:shadow-blue-500/40 disabled:cursor-not-allowed disabled:opacity-50"
+              aria-describedby={
+                isDrawDisabled ? "draw-disabled-helper" : undefined
+              }
+            >
+              Draw
+            </PendingButton>
+            {isDrawDisabled && (
+              <p
+                id="draw-disabled-helper"
+                className="text-center text-xs text-muted sm:text-right"
+                role="status"
+              >
+                {disabledHelperText}
+              </p>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/DrawCreditPage.tsx
+++ b/src/pages/DrawCreditPage.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * DrawCreditPage
  *
@@ -155,96 +157,188 @@ export default function DrawCreditPage() {
   );
 
   return (
-    /*
-     * `dc-page` sets min-height:100vh + flex centering via tokens.
-     * aria-label exposes this landmark to screen readers as "Draw credit".
-     */
-    <main className="dc-page" aria-label="Draw credit">
-      <div className="dc-page__inner">
-        {/* Card uses dc-page__card (token-backed padding + radius) — no inline style override */}
-        <div className="dc-page__card">
+    <main className="min-h-screen bg-background px-4 pb-24 pt-6 max-md:pb-28 md:pb-8 sm:pt-8">
+      <div className="mx-auto w-full max-w-4xl space-y-5">
+        {step !== "status" && (
+          <header className="card" aria-label="Draw credit progress">
+            <div className="space-y-2">
+              <p className="text-sm font-semibold uppercase text-muted">
+                Draw Credit
+              </p>
+              <h1 className="text-2xl font-bold text-foreground sm:text-3xl">
+                Request funds from an approved line
+              </h1>
+            </div>
+            <ol className="mt-6 grid gap-3 sm:grid-cols-4">
+              {drawSteps.map((drawStep, index) => {
+                const isActive = index === activeStepIndex;
+                const isComplete = index < activeStepIndex;
+                const microStep = microProgressSteps[index];
 
-          {/* ── Step 1: Select a credit line ── */}
-          {step === "select" && (
-            <CreditLineSelector
-              creditLines={mockCreditLines}
-              onSelect={handleSelectCreditLine}
-            />
-          )}
+                return (
+                  <li
+                    key={drawStep.id}
+                    className={`rounded-lg border px-3 py-3 ${
+                      isActive
+                        ? "border-blue-400 bg-blue-500/10"
+                        : isComplete
+                          ? "border-green-500/40 bg-green-500/10"
+                          : "border-border bg-background/60"
+                    }`}
+                    aria-current={isActive ? "step" : undefined}
+                  >
+                    <span className="text-xs font-semibold uppercase text-muted">
+                      Step {index + 1}
+                    </span>
+                    <p className="mt-1 text-sm font-semibold text-foreground">
+                      {drawStep.label}
+                    </p>
+                    {microStep && (
+                      <DrawWizardMicroIndicator
+                        stepId={microStep.id}
+                        tone={microStep.tone}
+                        label={microStep.label}
+                      />
+                    )}
+                  </li>
+                );
+              })}
+            </ol>
+            {/*
+              Polite live region for micro-progress updates — one announcer
+              for the whole header so AT users hear validity changes without
+              four competing regions.
+            */}
+            <span
+              className="sr-only"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              data-testid="draw-micro-progress-live"
+            >
+              {microProgressAnnouncement}
+            </span>
+          </header>
+        )}
 
-          {/* ── Step 2: Enter amount + live preview ── */}
-          {step === "amount" && selectedCreditLine && (
-            <div className="dc-step">
+        {/* ── Step 1: Select a credit line ── */}
+        {step === "select" && (
+          <div className="card card-large" style={{ maxWidth: "none", margin: 0 }}>
+            <section aria-labelledby="select-credit-line-heading">
+              <CreditLineSelector
+                creditLines={mockCreditLines}
+                onSelect={handleSelectCreditLine}
+                microProgressDescribedBy="draw-wizard-micro-select"
+              />
+            </section>
+          </div>
+        )}
+
+        {/* ── Step 2: Enter amount + live preview ── */}
+        {step === "amount" && selectedCreditLine && (
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(280px,360px)] lg:items-start">
+            <section className="card" style={{ margin: 0 }}>
               <AmountInput
                 creditLine={selectedCreditLine}
                 onAmountChange={setAmount}
                 onNext={handleAmountNext}
                 onBack={handleBack}
               />
-              {/* Separator uses dc-separator (border-top with space-8 padding — token-backed) */}
-              <div className="dc-separator">
-                <PreviewSection
-                  creditLine={selectedCreditLine}
-                  amount={amount}
-                />
-              </div>
-            </div>
-          )}
-
-          {/* ── Step 3: Review & confirm ── */}
-          {step === "confirm" && selectedCreditLine && (
-            <ConfirmationStep
-              creditLine={selectedCreditLine}
-              amount={amount}
-              onConfirm={handleConfirm}
-              onBack={handleBack}
-              isLoading={isLoading}
-            />
-          )}
-
-          {/* ── Step 4: Status (loading → result) ── */}
-          {step === "status" && (isLoading || transaction) && (
-            <>
-              {isLoading && (
-                /*
-                 * role="status" + aria-live="polite" announce the loading state
-                 * to screen readers without interrupting the user.
-                 * aria-label on the spinner ring itself provides a text
-                 * alternative for the animated element.
-                 */
-                <div
-                  className="dc-spinner-wrap"
-                  role="status"
-                  aria-live="polite"
-                  aria-label="Processing your draw request"
-                >
-                  <div className="dc-spinner-ring-bg">
-                    <div
-                      className="dc-spinner-ring"
-                      aria-hidden="true"
-                    />
-                  </div>
-                  <div>
-                    <h2 className="dc-step__title">Processing</h2>
-                    <p className="dc-step__subtitle">
-                      Your draw request is being processed.
-                    </p>
-                  </div>
+              {/* Drawing limit indicator */}
+              {selectedCreditLine && (
+                <div className="mt-6 border-t border-border pt-6">
+                  <DrawingLimit
+                    drawnAmount={selectedCreditLine.limit - selectedCreditLine.available}
+                    totalLimit={selectedCreditLine.limit}
+                  />
                 </div>
               )}
-              {transaction && !isLoading && (
-                <TransactionStatus
-                  transaction={transaction}
-                  onNewDraw={handleNewDraw}
-                />
-              )}
-            </>
-          )}
-        </div>
+            </section>
+            <aside className="card lg:sticky lg:top-6" style={{ margin: 0 }}>
+              <PreviewSection creditLine={selectedCreditLine} amount={amount} />
+            </aside>
+          </div>
+        )}
 
-        <p className="dc-page__footer">
-          Need help? Contact support at 1-800-CREDIT-1
-        </p>
+        {/* ── Step 3: Review & confirm ── */}
+        {step === "confirm" && selectedCreditLine && (
+          <div className="card card-large" style={{ maxWidth: "none", margin: 0 }}>
+            <section aria-labelledby="confirm-draw-heading">
+              <ConfirmationStep
+                creditLine={selectedCreditLine}
+                amount={amount}
+                onConfirm={handleConfirm}
+                onBack={handleBack}
+                onCancel={handleCancel}
+                isLoading={isLoading}
+                agreedToTerms={confirmationAcknowledged}
+                onAgreedToTermsChange={setConfirmationAcknowledged}
+              />
+            </section>
+          </div>
+        )}
+
+        {/* ── Step 4: Status (loading → result) ── */}
+        {step === "status" && transaction && (
+          <div className="card card-large" style={{ maxWidth: "none", margin: 0 }}>
+            <TransactionStatus
+              transaction={transaction}
+              onNewDraw={handleNewDraw}
+            />
+          </div>
+        )}
+
+        {step === "status" && !transaction && (
+          <div className="card card-large" style={{ maxWidth: "none", margin: 0 }}>
+            <div className="space-y-4 text-center">
+              <h2 className="text-2xl font-bold text-foreground">
+                Draw status unavailable
+              </h2>
+              <p className="text-muted">
+                Start a new request to draw from an approved credit line.
+              </p>
+              <button
+                type="button"
+                onClick={handleNewDraw}
+                className="rounded-lg bg-blue-600 px-4 py-3 font-semibold text-white transition-all hover:bg-blue-500"
+              >
+                Start new draw
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step !== "status" && (
+          <div className="flex flex-col gap-2 text-center text-sm text-muted sm:flex-row sm:items-center sm:justify-between sm:text-left">
+            <div className="flex flex-col sm:flex-row items-center gap-2 sm:gap-4">
+              <button
+                ref={helpTriggerRef}
+                type="button"
+                onClick={() => setIsHelpOpen(true)}
+                className="inline-flex min-h-11 items-center justify-center rounded-md px-3 font-semibold text-blue-300 underline-offset-4 transition-colors hover:text-blue-200 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 sm:justify-start"
+              >
+                I need help
+              </button>
+              {(step === "amount" || step === "confirm") && (
+                <button
+                  ref={whyAprTriggerRef}
+                  type="button"
+                  onClick={() => setIsWhyAprOpen(true)}
+                  className="inline-flex min-h-11 items-center justify-center rounded-md px-3 font-semibold text-blue-300 underline-offset-4 transition-colors hover:text-blue-200 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 sm:justify-start"
+                >
+                  Why this APR?
+                </button>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="font-semibold text-foreground underline-offset-4 hover:text-blue-400 hover:underline"
+            >
+              Cancel draw
+            </button>
+          </div>
+        )}
       </div>
       <InlineHelpOverlay
         isOpen={isHelpOpen}
@@ -317,4 +411,3 @@ export function DrawCreditPageSkeleton() {
     </main>
   );
 }
-


### PR DESCRIPTION
## Summary

Polish the draw wizard review-before-submit step (step 4 — Confirm) for the GrantFox FWC26 campaign.

### Changes

**`src/components/ConfirmationStep.tsx`**
- Replaced the flat data grid with a structured **cost-breakdown card** (sectioned with a visible heading and `aria-labelledby`)
- Added a **risk-band badge** (Prime / Standard / Watch) adjacent to the draw amount with a full accessible `aria-label` describing the band
- Added a **collapsible "How is my APR calculated?" disclosure** using a real `<button aria-expanded>` / `aria-controls` pattern — exposes base rate, utilization adjustment, and term adjustment from the pricing model
- Added **before / after utilization progress bars** with `role="progressbar"`, `aria-valuenow`, and `aria-label` (WCAG 4.1.2)
- Added a **risk-adjusted fee notice** (`role="note"`) shown only when the Watch band is active
- High-utilization warning upgraded to `role="alert"` for immediate AT announcement
- Maintained BUTTON_ORDER.md compliance: Cancel → Back → Draw

**`src/pages/DrawCreditPage.tsx`**
- Fixed `DrawingLimit` prop: derive `drawnAmount` from `creditLine.limit - creditLine.available` instead of the non-existent `drawnAmount` field on the wizard's `CreditLine` type

**`src/components/ConfirmationStep.test.tsx`**
- Rewrote with 42 focused tests covering all new polish elements:
  - Cost breakdown section presence and values
  - APR disclosure toggle: collapsed by default, aria-expanded, opens/closes, shows base rate + adjustments
  - Risk-band badge: renders, correct label, accessible aria-label
  - Watch-band fee notice: shown for Watch, hidden for Standard
  - Utilization progress bars: two `progressbar` roles, correct percentages
  - High-utilization warning: absent below 80%, present and `role=alert` above 80%
  - Button order (Cancel → Back → Draw)
  - Wallet signing hint visibility

### Tests

```
✓ src/components/ConfirmationStep.test.tsx (42 tests)
Tests  42 passed (42)
```

Pre-existing failures in `PreviewSection.test.tsx` (2 tests, same count before and after these changes) are unrelated to this PR.

### Accessibility checklist

- [x] Keyboard navigation works (Tab, Shift+Tab, Enter on disclosure toggle)
- [x] Focus indicators visible (inherits 2px outline tokens)
- [x] Color is never the sole signal — icons and text labels accompany every colored element (WCAG 1.4.1)
- [x] Touch targets ≥ 44×44 px (inherited from existing button styles)
- [x] Semantic HTML and ARIA roles/labels used throughout
- [x] `prefers-reduced-motion` respected via `transition-all` base CSS

Closes #429