### PR TITLE
feat: add themed empty-state illustration for RiskGauge

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,22 +1,75 @@
-import type { ReactNode } from 'react';
+import { useId } from 'react';
+import { Link } from 'react-router-dom';
+import type { ReactNode, ComponentPropsWithoutRef } from 'react';
 
-type EmptyStateProps = {
-  icon: ReactNode;
-  title: string;
-  description: string;
-  action?: ReactNode;
-  className?: string;
+type ActionShape = {
+  label: string;
+  to?: string;
+  onClick?: () => void;
 };
 
-export function EmptyState({ icon, title, description, action, className = '' }: EmptyStateProps) {
+export type EmptyStateProps = {
+  illustration: ReactNode;
+  title: string;
+  description: string;
+  eyebrow?: string;
+  tone?: 'info' | 'success';
+  primaryAction?: ActionShape;
+  secondaryAction?: ActionShape;
+  titleId?: string;
+} & ComponentPropsWithoutRef<'div'>;
+
+function renderAction(action: ActionShape, className: string) {
+  if (action.to) {
+    return (
+      <Link key={action.label} to={action.to} className={className}>
+        {action.label}
+      </Link>
+    );
+  }
   return (
-    <div className={`cl-empty ${className}`.trim()}>
-      <div className="cl-empty-icon-wrapper">
-        {icon}
-      </div>
-      <h3>{title}</h3>
-      <p>{description}</p>
-      {action && <div className="cl-empty-action">{action}</div>}
+    <button key={action.label} type="button" className={className} onClick={action.onClick}>
+      {action.label}
+    </button>
+  );
+}
+
+export function EmptyState({
+  illustration,
+  title,
+  description,
+  eyebrow,
+  tone,
+  primaryAction,
+  secondaryAction,
+  titleId: customTitleId,
+  className = '',
+  ...props
+}: EmptyStateProps) {
+  const autoId = useId();
+  const titleId = customTitleId ?? `empty-state-title-${autoId}`;
+  const toneClass = tone ? `empty-state--${tone}` : '';
+
+  return (
+    <div
+      className={`empty-state ${toneClass} ${className}`.trim()}
+      role="status"
+      aria-live="polite"
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {illustration}
+      {eyebrow && <p className="empty-state__eyebrow">{eyebrow}</p>}
+      <h2 className="empty-state__title" id={titleId}>
+        {title}
+      </h2>
+      <p className="empty-state__description">{description}</p>
+      {(primaryAction || secondaryAction) && (
+        <div className="empty-state__actions">
+          {primaryAction && renderAction(primaryAction, 'empty-state-btn')}
+          {secondaryAction && renderAction(secondaryAction, 'empty-state-secondary-btn')}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/__tests__/NoRiskGauge.test.tsx
+++ b/src/components/__tests__/NoRiskGauge.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { NoRiskGauge } from '../illustrations/EmptyStateIllustrations';
+
+describe('NoRiskGauge illustration', () => {
+  it('renders as aria-hidden so it does not appear in the AT tree', () => {
+    const { container } = render(<NoRiskGauge />);
+    const frame = container.querySelector('.empty-state-illustration');
+    expect(frame).not.toBeNull();
+    expect(frame?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('does not include any focusable SVG nodes', () => {
+    const { container } = render(<NoRiskGauge />);
+    const tabbables = container.querySelectorAll('[tabindex]');
+    expect(tabbables.length).toBe(0);
+  });
+
+  it('merges additional className props onto the frame', () => {
+    const { container } = render(
+      <NoRiskGauge className="extra-class" />,
+    );
+    const frame = container.querySelector('.empty-state-illustration');
+    expect(frame?.className).toContain('extra-class');
+    expect(frame?.className).toContain('empty-state-illustration');
+  });
+
+  it('renders a dashed semicircular arc hinting at the gauge', () => {
+    const { container } = render(<NoRiskGauge />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    // The dashed arc path should be present
+    const dashedArc = svg?.querySelector('path[stroke-dasharray="6 6"]');
+    expect(dashedArc).toBeInTheDocument();
+  });
+
+  it('renders a "?" text glyph to indicate absence of data', () => {
+    const { container } = render(<NoRiskGauge />);
+    const questionMark = container.querySelector('text');
+    expect(questionMark?.textContent).toBe('?');
+  });
+
+  it('inherits color from currentColor so it themes via tokens', () => {
+    const { container } = render(
+      <div style={{ color: 'rgb(88, 166, 255)' }}>
+        <NoRiskGauge />
+      </div>,
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/src/components/illustrations/EmptyStateIllustrations.tsx
+++ b/src/components/illustrations/EmptyStateIllustrations.tsx
@@ -89,6 +89,70 @@ export function NoActivity(props: IllustrationProps) {
  * Inherits `--accent` (or any other surrounding foreground) via `currentColor`
  * so it stays consistent with light, dark, and high-contrast themes.
  */
+/**
+ * NoRiskGauge — illustrated empty state for the RiskGauge page.
+ *
+ * Composition: a dashed semicircular gauge arc (to hint at the real gauge
+ * that will appear once data is available) with a question-mark glyph inside
+ * the arc. The dashed line and low-opacity "?" visually communicate "not yet
+ * populated" without relying on colour alone.
+ *
+ * Inherits `--accent` (or any other surrounding foreground) via `currentColor`
+ * so it stays consistent with light, dark, and high-contrast themes.
+ */
+export function NoRiskGauge(props: IllustrationProps) {
+  return (
+    <IllustrationFrame {...props}>
+      <svg viewBox="0 0 180 140" fill="none" focusable="false">
+        {/* background card */}
+        <rect x="16" y="16" width="148" height="108" rx="18" stroke="currentColor" strokeWidth="2" opacity="0.20" />
+        {/* dashed semicircular gauge arc */}
+        <path
+          d="M 42 92 A 48 48 0 0 1 138 92"
+          stroke="currentColor"
+          strokeWidth="4"
+          strokeLinecap="round"
+          strokeDasharray="6 6"
+          opacity="0.50"
+        />
+        {/* tick marks along the arc */}
+        <path d="M 58 78 L 62 74" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity="0.28" />
+        <path d="M 90 68 L 90 64" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity="0.28" />
+        <path d="M 122 78 L 118 74" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity="0.28" />
+        {/* "?" mark in the centre — communicates "no data yet" */}
+        <text
+          x="90"
+          y="82"
+          textAnchor="middle"
+          dominantBaseline="central"
+          fontFamily="system-ui, -apple-system, sans-serif"
+          fontSize="32"
+          fontWeight="700"
+          fill="currentColor"
+          opacity="0.28"
+        >
+          ?
+        </text>
+        {/* label hint below the gauge */}
+        <text
+          x="90"
+          y="112"
+          textAnchor="middle"
+          dominantBaseline="central"
+          fontFamily="system-ui, -apple-system, sans-serif"
+          fontSize="9"
+          fontWeight="600"
+          fill="currentColor"
+          opacity="0.32"
+          letterSpacing="0.12em"
+        >
+          RISK SCORE
+        </text>
+      </svg>
+    </IllustrationFrame>
+  );
+}
+
 export function NoOutstandingDebt(props: IllustrationProps) {
   return (
     <IllustrationFrame {...props}>

--- a/src/components/illustrations/index.ts
+++ b/src/components/illustrations/index.ts
@@ -1,1 +1,1 @@
-export { NoActivity, NoDataGraph, NoLines, NoOutstandingDebt } from './EmptyStateIllustrations';
+export { NoActivity, NoDataGraph, NoLines, NoOutstandingDebt, NoRiskGauge } from './EmptyStateIllustrations';

--- a/src/pages/RiskGauge.tsx
+++ b/src/pages/RiskGauge.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
 import { Sparkline } from "../components/Sparkline";
 import { EmptyState } from "../components/EmptyState";
-import { NoDataGraph } from "../components/illustrations/EmptyStateIllustrations";
+import { NoRiskGauge } from "../components/illustrations/EmptyStateIllustrations";
 import { COLOR, RISK_COLOR, fmtDate } from "../utils/tokens";
+import { KbdHint } from "../components/KbdHint";
 import { useReducedMotion } from "../context/ReducedMotionContext";
 
 const easeCubicBezier = (x: number): number => {
@@ -104,7 +105,7 @@ export function RiskGauge({
   if (isEmpty) {
     return (
       <EmptyState
-        illustration={<NoDataGraph />}
+        illustration={<NoRiskGauge />}
         eyebrow="Risk Score"
         title="No risk data available"
         description="Your risk score will appear here once your credit profile has been analyzed."

--- a/src/pages/__tests__/RiskGauge.test.tsx
+++ b/src/pages/__tests__/RiskGauge.test.tsx
@@ -4,7 +4,7 @@
  * Cover:
  *  1. Renders the gauge SVG when isEmpty is false (default).
  *  2. Renders EmptyState when isEmpty is true.
- *  3. EmptyState includes the NoDataGraph illustration, heading, and description.
+ *  3. EmptyState includes the NoRiskGauge illustration, heading, and description.
  *  4. EmptyState shows "Check again" CTA when onRefresh is provided.
  *  5. EmptyState does NOT render the SVG or meta row.
  *  6. When isEmpty is false, the original gauge behaviour is preserved.
@@ -43,7 +43,8 @@ describe('RiskGauge page', () => {
         trend: 'improving',
         lastUpdated: '2025-03-01T00:00:00Z',
       });
-      expect(screen.getByText(/improving/i)).toBeInTheDocument();
+      const trendElements = screen.getAllByText(/improving/i);
+      expect(trendElements.length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
- Implement EmptyState with full richer API (illustration, eyebrow, tone, primaryAction, secondaryAction, titleId, data-testid) matching tests
- Add NoRiskGauge illustration showing dashed semicircular gauge with question-mark glyph for the empty data state
- Update RiskGauge page to use NoRiskGauge instead of NoDataGraph
- Fix missing KbdHint import in RiskGauge page (pre-existing bug)
- Fix RiskGauge page test for multiple 'improving' matches

Closes #664