### PR TITLE
fix: add tabular -nums to DrawCreditPage numeric displays

### DIFF
--- a/src/components/CreditLineSelector.tsx
+++ b/src/components/CreditLineSelector.tsx
@@ -93,7 +93,7 @@ export function CreditLineSelector({
                         <span className="dc-credit-line-item__label">
                           Available:
                         </span>
-                        <span className="dc-credit-line-item__value">
+                        <span className="dc-credit-line-item__value tabular-nums">
                           ${line.available.toLocaleString()}
                         </span>
                       </div>
@@ -105,8 +105,8 @@ export function CreditLineSelector({
                         <span
                           className={
                             isHighUtilization
-                              ? "dc-credit-line-item__value--warning"
-                              : "dc-credit-line-item__value"
+                              ? "dc-credit-line-item__value--warning tabular-nums"
+                              : "dc-credit-line-item__value tabular-nums"
                           }
                         >
                           {line.utilization}%

--- a/src/components/CreditLineSummaryBlock.tsx
+++ b/src/components/CreditLineSummaryBlock.tsx
@@ -109,19 +109,19 @@ export function CreditLineSummaryBlock({
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
         <div className="rounded-lg border border-border bg-background/60 p-3">
           <p className="text-muted">Limit</p>
-          <p className="text-base font-semibold text-foreground mt-1">
+          <p className="text-base font-semibold text-foreground mt-1 tabular-nums">
             {formatMoney(creditLine.limit)}
           </p>
         </div>
         <div className="rounded-lg border border-border bg-background/60 p-3">
           <p className="text-muted">Utilized</p>
-          <p className="text-base font-semibold text-foreground mt-1">
+          <p className="text-base font-semibold text-foreground mt-1 tabular-nums">
             {formatMoney(projectedUtilized)}
           </p>
         </div>
         <div className="rounded-lg border border-border bg-background/60 p-3">
           <p className="text-muted">Available</p>
-          <p className="text-base font-semibold text-foreground mt-1">
+          <p className="text-base font-semibold text-foreground mt-1 tabular-nums">
             {formatMoney(projectedAvailable)}
           </p>
         </div>

--- a/src/components/DrawingLimit.tsx
+++ b/src/components/DrawingLimit.tsx
@@ -70,20 +70,20 @@ export function DrawingLimit({
         <div className="flex items-center gap-4">
           <span className="font-medium text-foreground">
             {drawnLabel}:{" "}
-            <span className={`font-semibold ${textColor}`}>
+            <span className={`font-semibold ${textColor} tabular-nums`}>
               {formatCurrency(drawnAmount)}
             </span>
           </span>
           <span className="text-muted-foreground">/</span>
           <span className="text-muted-foreground">
             {availableLabel}:{" "}
-            <span className="font-semibold text-foreground">
+            <span className="font-semibold text-foreground tabular-nums">
               {formatCurrency(available)}
             </span>
           </span>
         </div>
         <span
-          className={`text-sm font-semibold ${textColor}`}
+          className={`text-sm font-semibold ${textColor} tabular-nums`}
           aria-live="polite"
           aria-atomic="true"
         >
@@ -116,12 +116,12 @@ export function DrawingLimit({
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span>
           Limit:{" "}
-          <span className="font-medium text-foreground">
+          <span className="font-medium text-foreground tabular-nums">
             {formatCurrency(totalLimit)}
           </span>
         </span>
         {isExceeded && (
-          <span className="font-medium text-red-400">
+          <span className="font-medium text-red-400 tabular-nums">
             Overdrawn by {formatCurrency(drawnAmount - totalLimit)}
           </span>
         )}

--- a/src/components/PreviewSection.tsx
+++ b/src/components/PreviewSection.tsx
@@ -44,7 +44,7 @@ export function PreviewSection({ creditLine, amount }: PreviewSectionProps) {
           <div className="dc-stat-card__header">
             <div>
               <p className="dc-stat-card__label">Draw Amount</p>
-              <p className="dc-stat-card__value">
+              <p className="dc-stat-card__value tabular-nums">
                 ${amount.toLocaleString()}
               </p>
             </div>
@@ -60,7 +60,7 @@ export function PreviewSection({ creditLine, amount }: PreviewSectionProps) {
           <div className="dc-stat-card__header">
             <div>
               <p className="dc-stat-card__label">New Utilization</p>
-              <p className="dc-stat-card__value">
+              <p className="dc-stat-card__value tabular-nums">
                 {newUtilization}%
               </p>
             </div>
@@ -76,7 +76,7 @@ export function PreviewSection({ creditLine, amount }: PreviewSectionProps) {
       <div className="dc-util-section">
         <div className="dc-util-row">
           <span className="dc-util-row__label">Current utilization</span>
-          <span className="dc-util-row__value">{creditLine.utilization}%</span>
+          <span className="dc-util-row__value tabular-nums">{creditLine.utilization}%</span>
         </div>
         <div
           className="dc-progress-track dc-progress-track--lg"
@@ -100,8 +100,8 @@ export function PreviewSection({ creditLine, amount }: PreviewSectionProps) {
           <span
             className={
               isHighAfterDraw
-                ? "dc-util-row__value--warning"
-                : "dc-util-row__value"
+                ? "dc-util-row__value--warning tabular-nums"
+                : "dc-util-row__value tabular-nums"
             }
           >
             {newUtilization}%

--- a/src/components/TransactionStatus.tsx
+++ b/src/components/TransactionStatus.tsx
@@ -107,7 +107,7 @@ export function TransactionStatus({
         {/* Amount drawn */}
         <div className="dc-status-detail-row">
           <p className="dc-status-detail-row__label">Amount Drawn</p>
-          <p className="dc-status-detail-row__value dc-status-detail-row__value--large">
+          <p className="dc-status-detail-row__value dc-status-detail-row__value--large tabular-nums">
             ${transaction.amount.toLocaleString()}
           </p>
         </div>


### PR DESCRIPTION
## Summary

Applies the existing `tabular-nums` typography utility to numeric values on the Draw Credit page to ensure consistent digit alignment across currency and percentage displays.

Closes #593

## What changed

- Added `tabular-nums` to numeric values in the Draw Credit page.
- Reused the existing typography utility.
- No new CSS classes or dependencies introduced.
- No visual changes outside of numeric alignment.

## Testing

- Verified numeric values align correctly.
- Confirmed there are no lint errors.
- Existing functionality remains unchanged.