### PR TITLE
fix: Dashboard and Tooltip polish

### DIFF
--- a/src/components/AccessibleTooltip.css
+++ b/src/components/AccessibleTooltip.css
@@ -94,8 +94,7 @@
   transform: translate(-50%, -4px) rotate(45deg);
 }
 
-.accessible-tooltip:hover .accessible-tooltip__content,
-.accessible-tooltip:focus-within .accessible-tooltip__content {
+.accessible-tooltip__content.is-visible {
   opacity: 1;
   transform: translate(-50%, 0);
 }

--- a/src/components/AccessibleTooltip.tsx
+++ b/src/components/AccessibleTooltip.tsx
@@ -1,4 +1,4 @@
-import { useId, type ReactNode } from 'react';
+import { useId, useState, useRef, useEffect, type ReactNode } from 'react';
 import './AccessibleTooltip.css';
 
 interface AccessibleTooltipProps {
@@ -17,17 +17,65 @@ interface AccessibleTooltipProps {
  * `aria-label="More information"`, and is wired to the tooltip via
  * `aria-describedby` — so screen readers announce the label as the
  * trigger's accessible description.
- *
- * The visible tooltip itself uses `role="tooltip"`, and its show/hide
- * behaviour is controlled by `:hover` / `:focus-within` in
- * `AccessibleTooltip.css` — there's no JS state.
  */
 export function AccessibleTooltip({ label, children }: AccessibleTooltipProps) {
   const tooltipId = useId();
   const hasInlineContent = Boolean(children);
+  const [isVisible, setIsVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const handleMouseEnter = () => {
+    clearTimer();
+    timerRef.current = setTimeout(() => setIsVisible(true), 400); // hover delay
+  };
+
+  const handleMouseLeave = () => {
+    clearTimer();
+    setIsVisible(false);
+  };
+
+  const handleTouchStart = () => {
+    clearTimer();
+    timerRef.current = setTimeout(() => setIsVisible(true), 500); // long press delay
+  };
+
+  const handleTouchEnd = () => {
+    clearTimer();
+    setIsVisible(false);
+  };
+
+  const handleFocus = () => {
+    clearTimer();
+    setIsVisible(true);
+  };
+
+  const handleBlur = () => {
+    clearTimer();
+    setIsVisible(false);
+  };
+
+  useEffect(() => {
+    return clearTimer;
+  }, []);
 
   return (
-    <span className={`accessible-tooltip${hasInlineContent ? ' accessible-tooltip--inline' : ''}`}>
+    <span 
+      className={`accessible-tooltip${hasInlineContent ? ' accessible-tooltip--inline' : ''}`}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchEnd}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+    >
       <span
         tabIndex={0}
         className={`accessible-tooltip__trigger${hasInlineContent ? ' accessible-tooltip__trigger--text' : ''}`}
@@ -40,7 +88,11 @@ export function AccessibleTooltip({ label, children }: AccessibleTooltipProps) {
           <span aria-hidden="true">i</span>
         )}
       </span>
-      <span id={tooltipId} role="tooltip" className="accessible-tooltip__content">
+      <span 
+        id={tooltipId} 
+        role="tooltip" 
+        className={`accessible-tooltip__content${isVisible ? ' is-visible' : ''}`}
+      >
         {label}
       </span>
     </span>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -21,8 +21,8 @@ import {
   fmtDate,
   utilizationPct,
   getUtilizationLevel,
-} from "../utils/tokens";
 import "./Dashboard.css";
+import "../styles/focus.css";
 import { Skeleton } from "../components/Skeleton";
 import { NoDataGraph } from "../components/illustrations";
 import { useInertBackdrop } from "../hooks/useInertBackdrop";
@@ -227,7 +227,7 @@ export function Dashboard() {
             content: (
               <>
                 <strong>{cl.name}</strong> utilization is at{" "}
-                {Math.round(util * 100)}%. Consider a repayment.
+                <span className="tabular-nums">{Math.round(util * 100)}</span>%. Consider a repayment.
               </>
             ),
             type: "warning",
@@ -242,8 +242,8 @@ export function Dashboard() {
               icon: "🗓️",
               content: (
                 <>
-                  Payment of <strong>{fmt(cl.nextPaymentAmount ?? 0)}</strong>{" "}
-                  due in {daysUntil} day{daysUntil !== 1 ? "s" : ""} for{" "}
+                  Payment of <strong className="tabular-nums">{fmt(cl.nextPaymentAmount ?? 0)}</strong>{" "}
+                  due in <span className="tabular-nums">{daysUntil}</span> day{daysUntil !== 1 ? "s" : ""} for{" "}
                   {cl.name}.
                 </>
               ),
@@ -597,8 +597,8 @@ export function Dashboard() {
             </h2>
             {status === 'loading' ? (
               <div className="risk-gauge-container">
-                <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100px', width: '160px', marginBottom: '0.75rem' }}>
-                  <Skeleton style={{ width: '80px', height: '80px', borderRadius: '50%' }} />
+                <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'flex-end', height: '100px', width: '160px', marginBottom: '0.75rem' }}>
+                  <Skeleton style={{ width: '160px', height: '80px', borderRadius: '160px 160px 0 0' }} />
                 </div>
                 <div className="risk-meta" style={{ width: '100%' }}>
                   <div className="risk-meta-item" style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.375rem' }}>
@@ -915,7 +915,7 @@ export function Dashboard() {
                    <div className="qa-icon" style={{ background: "rgba(88,166,255,0.12)", color: COLOR.accent }}>↗</div>
                    <div>
                      <div className="qa-label" style={{ color: COLOR.accent }}>Draw Credit</div>
-                     <div className="qa-desc" style={{ color: COLOR.muted }}>{fmt(totalAvailable)} available</div>
+                     <div className="qa-desc num-tabular" style={{ color: COLOR.muted }}>{fmt(totalAvailable)} available</div>
                    </div>
                    <span className="qa-arrow" style={{ color: COLOR.muted }}>→</span>
                  </button>
@@ -928,7 +928,7 @@ export function Dashboard() {
                    <div className="qa-icon" style={{ background: "rgba(63,185,80,0.12)", color: COLOR.success }}>↙</div>
                    <div>
                      <div className="qa-label" style={{ color: COLOR.success }}>Repay Credit</div>
-                     <div className="qa-desc" style={{ color: COLOR.muted }}>{fmt(totalUtilized)} outstanding</div>
+                     <div className="qa-desc num-tabular" style={{ color: COLOR.muted }}>{fmt(totalUtilized)} outstanding</div>
                    </div>
                    <span className="qa-arrow" style={{ color: COLOR.muted }}>→</span>
                  </button>


### PR DESCRIPTION
This PR bundles several UI/UX enhancements and polish for the GrantFox FWC26 campaign.

**Changes Included:**
- **Dashboard Tabular Numerals:** Applied `tabular-nums` and `num-tabular` classes to additional numeric displays on the Dashboard (e.g., Quick Actions amounts, Utilization percentages, and notification amounts) to ensure stable digit widths as values change.
- **Dashboard Focus Outlines:** Ensured `focus.css` is correctly imported so that keyboard-only focus outlines are fully visible across all interactive elements on the Dashboard.
- **Dashboard Loading Skeleton Parity:** Audited and adjusted the Dashboard Risk Gauge skeleton. The skeleton's border-radius and dimensions were updated to reflect the final semi-circular component, improving layout parity during first paint.
- **Tooltip Primitive Polish:** Replaced the pure CSS `:hover` / `:focus-within` trigger with a JS-controlled state (`setTimeout`). This adds a slight hover delay and correctly handles long-press events on mobile. 

**Related Issues:**
closes #499
closes #498
closes #497
closes #474