### PR TITLE
feat: AmountInput kbd hints

### DIFF
--- a/src/components/AmountInput.test.tsx
+++ b/src/components/AmountInput.test.tsx
@@ -704,4 +704,17 @@ describe("AmountInput", () => {
       expect(continueBtn).toHaveClass("xs:w-auto");
     });
   });
+  it("renders keyboard shortcut hint for arrow key stepper controls", () => {
+    render(
+      <AmountInput
+        creditLine={creditLine}
+        onAmountChange={vi.fn()}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("↑ / ↓")).toBeInTheDocument();
+    expect(screen.getByText("Adjust amount")).toBeInTheDocument();
+  });
 });

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -13,6 +13,7 @@ import {
   getDrawAmountValidation,
 } from "../utils/amountValidation";
 import { FormMessage } from "./FormMessage";
+import { KbdHint } from "./KbdHint";
 import { Skeleton } from "./Skeleton";
 
 const STEP_AMOUNT = 100;
@@ -273,6 +274,15 @@ export function AmountInput({
             {formatMoney(creditLine.available)}
           </span>
         </p>
+
+        <div className="flex items-center gap-3 flex-wrap">
+          <KbdHint
+            keys={["↑", "↓"]}
+            separator="/"
+            label="Adjust amount"
+            description="Use up and down arrow keys to adjust the draw amount"
+          />
+        </div>
 
         {/* Input field container polished for narrow (<=375px) mobile viewports */}
         <div


### PR DESCRIPTION
## Summary

Adds keyboard shortcut hint (KbdHint) to the AmountInput component to inform users about arrow key stepper controls (↑/↓) for adjusting the draw amount.

## Changes

- **src/components/AmountInput.tsx**: Imported and rendered `KbdHint` showing ↑/↓ arrow keys with "Adjust amount" label, placed between the helper text and input field container.

- **src/components/AmountInput.test.tsx**: Added focused test verifying the KbdHint renders the arrow key symbols and label text.

## Acceptance Criteria

- [x] Keyboard shortcut hint displayed on AmountInput
- [x] Focused tests added and passing
- [x] Responsive across all breakpoints
- [x] WCAG 2.1 AA accessible (sr-only fallback, aria-label on container)
- [x] Design-token + dark-mode consistent
- [x] No API changes — purely additive UI enhancement

Closes #620