### PR TITLE
feat: implement interactive keyboard-accessible PreviewCard popovers

### DIFF
--- a/src/components/AutopaySchedule.css
+++ b/src/components/AutopaySchedule.css
@@ -90,6 +90,7 @@
 /* Table wrapper — horizontal scroll on small screens */
 .autopay-schedule__table-wrapper {
   overflow-x: auto;
+  overflow-y: visible;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   /* Keyboard-scrollable for accessibility */
@@ -146,6 +147,7 @@
 }
 
 .autopay-schedule__td--right {
+  position: relative;
   text-align: right;
 }
 
@@ -156,12 +158,28 @@
 }
 
 /* Row states */
+.autopay-schedule__row {
+  position: relative;
+  cursor: pointer;
+  outline: none;
+  transition: background-color 150ms ease, border-color 150ms ease;
+}
+
 .autopay-schedule__row:last-child .autopay-schedule__td {
   border-bottom: none;
 }
 
-.autopay-schedule__row:hover .autopay-schedule__td {
-  background: rgba(88, 166, 255, 0.04);
+.autopay-schedule__row:hover .autopay-schedule__td,
+.autopay-schedule__row:focus-visible .autopay-schedule__td,
+.autopay-schedule__row--active .autopay-schedule__td {
+  background: rgba(88, 166, 255, 0.08);
+}
+
+.autopay-schedule__row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: var(--radius-sm, 4px);
+  z-index: 10;
 }
 
 .autopay-schedule__row--upcoming .autopay-schedule__td {

--- a/src/components/AutopaySchedule.tsx
+++ b/src/components/AutopaySchedule.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
 import { fmt, fmtDate } from '../utils/tokens';
+import { PreviewCard } from './PreviewCard';
 import './AutopaySchedule.css';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -17,6 +18,8 @@ export interface AutopayScheduleProps {
   endDate?: string;
   /** Maximum rows to render (default 8). Prevents an unbounded list. */
   maxRows?: number;
+  /** Optional callback when a preview card row is hovered or focused */
+  onPreviewRowChange?: (index: number | null) => void;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -77,16 +80,15 @@ function buildSchedule(
 /**
  * AutopaySchedule — live, responsive list preview of upcoming repayment dates.
  *
- * Re-derives the schedule on every render from props, so the preview
- * updates in real-time as the user edits the form above it.
+ * Includes hover-triggered & keyboard-accessible PreviewCard popovers for
+ * each repayment installment row.
  *
  * Accessibility:
  * - Table is labelled with an `aria-labelledby` heading.
  * - Column headers use `scope="col"` per WCAG technique H63.
- * - "Upcoming" badge uses `aria-label` to give screen readers extra
- *   context (the visual color alone must not be the sole differentiator).
- * - The caption is visually hidden but keeps the table semantically
- *   self-describing when navigated out of context.
+ * - Rows are keyboard-focusable (tabIndex={0}) and announce details via aria-describedby.
+ * - Pressing Escape key dismisses any open preview popover.
+ * - Pressing Enter or Space toggles row preview details.
  */
 export function AutopaySchedule({
   amount,
@@ -94,10 +96,36 @@ export function AutopaySchedule({
   startDate,
   endDate,
   maxRows = 8,
+  onPreviewRowChange,
 }: AutopayScheduleProps) {
   const schedule = useMemo(
     () => buildSchedule(startDate, frequency, endDate, maxRows),
     [startDate, frequency, endDate, maxRows],
+  );
+
+  const [activePreviewIndex, setActivePreviewIndex] = useState<number | null>(null);
+
+  const handleRowHover = useCallback(
+    (index: number | null) => {
+      setActivePreviewIndex(index);
+      if (onPreviewRowChange) {
+        onPreviewRowChange(index);
+      }
+    },
+    [onPreviewRowChange],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent, index: number) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleRowHover(null);
+      } else if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        handleRowHover(activePreviewIndex === index ? null : index);
+      }
+    },
+    [activePreviewIndex, handleRowHover],
   );
 
   const today = new Date();
@@ -159,14 +187,18 @@ export function AutopaySchedule({
       </div>
 
       {/* ── Table ───────────────────────────────────────────────────────── */}
-      <div className="autopay-schedule__table-wrapper" tabIndex={0} aria-label="Scroll to view more payments">
+      <div
+        className="autopay-schedule__table-wrapper"
+        tabIndex={0}
+        aria-label="Scroll or focus payment rows to view details"
+      >
         <table
           className="autopay-schedule__table"
           aria-labelledby="schedule-heading"
         >
           <caption className="sr-only">
             Upcoming autopay payments — {FREQ_LABEL[frequency]}, {fmt(amount)}{' '}
-            per payment, starting {fmtDate(startDate)}
+            per payment, starting {fmtDate(startDate)}. Hover or focus rows for details.
           </caption>
           <thead>
             <tr>
@@ -190,11 +222,34 @@ export function AutopaySchedule({
               dateOnly.setHours(0, 0, 0, 0);
               const isUpcoming = dateOnly.getTime() === today.getTime();
               const isPast = dateOnly < today;
+              const status: 'Upcoming' | 'Scheduled' | 'Past' = isUpcoming
+                ? 'Upcoming'
+                : isPast
+                ? 'Past'
+                : 'Scheduled';
+
+              const previewId = `autopay-preview-card-${index}`;
+              const isPreviewActive = activePreviewIndex === index;
+              const accumulatedSoFar = amount * (index + 1);
 
               return (
                 <tr
                   key={date.toISOString()}
-                  className={`autopay-schedule__row${isUpcoming ? ' autopay-schedule__row--upcoming' : ''}${isPast ? ' autopay-schedule__row--past' : ''}`}
+                  tabIndex={0}
+                  role="row"
+                  aria-haspopup="dialog"
+                  aria-expanded={isPreviewActive}
+                  aria-describedby={isPreviewActive ? previewId : undefined}
+                  className={`autopay-schedule__row preview-card-trigger${
+                    isUpcoming ? ' autopay-schedule__row--upcoming' : ''
+                  }${isPast ? ' autopay-schedule__row--past' : ''}${
+                    isPreviewActive ? ' autopay-schedule__row--active' : ''
+                  }`}
+                  onMouseEnter={() => handleRowHover(index)}
+                  onMouseLeave={() => handleRowHover(null)}
+                  onFocus={() => handleRowHover(index)}
+                  onBlur={() => handleRowHover(null)}
+                  onKeyDown={(e) => handleKeyDown(e, index)}
                 >
                   <td className="autopay-schedule__td autopay-schedule__td--num">
                     {index + 1}
@@ -230,6 +285,19 @@ export function AutopaySchedule({
                         Scheduled
                       </span>
                     )}
+
+                    {/* Popover PreviewCard */}
+                    <PreviewCard
+                      id={previewId}
+                      paymentNumber={index + 1}
+                      date={date.toISOString()}
+                      amount={amount}
+                      frequency={FREQ_LABEL[frequency]}
+                      status={status}
+                      totalAccumulated={accumulatedSoFar}
+                      isOpenEnded={isOpen}
+                      className={isPreviewActive ? 'preview-card--visible' : ''}
+                    />
                   </td>
                 </tr>
               );
@@ -242,12 +310,12 @@ export function AutopaySchedule({
       {isOpen && (
         <p className="autopay-schedule__footnote">
           * Open-ended schedule — showing the first {totalPayments} payments.
-          Total will vary.
+          Total will vary. Focus or hover rows for installment preview details.
         </p>
       )}
       {!isOpen && totalPayments === maxRows && (
         <p className="autopay-schedule__footnote">
-          Showing first {maxRows} of all scheduled payments.
+          Showing first {maxRows} of all scheduled payments. Focus or hover rows for installment preview details.
         </p>
       )}
     </section>

--- a/src/components/PreviewCard.css
+++ b/src/components/PreviewCard.css
@@ -1,0 +1,230 @@
+/* ── PreviewCard CSS ──────────────────────────────────────────────────────────── */
+
+.preview-card {
+  position: absolute;
+  right: calc(100% + 12px);
+  top: 50%;
+  transform: translateY(-50%) scale(0.98);
+  z-index: 100;
+  width: 280px;
+  max-width: calc(100vw - 2rem);
+  padding: var(--space-4, 1rem);
+  background: var(--surface, #161b22);
+  border: 1px solid var(--border, #30363d);
+  border-radius: var(--radius-lg, 10px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45), 0 2px 6px rgba(0, 0, 0, 0.2);
+  color: var(--text, #e6edf3);
+  font-family: inherit;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 160ms cubic-bezier(0.16, 1, 0.3, 1),
+              transform 160ms cubic-bezier(0.16, 1, 0.3, 1);
+  text-align: left;
+}
+
+/* Arrow indicator pointing to trigger element */
+.preview-card::after {
+  content: '';
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%) rotate(45deg);
+  width: 10px;
+  height: 10px;
+  margin-left: -5px;
+  background: var(--surface, #161b22);
+  border-top: 1px solid var(--border, #30363d);
+  border-right: 1px solid var(--border, #30363d);
+}
+
+/* Active / visible state when hover or focused */
+.preview-card--visible,
+.preview-card-trigger:hover .preview-card,
+.preview-card-trigger:focus-within .preview-card {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(-50%) scale(1);
+}
+
+/* On smaller screens (e.g. mobile), position popover centered below or above */
+@media (max-width: 640px) {
+  .preview-card {
+    right: auto;
+    left: 50%;
+    bottom: calc(100% + 12px);
+    top: auto;
+    transform: translateX(-50%) scale(0.98);
+    width: 260px;
+  }
+
+  .preview-card::after {
+    left: 50%;
+    top: 100%;
+    margin-left: 0;
+    margin-top: -5px;
+    transform: translateX(-50%) rotate(45deg);
+    border-top: none;
+    border-right: 1px solid var(--border, #30363d);
+    border-bottom: 1px solid var(--border, #30363d);
+  }
+
+  .preview-card--visible,
+  .preview-card-trigger:hover .preview-card,
+  .preview-card-trigger:focus-within .preview-card {
+    transform: translateX(-50%) scale(1);
+  }
+}
+
+/* ── Card Header ────────────────────────────────────────────────────────── */
+
+.preview-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2, 0.5rem);
+}
+
+.preview-card__title-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.preview-card__index {
+  font-size: var(--text-xs, 0.75rem);
+  font-weight: 600;
+  color: var(--accent, #58a6ff);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.preview-card__date {
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: 600;
+  color: var(--text, #e6edf3);
+}
+
+/* Badges */
+.preview-card__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.5rem;
+  border-radius: var(--radius-full, 9999px);
+  font-size: var(--text-xs, 0.75rem);
+  font-weight: 500;
+  line-height: 1;
+}
+
+.preview-card__badge--upcoming {
+  background: rgba(88, 166, 255, 0.16);
+  color: var(--accent, #58a6ff);
+  border: 1px solid rgba(88, 166, 255, 0.35);
+}
+
+.preview-card__badge--scheduled {
+  background: rgba(63, 185, 80, 0.16);
+  color: var(--success, #3fb950);
+  border: 1px solid rgba(63, 185, 80, 0.35);
+}
+
+.preview-card__badge--past {
+  background: rgba(139, 148, 158, 0.16);
+  color: var(--muted, #8b949e);
+  border: 1px solid rgba(139, 148, 158, 0.35);
+}
+
+.preview-card__relative-time {
+  margin-top: 0.25rem;
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--muted, #8b949e);
+}
+
+.preview-card__divider {
+  height: 1px;
+  background: var(--border, #30363d);
+  margin: var(--space-3, 0.75rem) 0;
+}
+
+/* ── Primary Stat ────────────────────────────────────────────────────────── */
+
+.preview-card__stat-primary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  margin-bottom: var(--space-3, 0.75rem);
+}
+
+.preview-card__label {
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--muted, #8b949e);
+  font-weight: 500;
+}
+
+.preview-card__amount {
+  font-size: var(--text-xl, 1.25rem);
+  font-weight: 700;
+  color: var(--text, #e6edf3);
+  letter-spacing: -0.01em;
+}
+
+/* ── Breakdown ───────────────────────────────────────────────────────────── */
+
+.preview-card__breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 0.5rem 0.65rem;
+  border-radius: var(--radius-md, 6px);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.preview-card__breakdown-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: var(--text-xs, 0.75rem);
+}
+
+.preview-card__sublabel {
+  color: var(--muted, #8b949e);
+}
+
+.preview-card__subval {
+  color: var(--text, #e6edf3);
+  font-weight: 500;
+}
+
+.preview-card__breakdown-row--highlight {
+  margin-top: 0.2rem;
+  padding-top: 0.3rem;
+  border-top: 1px dashed var(--border, #30363d);
+}
+
+.preview-card__breakdown-row--highlight .preview-card__sublabel {
+  color: var(--text, #e6edf3);
+  font-weight: 600;
+}
+
+.preview-card__breakdown-row--highlight .preview-card__subval {
+  color: var(--accent, #58a6ff);
+  font-weight: 700;
+}
+
+/* ── Footer ──────────────────────────────────────────────────────────────── */
+
+.preview-card__footer {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: var(--space-3, 0.75rem);
+  font-size: 0.7rem;
+  color: var(--muted, #8b949e);
+}
+
+.preview-card__method-icon {
+  font-size: 0.8rem;
+}
+
+.preview-card__method-text {
+  line-height: 1.2;
+}

--- a/src/components/PreviewCard.test.tsx
+++ b/src/components/PreviewCard.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { PreviewCard } from './PreviewCard';
+
+describe('PreviewCard', () => {
+  it('renders payment installment number, date, and formatted amount', () => {
+    render(
+      <PreviewCard
+        paymentNumber={1}
+        date="2026-08-15"
+        amount={250}
+        frequency="Monthly"
+        status="Upcoming"
+        id="test-preview-1"
+      />
+    );
+
+    expect(screen.getByText('Payment #1')).toBeInTheDocument();
+    expect(screen.getByText(/Aug 15, 2026/i)).toBeInTheDocument();
+    expect(screen.getByText('$250')).toBeInTheDocument();
+    expect(screen.getByText('Upcoming')).toBeInTheDocument();
+  });
+
+  it('renders estimated principal and fee breakdown correctly', () => {
+    render(
+      <PreviewCard
+        paymentNumber={2}
+        date="2026-09-15"
+        amount={100}
+        principalAmount={90}
+        feeAmount={10}
+      />
+    );
+
+    expect(screen.getByText('Principal portion')).toBeInTheDocument();
+    expect(screen.getByText('$90')).toBeInTheDocument();
+    expect(screen.getByText('Est. fees / interest')).toBeInTheDocument();
+    expect(screen.getByText('$10')).toBeInTheDocument();
+  });
+
+  it('renders cumulative total when totalAccumulated prop is provided', () => {
+    render(
+      <PreviewCard
+        paymentNumber={3}
+        date="2026-10-15"
+        amount={100}
+        totalAccumulated={300}
+        isOpenEnded={true}
+      />
+    );
+
+    expect(screen.getByText(/Cumulative total\*/i)).toBeInTheDocument();
+    expect(screen.getByText('$300')).toBeInTheDocument();
+  });
+
+  it('carries role="tooltip" and accessible labels', () => {
+    render(
+      <PreviewCard
+        paymentNumber={4}
+        date="2026-11-15"
+        amount={150}
+        id="preview-tooltip-4"
+      />
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveAttribute('id', 'preview-tooltip-4');
+    expect(tooltip).toHaveAttribute('aria-label', 'Preview card for payment #4');
+  });
+});

--- a/src/components/PreviewCard.tsx
+++ b/src/components/PreviewCard.tsx
@@ -1,0 +1,159 @@
+import { fmt, fmtDate } from '../utils/tokens';
+import './PreviewCard.css';
+
+export interface PreviewCardProps {
+  /** Sequential payment number / installment index (1-based) */
+  paymentNumber?: number;
+  /** ISO date string or formatted date for the payment */
+  date: string;
+  /** Total installment payment amount in USD */
+  amount: number;
+  /** Frequency of recurring payment */
+  frequency?: string;
+  /** Current payment status */
+  status?: 'Upcoming' | 'Scheduled' | 'Past';
+  /** Cumulative total paid after this installment */
+  totalAccumulated?: number;
+  /** Whether the schedule is open-ended */
+  isOpenEnded?: boolean;
+  /** Estimated principal portion */
+  principalAmount?: number;
+  /** Estimated fee / interest portion */
+  feeAmount?: number;
+  /** Payment source/vault description */
+  paymentMethod?: string;
+  /** Element ID for ARIA linkage (e.g. aria-describedby) */
+  id?: string;
+  /** Optional custom class name */
+  className?: string;
+}
+
+/**
+ * PreviewCard — Rich hover-triggered & keyboard-accessible preview popover.
+ *
+ * Surfaced when hovering or focusing on an AutoPay payment card or schedule row.
+ * Displays breakdown of payment installment details:
+ * - Payment date & installment index
+ * - Amount breakdown (Principal vs Fee / Interest)
+ * - Status badge (Upcoming / Scheduled / Past)
+ * - Cumulative balance projection
+ * - Payment vault source
+ *
+ * Accessibility:
+ * - Rendered with role="tooltip" and links via aria-describedby/aria-details.
+ * - Colors adhere to AA contrast rules using project CSS custom properties.
+ * - Formatted tabular numbers for accessibility and scannability.
+ */
+export function PreviewCard({
+  paymentNumber,
+  date,
+  amount,
+  frequency = 'Monthly',
+  status = 'Scheduled',
+  totalAccumulated,
+  isOpenEnded = false,
+  principalAmount,
+  feeAmount,
+  paymentMethod = 'Stellar AutoPay Vault',
+  id,
+  className = '',
+}: PreviewCardProps) {
+  // If principal and fee amounts are not explicitly passed, calculate an estimated 92%/8% split
+  const calculatedPrincipal = principalAmount ?? Math.round(amount * 0.92 * 100) / 100;
+  const calculatedFee = feeAmount ?? Math.round((amount - calculatedPrincipal) * 100) / 100;
+
+  // Calculate days remaining/relative tag if valid ISO date string
+  let daysLabel = '';
+  const parsedDate = new Date(date);
+  if (!isNaN(parsedDate.getTime())) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const target = new Date(parsedDate);
+    target.setHours(0, 0, 0, 0);
+    const diffDays = Math.round((target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 0) {
+      daysLabel = 'Due today';
+    } else if (diffDays > 0) {
+      daysLabel = `In ${diffDays} day${diffDays === 1 ? '' : 's'}`;
+    } else {
+      daysLabel = `${Math.abs(diffDays)} day${Math.abs(diffDays) === 1 ? '' : 's'} ago`;
+    }
+  }
+
+  const badgeClass =
+    status === 'Upcoming'
+      ? 'preview-card__badge--upcoming'
+      : status === 'Past'
+      ? 'preview-card__badge--past'
+      : 'preview-card__badge--scheduled';
+
+  return (
+    <div
+      id={id}
+      role="tooltip"
+      aria-label={`Preview card for payment ${paymentNumber ? '#' + paymentNumber : ''}`}
+      className={`preview-card ${className}`}
+    >
+      {/* ── Card Header ────────────────────────────────────────────────── */}
+      <div className="preview-card__header">
+        <div className="preview-card__title-group">
+          {paymentNumber && (
+            <span className="preview-card__index">Payment #{paymentNumber}</span>
+          )}
+          <span className="preview-card__date">{fmtDate(date)}</span>
+        </div>
+        <span
+          className={`preview-card__badge ${badgeClass}`}
+          aria-label={`Status: ${status}`}
+        >
+          {status}
+        </span>
+      </div>
+
+      {daysLabel && (
+        <div className="preview-card__relative-time" aria-live="off">
+          ⏱ {daysLabel}
+        </div>
+      )}
+
+      <div className="preview-card__divider" />
+
+      {/* ── Main Amount Stat ────────────────────────────────────────────── */}
+      <div className="preview-card__stat-primary">
+        <span className="preview-card__label">Total Installment</span>
+        <span className="preview-card__amount num-tabular">{fmt(amount)}</span>
+      </div>
+
+      {/* ── Breakdown grid ──────────────────────────────────────────────── */}
+      <div className="preview-card__breakdown">
+        <div className="preview-card__breakdown-row">
+          <span className="preview-card__sublabel">Principal portion</span>
+          <span className="preview-card__subval num-tabular">{fmt(calculatedPrincipal)}</span>
+        </div>
+        <div className="preview-card__breakdown-row">
+          <span className="preview-card__sublabel">Est. fees / interest</span>
+          <span className="preview-card__subval num-tabular">{fmt(calculatedFee)}</span>
+        </div>
+        {totalAccumulated !== undefined && (
+          <div className="preview-card__breakdown-row preview-card__breakdown-row--highlight">
+            <span className="preview-card__sublabel">
+              Cumulative total{isOpenEnded ? '*' : ''}
+            </span>
+            <span className="preview-card__subval num-tabular">{fmt(totalAccumulated)}</span>
+          </div>
+        )}
+      </div>
+
+      {/* ── Footer / Vault Info ─────────────────────────────────────────── */}
+      <div className="preview-card__footer">
+        <span className="preview-card__method-icon" aria-hidden="true">
+          🔒
+        </span>
+        <span className="preview-card__method-text">
+          {paymentMethod} • {frequency}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AutoPayCard.test.tsx
+++ b/src/pages/AutoPayCard.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
 import { AutoPayCard } from './AutoPayCard';
 import React from 'react';
 
@@ -25,8 +25,81 @@ describe('AutoPayCard', () => {
         startDate="2026-08-01"
       />
     );
-    // When valid, it should show schedule header or amount
     expect(screen.queryByText(/Fill in an amount and start date/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/Upcoming Payments/i)).toBeInTheDocument(); // assuming AutopaySchedule renders this
+    expect(screen.getByText(/Payment Schedule Preview/i)).toBeInTheDocument();
+  });
+
+  it('shows hover-preview card on mouse enter and hides on mouse leave', () => {
+    const handlePreviewChange = vi.fn();
+    render(
+      <AutoPayCard
+        hasValidPreview={true}
+        parsedAmount={200}
+        frequency="monthly"
+        startDate="2026-09-01"
+        onPreviewRowChange={handlePreviewChange}
+      />
+    );
+
+    const rows = screen.getAllByRole('row');
+    // First body row is index 1 (index 0 is header row)
+    const firstRow = rows[1];
+
+    expect(firstRow).toBeInTheDocument();
+    expect(firstRow).toHaveAttribute('aria-expanded', 'false');
+
+    // Trigger mouseEnter on first schedule row
+    fireEvent.mouseEnter(firstRow);
+    expect(firstRow).toHaveAttribute('aria-expanded', 'true');
+    expect(handlePreviewChange).toHaveBeenCalledWith(0);
+
+    // Trigger mouseLeave
+    fireEvent.mouseLeave(firstRow);
+    expect(firstRow).toHaveAttribute('aria-expanded', 'false');
+    expect(handlePreviewChange).toHaveBeenCalledWith(null);
+  });
+
+  it('supports keyboard navigation (focusing and Escape key dismissal)', () => {
+    render(
+      <AutoPayCard
+        hasValidPreview={true}
+        parsedAmount={100}
+        frequency="weekly"
+        startDate="2026-08-10"
+      />
+    );
+
+    const rows = screen.getAllByRole('row');
+    const firstRow = rows[1];
+
+    // Focus row
+    fireEvent.focus(firstRow);
+    expect(firstRow).toHaveAttribute('aria-expanded', 'true');
+
+    // Press Escape key to dismiss popover
+    fireEvent.keyDown(firstRow, { key: 'Escape' });
+    expect(firstRow).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('toggles preview card when pressing Enter or Space key', () => {
+    render(
+      <AutoPayCard
+        hasValidPreview={true}
+        parsedAmount={120}
+        frequency="biweekly"
+        startDate="2026-08-15"
+      />
+    );
+
+    const rows = screen.getAllByRole('row');
+    const firstRow = rows[1];
+
+    // Press Enter to activate preview card
+    fireEvent.keyDown(firstRow, { key: 'Enter' });
+    expect(firstRow).toHaveAttribute('aria-expanded', 'true');
+
+    // Press Enter again to toggle off
+    fireEvent.keyDown(firstRow, { key: 'Enter' });
+    expect(firstRow).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/src/pages/AutoPayCard.tsx
+++ b/src/pages/AutoPayCard.tsx
@@ -1,21 +1,35 @@
-import React from 'react';
 import { AutopaySchedule, type AutopayFrequency } from '../components/AutopaySchedule';
-import './AutopayPage.css'; // Or inline styles if needed
+import './AutopayPage.css';
 
 export interface AutoPayCardProps {
+  /** Whether the schedule input form has valid values to preview. */
   hasValidPreview: boolean;
+  /** Payment amount per installment in USD. */
   parsedAmount: number;
+  /** Recurrence frequency (weekly, biweekly, monthly, quarterly). */
   frequency: AutopayFrequency;
+  /** Start date string in ISO format. */
   startDate: string;
+  /** Optional end date string in ISO format. */
   endDate?: string;
+  /** Optional callback triggered when a schedule row preview card is hovered/focused. */
+  onPreviewRowChange?: (index: number | null) => void;
 }
 
+/**
+ * AutoPayCard — Container card displaying the live payment schedule preview
+ * or an informative placeholder state.
+ *
+ * Each scheduled row inside the card features an interactive hover-preview card
+ * (`PreviewCard`) that displays payment breakdown details and supports keyboard focus navigation.
+ */
 export function AutoPayCard({
   hasValidPreview,
   parsedAmount,
   frequency,
   startDate,
   endDate,
+  onPreviewRowChange,
 }: AutoPayCardProps) {
   return (
     <div
@@ -34,6 +48,7 @@ export function AutoPayCard({
           startDate={startDate}
           endDate={endDate}
           maxRows={8}
+          onPreviewRowChange={onPreviewRowChange}
         />
       ) : (
         <div

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,4 @@
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/vitest";
 import "../index.css";
 import { beforeEach, vi } from "vitest";
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+/// <reference types="@testing-library/jest-dom/vitest" />
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,9 +17,8 @@
     "noFallthroughCasesInSwitch": true,
     "baseUrl": ".",
     "paths": { "@/*": ["src/*"] },
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "@testing-library/jest-dom/vitest"]
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Closes #686

---

cloese #686 

### Resolves: AutoPay Card Hover Preview

Implemented interactive, keyboard-accessible preview popovers for scheduled payment rows:

- **`PreviewCard`**: Created a detailed popover displaying payment breakdown (principal vs. fee) and status with full ARIA/AA contrast accessibility.
- **`AutopaySchedule`**: Updated the list to support hover states and keyboard interaction (focusing rows, toggling with `Enter`/`Space`, and dismissing with `Escape`).
- **`AutoPayCard`**: Connected the schedule container to support the new preview popover states.