### PR TITLE
feat: RiskGauge empty state (v7)

### DIFF
--- a/src/pages/RiskGauge.tsx
+++ b/src/pages/RiskGauge.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
 import { Sparkline } from "../components/Sparkline";
+import { EmptyState } from "../components/EmptyState";
+import { NoDataGraph } from "../components/illustrations/EmptyStateIllustrations";
 import { COLOR, RISK_COLOR, fmtDate } from "../utils/tokens";
 import { useReducedMotion } from "../context/ReducedMotionContext";
 
@@ -19,17 +21,36 @@ const easeCubicBezier = (x: number): number => {
   return 3 * t * (1 - t) + t * t * t;
 };
 
-export function RiskGauge({
-  score,
-  trend,
-  lastUpdated,
-  history,
-}: {
-  score: number;
-  trend: "improving" | "declining" | "stable";
-  lastUpdated: string;
+type RiskGaugeBaseProps = {
   history?: number[];
-}) {
+  /** When true, an empty-state illustration is shown instead of the gauge. */
+  isEmpty?: boolean;
+  /** Fired when the user clicks the "Check again" CTA on the empty state. */
+  onRefresh?: () => void;
+};
+
+type RiskGaugeProps =
+  | (RiskGaugeBaseProps & {
+      isEmpty: true;
+      score?: number;
+      trend?: "improving" | "declining" | "stable";
+      lastUpdated?: string;
+    })
+  | (RiskGaugeBaseProps & {
+      isEmpty?: false;
+      score: number;
+      trend: "improving" | "declining" | "stable";
+      lastUpdated: string;
+    });
+
+export function RiskGauge({
+  score = 0,
+  trend = "stable",
+  lastUpdated = "",
+  history,
+  isEmpty = false,
+  onRefresh,
+}: RiskGaugeProps) {
   const radius = 55;
   const cx = 80;
   const cy = 75;
@@ -91,6 +112,24 @@ export function RiskGauge({
   }, [normalizedScore, isReducedMotionActive]);
 
   const scoreFormatter = useMemo(() => new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }), []);
+
+  // ── Empty state ──
+  if (isEmpty) {
+    return (
+      <EmptyState
+        illustration={<NoDataGraph />}
+        eyebrow="Risk Score"
+        title="No risk data available"
+        description="Your risk score will appear here once your credit profile has been analyzed."
+        tone="info"
+        primaryAction={
+          onRefresh
+            ? { label: "Check again", onClick: onRefresh }
+            : undefined
+        }
+      />
+    );
+  }
 
   const srDescription = `Risk score ${normalizedScore} of 850. Trend: ${trendLabel}.`;
 

--- a/src/pages/RiskGauge.tsx
+++ b/src/pages/RiskGauge.tsx
@@ -21,28 +21,6 @@ const easeCubicBezier = (x: number): number => {
   return 3 * t * (1 - t) + t * t * t;
 };
 
-type RiskGaugeBaseProps = {
-  history?: number[];
-  /** When true, an empty-state illustration is shown instead of the gauge. */
-  isEmpty?: boolean;
-  /** Fired when the user clicks the "Check again" CTA on the empty state. */
-  onRefresh?: () => void;
-};
-
-type RiskGaugeProps =
-  | (RiskGaugeBaseProps & {
-      isEmpty: true;
-      score?: number;
-      trend?: "improving" | "declining" | "stable";
-      lastUpdated?: string;
-    })
-  | (RiskGaugeBaseProps & {
-      isEmpty?: false;
-      score: number;
-      trend: "improving" | "declining" | "stable";
-      lastUpdated: string;
-    });
-
 export function RiskGauge({
   score = 0,
   trend = "stable",
@@ -50,7 +28,16 @@ export function RiskGauge({
   history,
   isEmpty = false,
   onRefresh,
-}: RiskGaugeProps) {
+}: {
+  score?: number;
+  trend?: "improving" | "declining" | "stable";
+  lastUpdated?: string;
+  history?: number[];
+  /** When true, an empty-state illustration is shown instead of the gauge. */
+  isEmpty?: boolean;
+  /** Fired when the user clicks the "Check again" CTA on the empty state. */
+  onRefresh?: () => void;
+}) {
   const radius = 55;
   const cx = 80;
   const cy = 75;

--- a/src/pages/__tests__/RiskGauge.test.tsx
+++ b/src/pages/__tests__/RiskGauge.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * RiskGauge page tests
+ *
+ * Cover:
+ *  1. Renders the gauge SVG when isEmpty is false (default).
+ *  2. Renders EmptyState when isEmpty is true.
+ *  3. EmptyState includes the NoDataGraph illustration, heading, and description.
+ *  4. EmptyState shows "Check again" CTA when onRefresh is provided.
+ *  5. EmptyState does NOT render the SVG or meta row.
+ *  6. When isEmpty is false, the original gauge behaviour is preserved.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { RiskGauge } from '../RiskGauge';
+
+function renderRiskGauge(
+  props: Partial<Parameters<typeof RiskGauge>[0]> = {},
+) {
+  return render(
+    <MemoryRouter>
+      <RiskGauge {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe('RiskGauge page', () => {
+  describe('normal (non-empty) state', () => {
+    it('renders the gauge SVG with the score', () => {
+      renderRiskGauge({
+        score: 720,
+        trend: 'improving',
+        lastUpdated: '2025-03-01T00:00:00Z',
+      });
+      const svg = screen.getByTestId('risk-gauge-svg');
+      expect(svg).toBeInTheDocument();
+    });
+
+    it('renders the trend meta row', () => {
+      renderRiskGauge({
+        score: 720,
+        trend: 'improving',
+        lastUpdated: '2025-03-01T00:00:00Z',
+      });
+      expect(screen.getByText(/improving/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', () => {
+    it('renders EmptyState when isEmpty is true', () => {
+      renderRiskGauge({ isEmpty: true });
+      // The EmptyState renders a heading with the title
+      expect(
+        screen.getByRole('heading', { name: /no risk data available/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders the description text', () => {
+      renderRiskGauge({ isEmpty: true });
+      expect(
+        screen.getByText(
+          /your risk score will appear here once your credit profile has been analyzed/i,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('does NOT render the gauge SVG when empty', () => {
+      renderRiskGauge({ isEmpty: true });
+      expect(screen.queryByTestId('risk-gauge-svg')).not.toBeInTheDocument();
+    });
+
+    it('renders a "Check again" button when onRefresh is provided', () => {
+      const onRefresh = vi.fn();
+      renderRiskGauge({ isEmpty: true, onRefresh });
+      const btn = screen.getByRole('button', { name: /check again/i });
+      expect(btn).toBeInTheDocument();
+      fireEvent.click(btn);
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT render a CTA button when onRefresh is not provided', () => {
+      renderRiskGauge({ isEmpty: true });
+      expect(
+        screen.queryByRole('button', { name: /check again/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the eyebrow text "Risk Score"', () => {
+      renderRiskGauge({ isEmpty: true });
+      expect(screen.getByText('Risk Score')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Add themed empty-state illustration for RiskGauge with NoDataGraph and optional refresh CTA. Closes #601