### PR TITLE
fix: tabular-nums on DrawCreditPage

### DIFF
--- a/src/components/CreditLineSelector.tsx
+++ b/src/components/CreditLineSelector.tsx
@@ -93,7 +93,7 @@ export function CreditLineSelector({
                         <span className="dc-credit-line-item__label">
                           Available:
                         </span>
-                        <span className="dc-credit-line-item__value">
+                        <span className="dc-credit-line-item__value num-tabular">
                           ${line.available.toLocaleString()}
                         </span>
                       </div>
@@ -103,11 +103,11 @@ export function CreditLineSelector({
                           Utilization:
                         </span>
                         <span
-                          className={
+                          className={`num-tabular ${
                             isHighUtilization
                               ? "dc-credit-line-item__value--warning"
                               : "dc-credit-line-item__value"
-                          }
+                          }`}
                         >
                           {line.utilization}%
                         </span>

--- a/src/components/CreditLineSummaryBlock.tsx
+++ b/src/components/CreditLineSummaryBlock.tsx
@@ -109,19 +109,19 @@ export function CreditLineSummaryBlock({
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
         <div className="rounded-lg border border-border bg-background/60 p-3">
           <p className="text-muted">Limit</p>
-          <p className="text-base font-semibold text-foreground mt-1">
+          <p className="text-base font-semibold text-foreground mt-1 num-tabular">
             {formatMoney(creditLine.limit)}
           </p>
         </div>
         <div className="rounded-lg border border-border bg-background/60 p-3">
           <p className="text-muted">Utilized</p>
-          <p className="text-base font-semibold text-foreground mt-1">
+          <p className="text-base font-semibold text-foreground mt-1 num-tabular">
             {formatMoney(projectedUtilized)}
           </p>
         </div>
         <div className="rounded-lg border border-border bg-background/60 p-3">
           <p className="text-muted">Available</p>
-          <p className="text-base font-semibold text-foreground mt-1">
+          <p className="text-base font-semibold text-foreground mt-1 num-tabular">
             {formatMoney(projectedAvailable)}
           </p>
         </div>

--- a/src/components/PreviewSection.tsx
+++ b/src/components/PreviewSection.tsx
@@ -44,7 +44,7 @@ export function PreviewSection({ creditLine, amount }: PreviewSectionProps) {
           <div className="dc-stat-card__header">
             <div>
               <p className="dc-stat-card__label">Draw Amount</p>
-              <p className="dc-stat-card__value">
+              <p className="dc-stat-card__value num-tabular">
                 ${amount.toLocaleString()}
               </p>
             </div>
@@ -60,7 +60,7 @@ export function PreviewSection({ creditLine, amount }: PreviewSectionProps) {
           <div className="dc-stat-card__header">
             <div>
               <p className="dc-stat-card__label">New Utilization</p>
-              <p className="dc-stat-card__value">
+              <p className="dc-stat-card__value num-tabular">
                 {newUtilization}%
               </p>
             </div>
@@ -76,7 +76,7 @@ export function PreviewSection({ creditLine, amount }: PreviewSectionProps) {
       <div className="dc-util-section">
         <div className="dc-util-row">
           <span className="dc-util-row__label">Current utilization</span>
-          <span className="dc-util-row__value">{creditLine.utilization}%</span>
+          <span className="dc-util-row__value num-tabular">{creditLine.utilization}%</span>
         </div>
         <div
           className="dc-progress-track dc-progress-track--lg"
@@ -98,11 +98,11 @@ export function PreviewSection({ creditLine, amount }: PreviewSectionProps) {
         <div className="dc-util-row">
           <span className="dc-util-row__label">After draw</span>
           <span
-            className={
+            className={`num-tabular ${
               isHighAfterDraw
                 ? "dc-util-row__value--warning"
                 : "dc-util-row__value"
-            }
+            }`}
           >
             {newUtilization}%
           </span>

--- a/src/components/TransactionStatus.tsx
+++ b/src/components/TransactionStatus.tsx
@@ -107,7 +107,7 @@ export function TransactionStatus({
         {/* Amount drawn */}
         <div className="dc-status-detail-row">
           <p className="dc-status-detail-row__label">Amount Drawn</p>
-          <p className="dc-status-detail-row__value dc-status-detail-row__value--large">
+          <p className="dc-status-detail-row__value dc-status-detail-row__value--large num-tabular">
             ${transaction.amount.toLocaleString()}
           </p>
         </div>


### PR DESCRIPTION
## Summary
- Applies the existing `num-tabular` typography utility (`src/styles/typography.css`) to numeric displays on the DrawCreditPage flow that were missing it, so digit columns stay visually stable as values change.
- Updated: `PreviewSection` (draw amount, current/new utilization %), `CreditLineSelector` (available balance, utilization %), `CreditLineSummaryBlock` (limit, utilized, available), `TransactionStatus` (amount drawn).
- No logic changes — className additions only.

Closes #520

## Test plan
- [x] Confirmed pre-existing test/type-check failures in the repo are unchanged before/after this change (verified via `git stash` A/B comparison) — this PR introduces no new failures.
- [x] Manually reviewed each touched numeric display against the `num-tabular` / `tabular-nums` convention already used elsewhere on the page (e.g. `AmountInput`, `ConfirmationStep`, `DrawSummaryBar`).