### PR TITLE
fix: DrawCreditPage reduced-motion fallback #693

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -348,6 +348,8 @@ Inventory of CSS files with reduced motion overrides:
 - `src/components/WalletConnectionModal.css`
 - `src/components/FormField.css`
 - `src/components/LandingPage.css`
+- `src/pages/DrawCreditPage.css` — `.dc-page` scoped reset + static spinner fallback
+- `src/pages/RepayPage.css` — `.repay-page` scoped reset
 
 JS-driven animations (Framer Motion) call `useReducedMotion()` from the context and switch to instant
 state changes. The landing hero in `src/components/LandingPage.tsx` and risk gauge in `src/components/RiskGauge.tsx` are canonical examples.

--- a/docs/draw-credit-tokens.md
+++ b/docs/draw-credit-tokens.md
@@ -160,6 +160,7 @@ The table below is a full audit of every hard-coded value replaced in this PR.
 | `aria-disabled` mirrors `disabled` on action buttons | AmountInput, ConfirmationStep | 4.1.2 Name, Role, Value |
 | Credit-line list uses `<ul role="list">` / `<li>` | CreditLineSelector | 1.3.1 Info and Relationships |
 | Progress bars have `aria-label` describing the line name + percentage | CreditLineSelector, PreviewSection | 1.1.1 Non-text Content |
+| Reduced-motion: static clock icon replaces `dc-spinner-ring`; CSS kills `fadeInUp` / `dc-spin` under `prefers-reduced-motion` and `[data-motion="reduced"]` | DrawCreditPage + `DrawCreditPage.css` | 2.3.3 Animation from Interactions |
 
 ---
 

--- a/src/pages/DrawCreditPage.css
+++ b/src/pages/DrawCreditPage.css
@@ -1,0 +1,95 @@
+/**
+ * DrawCreditPage reduced-motion fallback (GrantFox FWC26 / issue #693)
+ *
+ * Suppresses transitions and animations when the user has
+ * `prefers-reduced-motion: reduce` active via their OS, or when the in-app
+ * ReducedMotionContext override (`data-motion="reduced"` on <html>) is set.
+ *
+ * Covers:
+ *  - `.dc-page__card` entrance animation (fadeInUp)
+ *  - `.dc-spinner-ring` rotation animation (dc-spin, infinite)
+ *  - `.dc-credit-line-item` hover transitions
+ *  - `.dc-btn` and `.dc-preset-btn` hover transitions
+ *  - `.dc-progress-bar` width transition
+ *  - `.dc-terms-label` background transition
+ *  - `.dc-chevron` colour transition
+ *
+ * The JS layer (DrawCreditPage.tsx) reads `isReducedMotionActive` from
+ * `useReducedMotion()` and swaps the animated spinner for a static icon,
+ * ensuring there is a meaningful static fallback rather than a frozen frame
+ * of an interrupted rotation.
+ */
+
+/* ── OS-level detection ───────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .dc-page *,
+  .dc-page *::before,
+  .dc-page *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ── In-app override via ReducedMotionContext (data-motion="reduced") ─────── */
+
+[data-motion="reduced"] .dc-page *,
+[data-motion="reduced"] .dc-page *::before,
+[data-motion="reduced"] .dc-page *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}
+
+/* ── Spinner: explicit no-animation belt-and-suspenders ──────────────────── */
+/*
+ * The dc-spin keyframe is an infinite rotation — even a 0.01 ms duration
+ * would leave the ring frozen at an arbitrary rotation angle, looking broken.
+ * Remove the animation entirely so the ring is simply hidden in favour of the
+ * JS-rendered static icon (dc-spinner-static, see DrawCreditPage.tsx).
+ */
+
+@media (prefers-reduced-motion: reduce) {
+  .dc-page .dc-spinner-ring {
+    animation: none !important;
+  }
+}
+
+[data-motion="reduced"] .dc-page .dc-spinner-ring {
+  animation: none !important;
+}
+
+/* ── Card entrance: collapse to no-op ────────────────────────────────────── */
+/*
+ * fadeInUp on .dc-page__card involves a transform (translateY) and an
+ * opacity change. Under reduced motion, skip directly to the final state.
+ */
+
+@media (prefers-reduced-motion: reduce) {
+  .dc-page .dc-page__card {
+    animation: none !important;
+  }
+}
+
+[data-motion="reduced"] .dc-page .dc-page__card {
+  animation: none !important;
+}
+
+/* ── Static processing indicator (replaces spinner under reduced motion) ──── */
+/*
+ * `.dc-spinner-static` is rendered by DrawCreditPage.tsx when
+ * `isReducedMotionActive` is true. It shows a pulseless icon at the same
+ * size as the spinner ring so the layout remains stable.
+ */
+
+.dc-spinner-static {
+  width: 4rem;
+  height: 4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+}

--- a/src/pages/DrawCreditPage.reduced-motion.test.tsx
+++ b/src/pages/DrawCreditPage.reduced-motion.test.tsx
@@ -1,0 +1,397 @@
+/**
+ * DrawCreditPage reduced-motion tests (GrantFox FWC26 / issue #693)
+ *
+ * Covers:
+ *  1. Root <main> has the `dc-page` class so CSS rules can target it.
+ *  2. When OS prefers-reduced-motion is active, the loading state renders a
+ *     static icon (dc-spinner-static) instead of the animated spinner ring.
+ *  3. When OS prefers-reduced-motion is NOT active, the animated spinner ring
+ *     is rendered during loading.
+ *  4. When the in-app ReducedMotionContext override is "reduced", the static
+ *     icon is rendered regardless of the OS setting.
+ *  5. The static icon is accessible: it is aria-hidden (described by the
+ *     parent role="status" aria-label).
+ *  6. The role="status" region and aria-live="polite" are present in both
+ *     motion modes.
+ *  7. DrawCreditPage.css contains @media (prefers-reduced-motion: reduce)
+ *     rules scoped to .dc-page.
+ *  8. DrawCreditPage.css contains [data-motion="reduced"] rules scoped to
+ *     .dc-page.
+ *  9. DrawCreditPage.css contains an explicit `animation: none` override for
+ *     .dc-spinner-ring under reduced-motion.
+ * 10. DrawCreditPage.css contains an explicit `animation: none` override for
+ *     .dc-page__card under reduced-motion.
+ * 11. Live OS preference change: toggling matchMedia fires a re-render that
+ *     swaps spinner ↔ static icon correctly.
+ */
+
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import DrawCreditPage from './DrawCreditPage';
+import { ReducedMotionProvider } from '../context/ReducedMotionContext';
+import * as ReducedMotionContext from '../context/ReducedMotionContext';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+//
+// ConfirmationStep has incomplete local pricing bindings in some upstream
+// revisions. Mock it with a minimal stand-in so tests can reach the loading
+// state without depending on that component's internals.
+
+vi.mock('@/components/ConfirmationStep', () => ({
+  ConfirmationStep: ({
+    onConfirm,
+    isLoading,
+  }: {
+    onConfirm: () => void;
+    isLoading: boolean;
+    onBack: () => void;
+  }) => (
+    <div>
+      <h2>Review &amp; Confirm</h2>
+      <input type="checkbox" aria-label="I agree to the terms" />
+      <button
+        type="button"
+        onClick={onConfirm}
+        disabled={isLoading}
+        aria-label="Confirm Draw"
+      >
+        {isLoading ? 'Processing…' : 'Confirm Draw'}
+      </button>
+    </div>
+  ),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Stub window.matchMedia so `(prefers-reduced-motion: reduce)` returns the
+ * given value.  Returns a teardown function to restore the original.
+ */
+function stubMatchMedia(matches: boolean) {
+  const original = window.matchMedia;
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)' ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+  return () => {
+    Object.defineProperty(window, 'matchMedia', { writable: true, value: original });
+  };
+}
+
+/**
+ * Stub matchMedia so we can fire change events to test live preference changes.
+ * Returns both the teardown and a `fireChange` helper.
+ */
+function stubMatchMediaWithListener(initialMatches: boolean) {
+  const listeners: Array<(e: MediaQueryListEvent) => void> = [];
+  const original = window.matchMedia;
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)' ? initialMatches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn((_event: string, cb: (e: MediaQueryListEvent) => void) => {
+        if (query === '(prefers-reduced-motion: reduce)') listeners.push(cb);
+      }),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+  return {
+    restore: () => {
+      Object.defineProperty(window, 'matchMedia', { writable: true, value: original });
+    },
+    fireChange: (newMatches: boolean) => {
+      listeners.forEach((cb) => cb({ matches: newMatches } as MediaQueryListEvent));
+    },
+  };
+}
+
+/** Navigate the wizard to the confirm step. */
+async function navigateToConfirmStep(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(
+    screen.getByRole('button', { name: /select business line of credit/i }),
+  );
+  await user.type(screen.getByRole('spinbutton'), '500');
+  await user.click(screen.getByRole('button', { name: /continue/i }));
+}
+
+/**
+ * Click "Confirm Draw" so handleConfirm sets isLoading + step="status"
+ * and the processing indicator renders.
+ */
+function triggerLoadingState() {
+  const confirmBtn = screen.getByRole('button', { name: /confirm draw/i });
+  fireEvent.click(confirmBtn);
+}
+
+/** Render the page inside the necessary providers. */
+function renderPage() {
+  const user = userEvent.setup({ delay: null });
+  render(
+    <ReducedMotionProvider>
+      <MemoryRouter>
+        <DrawCreditPage />
+      </MemoryRouter>
+    </ReducedMotionProvider>,
+  );
+  return { user };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('DrawCreditPage reduced-motion — container', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.documentElement.removeAttribute('data-motion');
+    localStorage.removeItem('grantfox_draw_wizard_draft');
+    localStorage.removeItem('creditra-motion-override');
+  });
+
+  // 1
+  it('root <main> has dc-page class for CSS targeting', () => {
+    const restore = stubMatchMedia(false);
+    renderPage();
+    expect(document.querySelector('main.dc-page')).toBeInTheDocument();
+    restore();
+  });
+});
+
+describe('DrawCreditPage reduced-motion — spinner fallback', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.documentElement.removeAttribute('data-motion');
+    localStorage.removeItem('grantfox_draw_wizard_draft');
+    localStorage.removeItem('creditra-motion-override');
+    vi.useRealTimers();
+  });
+
+  // 2
+  it('renders static icon when OS prefers-reduced-motion is active', async () => {
+    const restore = stubMatchMedia(true);
+    const { user } = renderPage();
+
+    await navigateToConfirmStep(user);
+    triggerLoadingState();
+
+    expect(document.querySelector('.dc-spinner-static')).toBeInTheDocument();
+    expect(document.querySelector('.dc-spinner-ring')).not.toBeInTheDocument();
+    restore();
+  });
+
+  // 3
+  it('renders animated spinner ring when OS prefers-reduced-motion is inactive', async () => {
+    const restore = stubMatchMedia(false);
+    const { user } = renderPage();
+
+    await navigateToConfirmStep(user);
+    triggerLoadingState();
+
+    expect(document.querySelector('.dc-spinner-ring')).toBeInTheDocument();
+    expect(document.querySelector('.dc-spinner-static')).not.toBeInTheDocument();
+    restore();
+  });
+
+  // 4
+  it('renders static icon when in-app ReducedMotionContext override is reduced', async () => {
+    const restore = stubMatchMedia(false);
+    const spy = vi.spyOn(ReducedMotionContext, 'useReducedMotion').mockReturnValue({
+      motionOverride: 'reduced',
+      toggleMotionOverride: () => {},
+      setMotionOverride: () => {},
+      isReducedMotionActive: true,
+    });
+    const { user } = renderPage();
+
+    await navigateToConfirmStep(user);
+    triggerLoadingState();
+
+    expect(document.querySelector('.dc-spinner-static')).toBeInTheDocument();
+    expect(document.querySelector('.dc-spinner-ring')).not.toBeInTheDocument();
+    spy.mockRestore();
+    restore();
+  });
+
+  // 5
+  it('static icon is aria-hidden (status region carries the accessible name)', async () => {
+    const restore = stubMatchMedia(true);
+    const { user } = renderPage();
+
+    await navigateToConfirmStep(user);
+    triggerLoadingState();
+
+    const icon = document.querySelector('.dc-spinner-static');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+    restore();
+  });
+});
+
+describe('DrawCreditPage reduced-motion — status region a11y', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.documentElement.removeAttribute('data-motion');
+    localStorage.removeItem('grantfox_draw_wizard_draft');
+    localStorage.removeItem('creditra-motion-override');
+  });
+
+  // 6a
+  it('role=status region is present under reduced motion', async () => {
+    const restore = stubMatchMedia(true);
+    const { user } = renderPage();
+
+    await navigateToConfirmStep(user);
+    triggerLoadingState();
+
+    const region = screen.getByRole('status', {
+      name: /processing your draw request/i,
+    });
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    restore();
+  });
+
+  // 6b
+  it('role=status region is present when motion is normal', async () => {
+    const restore = stubMatchMedia(false);
+    const { user } = renderPage();
+
+    await navigateToConfirmStep(user);
+    triggerLoadingState();
+
+    const region = screen.getByRole('status', {
+      name: /processing your draw request/i,
+    });
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    restore();
+  });
+});
+
+describe('DrawCreditPage reduced-motion — live OS preference change', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.documentElement.removeAttribute('data-motion');
+    localStorage.removeItem('grantfox_draw_wizard_draft');
+    localStorage.removeItem('creditra-motion-override');
+  });
+
+  // 11
+  it('swaps spinner ↔ static icon when the OS media query fires a change event', async () => {
+    const { restore, fireChange } = stubMatchMediaWithListener(false);
+    const { user } = renderPage();
+
+    await navigateToConfirmStep(user);
+    triggerLoadingState();
+
+    expect(document.querySelector('.dc-spinner-ring')).toBeInTheDocument();
+    expect(document.querySelector('.dc-spinner-static')).not.toBeInTheDocument();
+
+    act(() => {
+      fireChange(true);
+    });
+
+    expect(document.querySelector('.dc-spinner-static')).toBeInTheDocument();
+    expect(document.querySelector('.dc-spinner-ring')).not.toBeInTheDocument();
+
+    restore();
+  });
+});
+
+// ── CSS source assertions ─────────────────────────────────────────────────────
+//
+// jsdom does not compute CSS from stylesheets, so we assert directly against
+// the stylesheet source. This mirrors the pattern used in RiskGauge.test.tsx,
+// Dashboard.reduced-motion.test.tsx, and RepayPage.reduced-motion.test.tsx.
+
+describe('DrawCreditPage.css — prefers-reduced-motion rules', () => {
+  const cssPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'DrawCreditPage.css',
+  );
+  const css = readFileSync(cssPath, 'utf-8');
+
+  // 7
+  it('contains @media (prefers-reduced-motion: reduce) block targeting .dc-page', () => {
+    expect(css).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[^}]*\.dc-page/m,
+    );
+  });
+
+  it('OS-level block disables animation-duration on .dc-page descendants', () => {
+    expect(css).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)[^}]*animation-duration:\s*0\.01ms.*!important/m,
+    );
+  });
+
+  it('OS-level block disables transition-duration on .dc-page descendants', () => {
+    expect(css).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)[^}]*transition-duration:\s*0\.01ms.*!important/m,
+    );
+  });
+
+  it('OS-level block sets scroll-behavior to auto', () => {
+    expect(css).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)[^}]*scroll-behavior:\s*auto.*!important/m,
+    );
+  });
+
+  // 8
+  it('contains [data-motion="reduced"] block targeting .dc-page', () => {
+    expect(css).toMatch(
+      /\[data-motion=["']reduced["']\]\s*\.dc-page\s*\*/m,
+    );
+  });
+
+  it('[data-motion="reduced"] block disables animation-duration on .dc-page descendants', () => {
+    expect(css).toMatch(
+      /\[data-motion=["']reduced["']\][^}]*animation-duration:\s*0\.01ms.*!important/m,
+    );
+  });
+
+  it('[data-motion="reduced"] block disables transition-duration on .dc-page descendants', () => {
+    expect(css).toMatch(
+      /\[data-motion=["']reduced["']\][^}]*transition-duration:\s*0\.01ms.*!important/m,
+    );
+  });
+
+  // 9
+  it('has explicit animation: none for .dc-spinner-ring under prefers-reduced-motion: reduce', () => {
+    expect(css).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)[^}]*\.dc-page\s*\.dc-spinner-ring[^}]*animation:\s*none/m,
+    );
+  });
+
+  it('has explicit animation: none for .dc-spinner-ring under [data-motion="reduced"]', () => {
+    expect(css).toMatch(
+      /\[data-motion=["']reduced["']\]\s*\.dc-page\s*\.dc-spinner-ring[^}]*animation:\s*none/m,
+    );
+  });
+
+  // 10
+  it('has explicit animation: none for .dc-page__card under prefers-reduced-motion: reduce', () => {
+    expect(css).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)[^}]*\.dc-page\s*\.dc-page__card[^}]*animation:\s*none/m,
+    );
+  });
+
+  it('has explicit animation: none for .dc-page__card under [data-motion="reduced"]', () => {
+    expect(css).toMatch(
+      /\[data-motion=["']reduced["']\]\s*\.dc-page\s*\.dc-page__card[^}]*animation:\s*none/m,
+    );
+  });
+});

--- a/src/pages/DrawCreditPage.tsx
+++ b/src/pages/DrawCreditPage.tsx
@@ -15,6 +15,14 @@
  *   - <main> labelled with aria-label for screen-reader landmark navigation
  *   - Loading state wrapped in role="status" + aria-live="polite"
  *   - Spinner has aria-label describing the in-progress action
+ *
+ * Reduced-motion strategy (GrantFox FWC26 / issue #693):
+ *   - DrawCreditPage.css suppresses all animations and transitions on
+ *     `.dc-page` descendants via @media (prefers-reduced-motion: reduce)
+ *     and the in-app [data-motion="reduced"] attribute override.
+ *   - The animated `dc-spinner-ring` is replaced with a static SVG icon
+ *     (dc-spinner-static) when `isReducedMotionActive` is true, giving
+ *     a meaningful visual fallback rather than a frozen rotation frame.
  */
 
 import { useRef, useState, useEffect } from "react";
@@ -34,7 +42,9 @@ import { DrawingLimit } from "@/components/DrawingLimit";
 import { DrawSummaryBar } from "@/components/DrawSummaryBar";
 import { DrawWizardMicroIndicator } from "@/components/DrawWizardMicroIndicator";
 import { useDrawWizardMicroProgress } from "@/hooks/useDrawWizardMicroProgress";
+import { useReducedMotion } from "@/context/ReducedMotionContext";
 import "@/components/DrawWizardMicroProgress.css";
+import "./DrawCreditPage.css";
 
 const drawSteps = [
   { id: "select", label: "Select line" },
@@ -84,6 +94,8 @@ export default function DrawCreditPage() {
       isOnConfirmStep: step === "confirm",
     });
 
+  const { isReducedMotionActive } = useReducedMotion();
+
   const handleSelectCreditLine = (creditLine: CreditLine) => {
     setSelectedCreditLine(creditLine);
     setAmount(0);
@@ -97,7 +109,11 @@ export default function DrawCreditPage() {
   };
 
   const handleConfirm = async () => {
+    // Move to the status step immediately so the loading indicator
+    // (animated spinner or static reduced-motion fallback) is visible
+    // while the request is in flight.
     setIsLoading(true);
+    setStep("status");
 
     // Simulate API call
     await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -209,8 +225,15 @@ export default function DrawCreditPage() {
                 /*
                  * role="status" + aria-live="polite" announce the loading state
                  * to screen readers without interrupting the user.
-                 * aria-label on the spinner ring itself provides a text
-                 * alternative for the animated element.
+                 *
+                 * Reduced-motion strategy:
+                 *   When isReducedMotionActive is true, the animated
+                 *   dc-spinner-ring is replaced with a static SVG clock icon.
+                 *   This gives a meaningful visual cue without triggering
+                 *   vestibular discomfort from continuous rotation.
+                 *   DrawCreditPage.css additionally suppresses the dc-spin
+                 *   keyframe via @media (prefers-reduced-motion: reduce) and
+                 *   [data-motion="reduced"] as a belt-and-suspenders fallback.
                  */
                 <div
                   className="dc-spinner-wrap"
@@ -219,10 +242,55 @@ export default function DrawCreditPage() {
                   aria-label="Processing your draw request"
                 >
                   <div className="dc-spinner-ring-bg">
-                    <div
-                      className="dc-spinner-ring"
-                      aria-hidden="true"
-                    />
+                    {isReducedMotionActive ? (
+                      /*
+                       * Static fallback: a simple clock SVG at the same 4rem
+                       * size as the spinner ring, using the accent colour
+                       * token. No animation.
+                       */
+                      <div className="dc-spinner-static" aria-hidden="true">
+                        <svg
+                          viewBox="0 0 64 64"
+                          fill="none"
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="64"
+                          height="64"
+                          aria-hidden="true"
+                        >
+                          <circle
+                            cx="32"
+                            cy="32"
+                            r="28"
+                            stroke="currentColor"
+                            strokeWidth="4"
+                            strokeLinecap="round"
+                          />
+                          <line
+                            x1="32"
+                            y1="32"
+                            x2="32"
+                            y2="14"
+                            stroke="currentColor"
+                            strokeWidth="4"
+                            strokeLinecap="round"
+                          />
+                          <line
+                            x1="32"
+                            y1="32"
+                            x2="46"
+                            y2="32"
+                            stroke="currentColor"
+                            strokeWidth="4"
+                            strokeLinecap="round"
+                          />
+                        </svg>
+                      </div>
+                    ) : (
+                      <div
+                        className="dc-spinner-ring"
+                        aria-hidden="true"
+                      />
+                    )}
                   </div>
                   <div>
                     <h2 className="dc-step__title">Processing</h2>


### PR DESCRIPTION
## Overview

This PR adds a **reduced-motion fallback** for `DrawCreditPage` animations so users with `prefers-reduced-motion: reduce` (or the in-app `[data-motion="reduced"]` override) get a static processing state instead of continuous spinner / entrance motion.

## Related Issue

Closes #693

## Changes

### ♿️ Reduced-motion fallback

* **[ADD]** `src/pages/DrawCreditPage.css`
  * Scoped `@media (prefers-reduced-motion: reduce)` and `[data-motion="reduced"]` resets for `.dc-page` descendants.
  * Explicit `animation: none` for `.dc-spinner-ring` and `.dc-page__card`.
  * Styles for the static `.dc-spinner-static` processing indicator.

* **[MODIFY]** `src/pages/DrawCreditPage.tsx`
  * Wires `useReducedMotion()` and swaps the animated spinner for a static clock SVG when reduced motion is active.
  * Advances to the `status` step immediately on confirm so the loading indicator (animated or static) is visible during the request.

* **[ADD]** `src/pages/DrawCreditPage.reduced-motion.test.tsx`
  * 19 focused tests covering OS preference, in-app override, live media-query changes, status-region a11y, and CSS source assertions.

* **[MODIFY]** Docs
  * `docs/ACCESSIBILITY.md` — inventory entry for `DrawCreditPage.css`.
  * `docs/draw-credit-tokens.md` — WCAG note for the reduced-motion spinner fallback.

## Verification Results

```
pnpm exec vitest run --no-file-parallelism --poolOptions.forks.singleFork src/pages/DrawCreditPage.reduced-motion.test.tsx
✅ 19/19 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Static fallback when `prefers-reduced-motion: reduce` is set | ✅ Animated `dc-spinner-ring` replaced by static clock icon |
| In-app `[data-motion="reduced"]` override also disables motion | ✅ CSS + `useReducedMotion()` path covered |
| Card entrance / spinner keyframes suppressed | ✅ Explicit `animation: none` in `DrawCreditPage.css` |
| Focused tests added and passing | ✅ 19/19 reduced-motion tests |
| Docs updated for visible/a11y change | ✅ `ACCESSIBILITY.md` + `draw-credit-tokens.md` |