### PR TITLE
feat: add TransactionHistory keyboard shortcut hints

### DIFF
--- a/src/pages/TransactionHistory.css
+++ b/src/pages/TransactionHistory.css
@@ -1040,3 +1040,26 @@
         page-break-inside: avoid;
     }
 }
+
+/* Keyboard guidance for the search combobox. */
+.th-search-label-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+}
+
+.th-search-shortcuts {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+}
+
+@media (max-width: 640px) {
+    .th-search-shortcuts {
+        justify-content: flex-start;
+    }
+}

--- a/src/pages/TransactionHistory.test.tsx
+++ b/src/pages/TransactionHistory.test.tsx
@@ -286,6 +286,19 @@ describe("TransactionHistory", () => {
       expect(listbox).toHaveAttribute("role", "listbox");
     });
 
+    it("shows keyboard shortcut hints for search suggestions", () => {
+      const { container } = renderTransactionHistory();
+
+      const shortcuts = container.querySelector(
+        '[aria-label="Search keyboard shortcuts"]',
+      );
+      expect(shortcuts).toBeInTheDocument();
+      expect(shortcuts?.querySelectorAll("kbd")).toHaveLength(4);
+      expect(shortcuts).toHaveTextContent("Navigate");
+      expect(shortcuts).toHaveTextContent("Select");
+      expect(shortcuts).toHaveTextContent("Close");
+    });
+
     it("filters transactions by credit-line name", async () => {
       renderTransactionHistory();
       // Full dataset: 28 transactions

--- a/src/pages/TransactionHistory.tsx
+++ b/src/pages/TransactionHistory.tsx
@@ -17,6 +17,7 @@ import { COLOR, fmt, fmtDate, fmtDateTime } from "../utils/tokens";
 import "./TransactionHistory.css";
 import { NoActivity, NoDataGraph, NoLines } from "../components/illustrations";
 import { LiveRegion } from "../components/LiveRegion";
+import { KbdHint } from "../components/KbdHint";
 
 /**
  * TransactionHistory Page Component
@@ -1500,9 +1501,32 @@ export function TransactionHistory() {
             }
           }}
         >
-          <label htmlFor={SEARCH_INPUT_ID} className="th-filter-label">
-            Search
-          </label>
+          <div className="th-search-label-row">
+            <label htmlFor={SEARCH_INPUT_ID} className="th-filter-label">
+              Search
+            </label>
+            <div
+              className="th-search-shortcuts"
+              role="group"
+              aria-label="Search keyboard shortcuts"
+            >
+              <KbdHint
+                keys={["↑", "↓"]}
+                label="Navigate"
+                description="Use Arrow Up and Arrow Down to navigate search suggestions"
+              />
+              <KbdHint
+                keys="Enter"
+                label="Select"
+                description="Press Enter to select the active search suggestion"
+              />
+              <KbdHint
+                keys="Esc"
+                label="Close"
+                description="Press Escape to close search suggestions"
+              />
+            </div>
+          </div>
           {/* combobox wrapper — positions the floating listbox */}
           <div className="th-search-combobox">
             <input


### PR DESCRIPTION
## Summary

Adds visible keyboard shortcut guidance to the `TransactionHistory` search combobox.

The page now shows the shortcuts users can already use to navigate and dismiss search suggestions:

* `↑` / `↓` - navigate suggestions
* `Enter` - select the active suggestion
* `Esc` - close the suggestion list

Closes #630.

## Changes

* Integrated the existing reusable `KbdHint` component into `TransactionHistory`.
* Added keyboard hints beside the Search label.
* Added an accessible shortcut group labelled `Search keyboard shortcuts`.
* Added responsive layout styles so the hints wrap cleanly on smaller screens.
* Added focused page-level test coverage for the rendered shortcut guidance.

## Implementation details

The shortcut hints describe existing search-combobox behaviour; this PR does not introduce new keyboard handlers or modify the current interaction model.

The existing `KbdHint` component was reused without modification because it already provides:

* semantic `<kbd>` elements
* screen-reader descriptions
* design-token styling
* dark-mode and high-contrast compatibility
* responsive wrapping support

## Accessibility

* Uses semantic `<kbd>` elements for each displayed key.
* Groups the shortcuts with `role="group"` and an accessible label.
* Provides detailed descriptions for assistive technologies.
* Preserves the existing ARIA 1.2 combobox implementation.
* Does not alter focus handling, keyboard navigation or form behaviour.
* Maintains WCAG 2.1 AA keyboard operability.

## Responsive and visual consistency

* Uses existing spacing and colour design tokens.
* Introduces no hard-coded colours.
* Allows the shortcut row to wrap at narrow widths.
* Aligns hints to the start on mobile layouts.
* Inherits the existing dark-mode and high-contrast styles from `KbdHint`.

## Tests

Focused TransactionHistory test suite:

```text
Test Files  1 passed (1)
Tests       57 passed (57)
```

The new test verifies that:

* the accessible shortcut group is rendered
* four `<kbd>` elements are present
* Navigate, Select and Close labels are displayed

Command:

```bash
npm test -- --run src/pages/TransactionHistory.test.tsx
```

## Validation

Passed:

```bash
git diff --check
npm test -- --run src/pages/TransactionHistory.test.tsx
```

### Repository baseline limitations

The full test suite currently contains unrelated existing failures:

```text
Test Files  27 failed | 109 passed
Tests       172 failed | 1538 passed
Snapshots   3 failed
```

The failures occur in unrelated areas including `DrawCreditPage`, `RepayModal`, `WalletConnectionModal` and `NotificationBell`.

The production build is also currently blocked by 196 pre-existing TypeScript errors across the repository. The errors reported in `TransactionHistory.tsx` concern unused imports already present on `main`, not the keyboard-hint implementation.

The repository’s lint command could not be completed because ESLint is not installed in the project dependencies and no ESLint configuration file is present.

## API and visible changes

There are no API, routing, state-management or data-model changes.

The only visible change is the keyboard shortcut guidance displayed above the TransactionHistory search field.

## Files changed

* `src/pages/TransactionHistory.tsx`
* `src/pages/TransactionHistory.css`
* `src/pages/TransactionHistory.test.tsx`
