### PR TITLE
fix: DrawCreditPage reduced-motion (v7)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -579,6 +579,18 @@ button.header-nav-link {
   to { transform: rotate(360deg); }
 }
 
+/* ── Reduced-motion fallback (in-app override) ──
+   The OS-level `prefers-reduced-motion: reduce` is already handled globally
+   at the top of this file.  These rules cover the in-app toggle provided by
+   ReducedMotionContext, which sets data-reduced-motion="true" on <main>. */
+.dc-page[data-reduced-motion="true"] .dc-page__card {
+  animation: none;
+}
+
+.dc-page[data-reduced-motion="true"] .dc-spinner-ring {
+  animation: none;
+}
+
 /* ── Credit-line selector ── */
 .dc-credit-line-list { display: flex; flex-direction: column; gap: var(--space-3); }
 

--- a/src/pages/DrawCreditPage.test.tsx
+++ b/src/pages/DrawCreditPage.test.tsx
@@ -295,6 +295,10 @@ describe("DrawCreditPage — step navigation & token audit", () => {
 // ─── Reduced-motion fallback tests ────────────────────────────────────
 
 describe("DrawCreditPage — reduced-motion fallback", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("does NOT set data-reduced-motion when motion is enabled (default)", () => {
     vi.spyOn(ReducedMotionContext, "useReducedMotion").mockReturnValue({
       motionOverride: "system",

--- a/src/pages/DrawCreditPage.test.tsx
+++ b/src/pages/DrawCreditPage.test.tsx
@@ -26,6 +26,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import DrawCreditPage from "./DrawCreditPage";
+import * as ReducedMotionContext from "@/context/ReducedMotionContext";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -288,5 +289,35 @@ describe("DrawCreditPage — step navigation & token audit", () => {
     ).toBeInTheDocument();
 
     randomSpy.mockRestore();
+  });
+});
+
+// ─── Reduced-motion fallback tests ────────────────────────────────────
+
+describe("DrawCreditPage — reduced-motion fallback", () => {
+  it("does NOT set data-reduced-motion when motion is enabled (default)", () => {
+    vi.spyOn(ReducedMotionContext, "useReducedMotion").mockReturnValue({
+      motionOverride: "system",
+      toggleMotionOverride: vi.fn(),
+      setMotionOverride: vi.fn(),
+      isReducedMotionActive: false,
+    });
+
+    render(<DrawCreditPage />);
+    const main = document.querySelector("main.dc-page");
+    expect(main).not.toHaveAttribute("data-reduced-motion");
+  });
+
+  it("sets data-reduced-motion='true' when in-app reduced-motion override is active", () => {
+    vi.spyOn(ReducedMotionContext, "useReducedMotion").mockReturnValue({
+      motionOverride: "reduced",
+      toggleMotionOverride: vi.fn(),
+      setMotionOverride: vi.fn(),
+      isReducedMotionActive: true,
+    });
+
+    render(<DrawCreditPage />);
+    const main = document.querySelector("main.dc-page");
+    expect(main).toHaveAttribute("data-reduced-motion", "true");
   });
 });

--- a/src/pages/DrawCreditPage.tsx
+++ b/src/pages/DrawCreditPage.tsx
@@ -20,6 +20,7 @@
 import { useRef, useState, useEffect } from "react";
 import { Skeleton } from "@/components/Skeleton";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useReducedMotion } from "@/context/ReducedMotionContext";
 import { loadDraft, saveDraft, clearDraft } from "@/state/wizardDraft";
 import { CreditLineSelector } from "@/components/CreditLineSelector";
 import { AmountInput } from "@/components/AmountInput";
@@ -75,6 +76,8 @@ export default function DrawCreditPage() {
   );
   const [confirmationAcknowledged, setConfirmationAcknowledged] =
     useState(false);
+
+  const { isReducedMotionActive } = useReducedMotion();
 
   const { steps: microProgressSteps, debouncedAnnouncement: microProgressAnnouncement } =
     useDrawWizardMicroProgress({
@@ -159,7 +162,11 @@ export default function DrawCreditPage() {
      * `dc-page` sets min-height:100vh + flex centering via tokens.
      * aria-label exposes this landmark to screen readers as "Draw credit".
      */
-    <main className="dc-page" aria-label="Draw credit">
+    <main
+      className="dc-page"
+      aria-label="Draw credit"
+      data-reduced-motion={isReducedMotionActive ? "true" : undefined}
+    >
       <div className="dc-page__inner">
         {/* Card uses dc-page__card (token-backed padding + radius) — no inline style override */}
         <div className="dc-page__card">


### PR DESCRIPTION
Add reduced-motion fallback for DrawCreditPage spinner and card animations. Closes #594