### PR TITLE
feat: RepaymentVisualizer skeleton (#609)

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -273,6 +273,9 @@ The `KbdHint` component (`src/components/KbdHint.tsx`) provides standardized vis
   chart, schedule disclosure, and row-expansion control. The class uses shared
   focus tokens and `:focus-visible`, so keyboard users receive a consistent
   outline without adding a focus ring on pointer clicks.
+- `RepaymentVisualizer` first-paint loading (issue #609) uses
+  `RepaymentVisualizerSkeleton` with `role="status"` / `aria-busy="true"` so
+  assistive technology hears the loading state before the chart commits.
 - Active nav links keep focus styling distinct from active styling (see the comment block
   around `.header-nav-link.active` in `src/index.css`).
 - Modal close returns focus to the trigger via `useFocusTrap`'s `triggerRef`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -191,7 +191,7 @@ stateDiagram-v2
 
 | State | Visual | Component |
 | --- | --- | --- |
-| Loading | Shimmer matching the final layout | `components/Skeleton.tsx` (`Skeleton.css` animation, `prefers-reduced-motion` disables shimmer). `TransactionHistory` uses the page-level `components/TransactionHistorySkeleton.tsx` wrapper which composes `Skeleton` into a full stats + filter + table placeholder. |
+| Loading | Shimmer matching the final layout | `components/Skeleton.tsx` (`Skeleton.css` animation, `prefers-reduced-motion` disables shimmer). `TransactionHistory` uses the page-level `components/TransactionHistorySkeleton.tsx` wrapper which composes `Skeleton` into a full stats + filter + table placeholder. `RepaymentVisualizer` uses `RepaymentVisualizerSkeleton` (issue #609) for a one-frame first-paint gate that mirrors the chart card geometry. |
 | Empty | Illustration + primary CTA to populate | inline per page (e.g. Dashboard's "no credit lines" state) |
 | Error | Banner + retry, or full-page `ErrorBoundary` if render-time | `components/ErrorBoundary.tsx` for render errors, `BannerAlert` for fetch errors |
 | Ready | Real data | the screen |

--- a/docs/REPAYMENT_VISUALIZER_SKELETON.md
+++ b/docs/REPAYMENT_VISUALIZER_SKELETON.md
@@ -1,0 +1,63 @@
+# RepaymentVisualizer — First-Paint Loading Skeleton
+
+Themed shimmer placeholder shown on the first paint of `RepaymentVisualizer`
+while the repayment schedule chart is preparing to commit.
+
+---
+
+## Why this exists
+
+Without a skeleton, the chart card can pop in after layout work, causing a
+visible jump (CLS). The skeleton occupies the same card geometry — header row,
+220px chart plane, legend row — so the transition to real content is stable.
+
+---
+
+## Components involved
+
+| File | Role |
+|---|---|
+| `src/components/RepaymentVisualizer.tsx` | Hosts `RepaymentVisualizerSkeleton` and the `loading` / first-paint gate. |
+| `src/components/Skeleton.tsx` | Shared shimmer primitive (tokens + reduced-motion). |
+| `src/pages/RepaymentVisualizer.tsx` | Re-exports component + skeleton for the route module path. |
+
+---
+
+## How the loading state works
+
+```ts
+// loading omitted → one-frame first-paint skeleton
+const [bootstrapping, setBootstrapping] = useState(true);
+useEffect(() => {
+  const id = setTimeout(() => setBootstrapping(false), 0);
+  return () => clearTimeout(id);
+}, [principal, apr, monthlyPayment]);
+
+if (loading === true || bootstrapping) {
+  return <RepaymentVisualizerSkeleton />;
+}
+```
+
+| `loading` prop | Behavior |
+|---|---|
+| omitted | First-paint skeleton for one macrotask, then chart |
+| `true` | Skeleton stays until the prop flips |
+| `false` | Skip skeleton (preferred in sync unit tests) |
+
+---
+
+## Accessibility
+
+- Wrapper: `role="status"`, `aria-busy="true"`,
+  `aria-label="Loading repayment plan visualizer"` (WCAG 2.1 AA — SC 4.1.3).
+- Placeholder shapes are `aria-hidden` so assistive tech does not narrate them.
+- Shimmer respects `prefers-reduced-motion` / `[data-motion="reduced"]` via
+  `Skeleton.css`.
+
+---
+
+## Tests
+
+| File | Coverage |
+|---|---|
+| `src/components/__tests__/RepaymentVisualizer.skeleton.test.tsx` | Skeleton a11y, shape parity, `loading` prop, first-paint timer |

--- a/src/components/RepaymentVisualizer.tsx
+++ b/src/components/RepaymentVisualizer.tsx
@@ -25,13 +25,14 @@
  * it without needing JS class manipulation on every child element.
  */
 
-import React, { useState, useRef, useCallback, useId, useMemo } from 'react';
+import React, { useState, useRef, useCallback, useId, useMemo, useEffect } from 'react';
 import { COLOR } from '@/utils/tokens';
 import { KbdHint } from './KbdHint';
 import { LiveRegion } from './LiveRegion';
 import { useReducedMotion } from '@/context/ReducedMotionContext';
 import { EmptyState } from './EmptyState';
 import { NoDataGraph } from './illustrations';
+import { Skeleton } from './Skeleton';
 import './RepaymentVisualizer.css';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -80,6 +81,15 @@ export interface RepaymentVisualizerProps {
    * Example: "Home improvement loan — 48 months · $4,230 total interest"
    */
   caption?: string;
+  /**
+   * Loading / first-paint control (FWC26 / issue #609).
+   *
+   * - `true`  — always show the themed skeleton
+   * - `false` — skip the first-paint skeleton (useful in unit tests)
+   * - omitted — show a one-frame first-paint skeleton via `setTimeout(0)` so
+   *   the chart layout does not pop in before the browser paints placeholders
+   */
+  loading?: boolean;
 }
 
 // ─── Schedule generator ────────────────────────────────────────────────────────
@@ -594,6 +604,51 @@ function EmptyStatePrompt() {
   );
 }
 
+// ─── First-paint skeleton (FWC26 / issue #609) ─────────────────────────────────
+
+/**
+ * Themed shimmer matching the final RepaymentVisualizer card geometry so
+ * first paint does not jump when the schedule chart commits (CLS ≈ 0).
+ *
+ * Shape parity:
+ *  - Card shell uses `--surface` / `--border` / `--radius-lg`
+ *  - Chart placeholder height matches the SVG viewBox height (`H = 220`)
+ *  - Header / meta / legend rows mirror the loaded layout spacing
+ */
+export function RepaymentVisualizerSkeleton() {
+  return (
+    <section
+      className="p-4 sm:p-5 md:p-6 rv-skeleton"
+      role="status"
+      aria-busy="true"
+      aria-label="Loading repayment plan visualizer"
+      data-testid="repayment-visualizer-skeleton"
+      style={{
+        background: `var(--surface, ${COLOR.surface})`,
+        border: `1px solid var(--border, ${COLOR.border})`,
+        borderRadius: 'var(--radius-lg)',
+      }}
+    >
+      <div aria-hidden="true" className="mb-4 sm:mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-4">
+        <Skeleton width={140} height={20} shape="rounded" />
+        <Skeleton width={160} height={14} shape="rounded" />
+      </div>
+      <Skeleton
+        width="100%"
+        height={220}
+        shape="rounded"
+        className="rv-skeleton__chart"
+        aria-hidden={true}
+      />
+      <div aria-hidden="true" className="mt-3 sm:mt-4 flex flex-wrap items-center justify-between gap-3">
+        <Skeleton width={180} height={12} shape="rounded" />
+        <Skeleton width={120} height={12} shape="rounded" />
+      </div>
+      <Skeleton width={110} height={14} shape="rounded" className="mt-4" aria-hidden={true} />
+    </section>
+  );
+}
+
 // ─── Main component ────────────────────────────────────────────────────────────
 
 /**
@@ -605,6 +660,11 @@ function EmptyStatePrompt() {
  * ───────────────────
  * `chartAriaLabel` — overrides the default `aria-label` on the SVG element.
  * `caption` — overrides the auto-generated `<caption>` in the SR-only table.
+ *
+ * Loading / first paint (FWC26 / issue #609)
+ * ──────────────────────────────────────────
+ * When `loading` is omitted, a one-frame themed skeleton paints first so the
+ * chart does not pop in. Pass `loading={false}` to skip that gate (tests).
  *
  * Reduced-motion
  * ──────────────
@@ -619,16 +679,35 @@ export function RepaymentVisualizer({
   maxMonths = 360,
   chartAriaLabel,
   caption,
+  loading,
 }: RepaymentVisualizerProps) {
   const [tooltip, setTooltip] = useState<TooltipData | null>(null);
   const tooltipId = useId();
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [bootstrapping, setBootstrapping] = useState(() => loading !== false);
+
+  // First-paint / controlled loading gate — yields one frame for the skeleton.
+  useEffect(() => {
+    if (loading === true) {
+      setBootstrapping(true);
+      return;
+    }
+    if (loading === false) {
+      setBootstrapping(false);
+      return;
+    }
+    const id = setTimeout(() => setBootstrapping(false), 0);
+    return () => clearTimeout(id);
+  }, [loading, principal, apr, monthlyPayment]);
 
   // Detect reduced-motion preference from OS or in-app override.
   // When true, the chart renders statically (no CSS animations).
   const { isReducedMotionActive } = useReducedMotion();
 
-  const schedule = buildSchedule(principal, apr, monthlyPayment, maxMonths);
+  const schedule = useMemo(
+    () => buildSchedule(principal, apr, monthlyPayment, maxMonths),
+    [principal, apr, monthlyPayment, maxMonths],
+  );
 
   // Long-press for mobile tooltip
   const handleTouchStart = useCallback(
@@ -687,6 +766,10 @@ export function RepaymentVisualizer({
 
     return `Repayment plan: ${termMonths} month${termMonths !== 1 ? 's' : ''}, ${interestFmt} total interest.`;
   }, [schedule, tooltip, termMonths, totalInterest]);
+
+  if (loading === true || bootstrapping) {
+    return <RepaymentVisualizerSkeleton />;
+  }
 
   return (
     <section

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -61,6 +61,11 @@ type SkeletonProps = React.HTMLAttributes<HTMLDivElement> & {
  * element and first-paint does not jump when real content arrives.
  * Use `shape="circular"` only for avatar / icon-sized placeholders (≤ 48 px).
  *
+ * ## Composed page skeletons
+ * Higher-level first-paint layouts compose this primitive — e.g.
+ * `RepaymentVisualizerSkeleton` in `RepaymentVisualizer.tsx` (issue #609)
+ * mirrors the chart card height (220px) and header/legend rows.
+ *
  * ## Motion
  * The shimmer animation is suppressed under both
  * `@media (prefers-reduced-motion: reduce)` and `[data-motion="reduced"]`

--- a/src/components/__tests__/RepaymentVisualizer.skeleton.test.tsx
+++ b/src/components/__tests__/RepaymentVisualizer.skeleton.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * RepaymentVisualizer first-paint skeleton (GrantFox FWC26 / issue #609)
+ *
+ * Covers:
+ *  - Controlled `loading` prop shows themed skeleton with a11y attributes
+ *  - Chart / schedule content is absent while loading
+ *  - First-paint bootstrap (loading omitted) paints skeleton then content
+ *  - Skeleton composes the shared `Skeleton` primitive (shape parity)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import {
+  RepaymentVisualizer,
+  RepaymentVisualizerSkeleton,
+} from '../RepaymentVisualizer';
+import * as ReducedMotionContext from '../../context/ReducedMotionContext';
+
+vi.spyOn(ReducedMotionContext, 'useReducedMotion').mockReturnValue({
+  motionOverride: 'system',
+  toggleMotionOverride: vi.fn(),
+  setMotionOverride: vi.fn(),
+  isReducedMotionActive: false,
+});
+
+const BASE = {
+  principal: 50_000,
+  apr: 7.5,
+  monthlyPayment: 1_500,
+};
+
+describe('RepaymentVisualizerSkeleton', () => {
+  it('announces loading with role=status, aria-busy, and accessible name', () => {
+    render(<RepaymentVisualizerSkeleton />);
+    const region = screen.getByRole('status', {
+      name: /loading repayment plan visualizer/i,
+    });
+    expect(region).toHaveAttribute('aria-busy', 'true');
+    expect(region).toHaveAttribute(
+      'data-testid',
+      'repayment-visualizer-skeleton',
+    );
+  });
+
+  it('renders themed Skeleton placeholders including a 220px chart block', () => {
+    const { container } = render(<RepaymentVisualizerSkeleton />);
+    const skeletons = container.querySelectorAll('.skeleton');
+    expect(skeletons.length).toBeGreaterThanOrEqual(4);
+    const chart = container.querySelector('.rv-skeleton__chart') as HTMLElement;
+    expect(chart).toBeInTheDocument();
+    expect(chart.style.height).toBe('220px');
+  });
+});
+
+describe('RepaymentVisualizer — loading / first-paint (issue #609)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows the skeleton when loading={true} and hides the chart', () => {
+    const { container } = render(
+      <RepaymentVisualizer {...BASE} loading={true} />,
+    );
+
+    expect(
+      screen.getByRole('status', {
+        name: /loading repayment plan visualizer/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Repayment Plan')).not.toBeInTheDocument();
+    expect(container.querySelector('svg[role="img"]')).not.toBeInTheDocument();
+  });
+
+  it('skips the skeleton when loading={false}', () => {
+    render(<RepaymentVisualizer {...BASE} loading={false} />);
+    expect(screen.getByText('Repayment Plan')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('repayment-visualizer-skeleton'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('paints the skeleton on first mount, then the chart after the bootstrap timer', () => {
+    const { container } = render(<RepaymentVisualizer {...BASE} />);
+
+    expect(
+      screen.getByTestId('repayment-visualizer-skeleton'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Repayment Plan')).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+
+    expect(
+      screen.queryByTestId('repayment-visualizer-skeleton'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Repayment Plan')).toBeInTheDocument();
+    expect(container.querySelectorAll('.skeleton').length).toBe(0);
+  });
+});

--- a/src/components/__tests__/RepaymentVisualizer.test.tsx
+++ b/src/components/__tests__/RepaymentVisualizer.test.tsx
@@ -17,6 +17,8 @@ const BASE = {
   principal: 100_000,
   apr: 8.5,
   monthlyPayment: 2500,
+  /** Skip first-paint skeleton so existing sync assertions stay stable. */
+  loading: false as const,
 };
 
 describe('RepaymentVisualizer', () => {
@@ -97,7 +99,7 @@ describe('RepaymentVisualizer', () => {
   });
 
   it('caps term at maxMonths', () => {
-    render(<RepaymentVisualizer principal={100_000} apr={8.5} monthlyPayment={3000} maxMonths={6} />);
+    render(<RepaymentVisualizer principal={100_000} apr={8.5} monthlyPayment={3000} maxMonths={6}  loading={false} />);
     expect(screen.getAllByText(/6 month/).length).toBeGreaterThanOrEqual(1);
   });
 
@@ -161,7 +163,7 @@ describe('RepaymentVisualizer — keyboard shortcut hints & navigation', () => {
   });
 
   it('jumps to start and end of schedule using Home and End keys', () => {
-    render(<RepaymentVisualizer principal={100_000} apr={8.5} monthlyPayment={3000} maxMonths={6} />);
+    render(<RepaymentVisualizer principal={100_000} apr={8.5} monthlyPayment={3000} maxMonths={6}  loading={false} />);
     const svg = screen.getByRole('img');
 
     fireEvent.keyDown(svg, { key: 'End' });

--- a/src/pages/RepaymentVisualizer.tsx
+++ b/src/pages/RepaymentVisualizer.tsx
@@ -1,3 +1,16 @@
-export { RepaymentVisualizer } from "@/components/RepaymentVisualizer";
-export type { RepaymentVisualizerProps, ScheduleRow } from "@/components/RepaymentVisualizer";
+/**
+ * Page re-export for the RepaymentVisualizer route module.
+ *
+ * The canonical implementation (including the first-paint skeleton) lives in
+ * `src/components/RepaymentVisualizer.tsx`. This module re-exports the public
+ * surface so route-level imports and GrantFox issue paths stay stable.
+ */
+export {
+  RepaymentVisualizer,
+  RepaymentVisualizerSkeleton,
+} from "@/components/RepaymentVisualizer";
+export type {
+  RepaymentVisualizerProps,
+  ScheduleRow,
+} from "@/components/RepaymentVisualizer";
 export { RepaymentVisualizer as default } from "@/components/RepaymentVisualizer";

--- a/src/pages/__tests__/RepaymentVisualizerPage.test.tsx
+++ b/src/pages/__tests__/RepaymentVisualizerPage.test.tsx
@@ -1,10 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import RepaymentVisualizerPage, { RepaymentVisualizer } from '../RepaymentVisualizer';
+import RepaymentVisualizerPage, {
+  RepaymentVisualizer,
+  RepaymentVisualizerSkeleton,
+} from '../RepaymentVisualizer';
 
 describe('RepaymentVisualizer Page Re-export', () => {
   it('re-exports RepaymentVisualizer component as named and default export', () => {
     expect(RepaymentVisualizerPage).toBe(RepaymentVisualizer);
+  });
+
+  it('re-exports RepaymentVisualizerSkeleton', () => {
+    expect(typeof RepaymentVisualizerSkeleton).toBe('function');
   });
 
   it('renders RepaymentVisualizer component via page export', () => {
@@ -13,6 +20,7 @@ describe('RepaymentVisualizer Page Re-export', () => {
         principal={50000}
         apr={7.5}
         monthlyPayment={1500}
+        loading={false}
       />
     );
     expect(screen.getByRole('region', { name: 'Repayment plan visualizer' })).toBeInTheDocument();


### PR DESCRIPTION
## Overview

Adds a themed **first-paint loading skeleton** for `RepaymentVisualizer` (GrantFox FWC26 / Stellar Wave issue #609). The skeleton mirrors the final chart-card geometry so Cumulative Layout Shift stays near zero while the schedule view commits.

## Related Issue

Closes #609

## Changes

### 💀 Loading skeleton

* **[ADD]** `RepaymentVisualizerSkeleton` in `src/components/RepaymentVisualizer.tsx`
  * Card shell uses `--surface` / `--border` / `--radius-lg`
  * Chart placeholder height matches SVG viewBox (`220px`)
  * `role="status"`, `aria-busy="true"`, labelled for screen readers
* **[MODIFY]** `RepaymentVisualizer` props
  * New `loading?: boolean` — `true` forces skeleton; `false` skips; omitted runs a one-frame first-paint gate via `setTimeout(0)`
* **[MODIFY]** `src/pages/RepaymentVisualizer.tsx`
  * Re-exports skeleton alongside the component
* **[MODIFY]** `src/components/Skeleton.tsx`
  * Documents composition with `RepaymentVisualizerSkeleton`
* **[ADD]** Tests + docs (`REPAYMENT_VISUALIZER_SKELETON.md`, ARCHITECTURE, ACCESSIBILITY)

## Verification Results

```
node node_modules/vitest/vitest.mjs --run \
  src/components/__tests__/RepaymentVisualizer.skeleton.test.tsx \
  src/pages/__tests__/RepaymentVisualizerPage.test.tsx
✅ 8/8 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Themed skeleton while RepaymentVisualizer data loads / first paint | ✅ Skeleton + bootstrap timer |
| Shape parity with final chart card | ✅ 220px chart + header/legend rows |
| Tests added and passing | ✅ Skeleton + page re-export tests |
| Docs updated | ✅ New skeleton doc + ARCHITECTURE / ACCESSIBILITY |
| Design-token + reduced-motion consistency | ✅ Uses `Skeleton` primitive tokens |


Made with [Cursor](https://cursor.com)