### PR TITLE
feat: show keyboard shortcut hint chip on AgingTag for primary action…

### DIFF
--- a/src/components/AgingTag.css
+++ b/src/components/AgingTag.css
@@ -15,3 +15,26 @@
   flex-shrink: 0;
   stroke-width: 5px;
 }
+
+.aging-tag__shortcut {
+  margin-left: 0.25rem;
+}
+
+.aging-tag__shortcut .kbd-hint-key {
+  min-width: 1.1rem;
+  height: 1.1rem;
+  font-size: 0.6rem;
+  padding: 0 0.2rem;
+  border-radius: 2px;
+  background-color: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.25);
+  color: inherit;
+  box-shadow: none;
+}
+
+[data-contrast="high"] .aging-tag__shortcut .kbd-hint-key {
+  background-color: var(--surface-raised, #141414);
+  border-color: var(--border, #ffffff);
+  color: var(--text, #ffffff);
+}
+

--- a/src/components/AgingTag.test.tsx
+++ b/src/components/AgingTag.test.tsx
@@ -3,11 +3,21 @@ import { describe, it, expect } from 'vitest';
 import { AgingTag } from './AgingTag';
 
 describe('AgingTag', () => {
-  it('renders correctly for a delinquent line', () => {
+  it('renders correctly for a delinquent line with default shortcut hint', () => {
     render(<AgingTag daysPastDue={15} />);
     
     // The text should be present
     expect(screen.getByText('15 days past due')).toBeInTheDocument();
+    
+    // The default shortcut hint 'R' should be present
+    expect(screen.getByText('R')).toBeInTheDocument();
+  });
+
+  it('renders correctly with a custom shortcut hint', () => {
+    render(<AgingTag daysPastDue={15} shortcutKey="P" />);
+    
+    // The custom shortcut hint 'P' should be present
+    expect(screen.getByText('P')).toBeInTheDocument();
   });
 
   it('does not render if daysPastDue is 0', () => {
@@ -36,3 +46,4 @@ describe('AgingTag', () => {
     expect(icon).toHaveAttribute('aria-hidden', 'true');
   });
 });
+

--- a/src/components/AgingTag.tsx
+++ b/src/components/AgingTag.tsx
@@ -1,5 +1,6 @@
 import { Clock } from 'lucide-react';
 import { STATUS_COLOR } from '../utils/tokens';
+import { KbdHint } from './KbdHint';
 import './AgingTag.css';
 
 interface AgingTagProps {
@@ -7,6 +8,8 @@ interface AgingTagProps {
   daysPastDue: number;
   /** Optional additional class names appended to the tag. */
   className?: string;
+  /** Optional keyboard shortcut key(s) to display. Defaults to 'R'. */
+  shortcutKey?: string | string[];
 }
 
 /**
@@ -19,7 +22,11 @@ interface AgingTagProps {
  * Accessibility: The icon is hidden from screen readers since the text
  * already explicitly states "X days past due", avoiding redundant announcements.
  */
-export function AgingTag({ daysPastDue, className = '' }: AgingTagProps) {
+export function AgingTag({
+  daysPastDue,
+  className = '',
+  shortcutKey = 'R',
+}: AgingTagProps) {
   if (daysPastDue <= 0) return null;
 
   // Use the "Defaulted" (danger) color palette for delinquent lines
@@ -34,6 +41,13 @@ export function AgingTag({ daysPastDue, className = '' }: AgingTagProps) {
     >
       <Clock size={12} className="aging-tag__icon" aria-hidden="true" />
       <span>{daysPastDue} days past due</span>
+      <KbdHint
+        keys={shortcutKey}
+        variant="inline"
+        className="aging-tag__shortcut"
+        description="Repay delinquent line"
+      />
     </span>
   );
 }
+

--- a/src/pages/CreditLines.tsx
+++ b/src/pages/CreditLines.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { StatusBadge } from '../components/StatusBadge';
+import { AgingTag } from '../components/AgingTag';
 import { RepaymentPlanChart } from '../components/RepaymentPlanChart';
 import {
   HealthFactorChart,
@@ -88,9 +89,22 @@ function CreditLineCard({
              <p className="cl-id">{line.id}</p>
            </div>
          </div>
-         <div className="flex items-center gap-2">
-           <StatusBadge status={line.status} />
-           <CreditLineRowMenu
+          <div className="flex items-center gap-2">
+            <StatusBadge status={line.status} />
+            {(() => {
+              if (line.status === 'Defaulted' || line.status === 'Suspended') {
+                const overdueEntry = line.statusHistory.find(
+                  (h) => h.status === 'Suspended' || h.status === 'Defaulted'
+                );
+                if (overdueEntry) {
+                  const diffTime = Math.abs(new Date().getTime() - new Date(overdueEntry.date).getTime());
+                  const days = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+                  return <AgingTag daysPastDue={days} />;
+                }
+              }
+              return null;
+            })()}
+            <CreditLineRowMenu
              lineId={line.id}
              lineName={line.name}
              frozen={line.status === 'Frozen'}
@@ -390,12 +404,20 @@ export default function CreditLines() {
       } else if (e.key === 'n' || e.key === 'N') {
         e.preventDefault();
         navigate('/open-credit');
+      } else if (e.key === 'r' || e.key === 'R') {
+        const delinquentLine = creditLines.find(
+          (cl) => cl.status === 'Defaulted' || cl.status === 'Suspended'
+        );
+        if (delinquentLine) {
+          e.preventDefault();
+          handleRepay(delinquentLine.id);
+        }
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [selectedLines, showCompare, navigate]);
+  }, [selectedLines, showCompare, navigate, creditLines]);
 
   return (
     <div className="credit-lines-page">


### PR DESCRIPTION
Closes #684

## Summary
Introduces a subtle keyboard shortcut hint chip (`KbdHint`) on the `AgingTag` component to visually highlight the primary action (`Repay`, mapped to the `R` key) for delinquent credit lines.

## What Changed
- **`src/components/AgingTag.tsx`**: Updated to import `KbdHint` and render it inside the tag for delinquent credit lines, defaulting to the `R` shortcut key.
- **`src/components/AgingTag.css`**: Styled the nested shortcut chip (`.aging-tag__shortcut`) to make it look subtle, visually balanced within the badge, and compatible with high-contrast/dark modes.
- **`src/pages/CreditLines.tsx`**: Imported and integrated `AgingTag` within the `CreditLineCard` rendering flow for defaulted and suspended lines, calculating days past due dynamically. Additionally, registered the keydown handler for `R` to quickly invoke the repayment flow for the delinquent credit line.
- **`src/components/AgingTag.test.tsx`**: Updated unit tests to cover default and custom shortcut hint rendering.

## Testing & Accessibility
- Checked `AgingTag` tests to verify that they are 100% passing.
- Retained full semantic HTML formatting with screen-reader accessible attributes (`aria-hidden` and `.sr-only` fallbacks) for keyboard accessibility.
```