### PR TITLE
feat: high-contrast toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import {
   RouteHeadProvider,
 } from "./components/RouteAnnouncer";
 import { WalletProvider } from "./context/WalletContext";
+import { ThemeProvider } from "./context/ThemeContext";
+import { ContrastProvider } from "./context/ContrastContext";
 import { KycProvider } from "./context/KycContext";
 import { NotificationProvider } from "./context/NotificationContext";
 import { WalletButton } from "./components/WalletButton";
@@ -25,6 +27,8 @@ import { ShortcutHelpOverlay } from "./components/ShortcutHelpOverlay";
 import { DutchAuctions } from "./pages/DutchAuctions";
 import RepayPage from "./pages/RepayPage";
 import RepayCalendar from "./pages/RepayCalendar";
+import { SettingsAccount } from "./pages/SettingsAccount";
+import { Theme } from "./pages/settings/Theme";
 import { LinkedAccounts } from "./pages/LinkedAccounts";
 import { WalletReconnectBanner } from "./components/WalletReconnectBanner";
 import { SessionTimeoutBanner } from "./components/SessionTimeoutBanner";
@@ -124,155 +128,160 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <WalletProvider>
-        <KycProvider>
-          <NotificationProvider>
-            <BrowserRouter>
-              <RouteHeadProvider>
-                <div className="app">
-                  <header className="header">
-                    <Link to="/" className="logo">
-                      Creditra
-                    </Link>
-                  <nav className="header-nav">
-                    {/*
-                      NavLink with render function allows us to:
-                      1. Apply active class for styling (accent + underline + weight)
-                      2. Set aria-current="page" on active links for accessibility
+      <ThemeProvider>
+        <ContrastProvider>
+          <WalletProvider>
+            <KycProvider>
+              <NotificationProvider>
+                <BrowserRouter>
+                  <RouteHeadProvider>
+                    <div className="app">
+                      <header className="header">
+                        <Link to="/" className="logo">
+                          Creditra
+                        </Link>
+                      <nav className="header-nav">
+                        {/*
+                          NavLink with render function allows us to:
+                          1. Apply active class for styling (accent + underline + weight)
+                          2. Set aria-current="page" on active links for accessibility
 
-                      This satisfies WCAG 2.1 AA requirements:
-                      - 1.4.1: Use of Color - active state uses color + other visual indicators
-                      - 2.4.7: Focus Visible - outline differs from active underline
-                      - 2.4.8: Location - aria-current="page" indicates current page
-                    */}
-                    <NavLink
-                      to="/"
-                      end
-                      className={({ isActive }) =>
-                        isActive ? "header-nav-link active" : "header-nav-link"
-                      }
-                    >
-                      Dashboard
-                    </NavLink>
-                    <NavLink
-                      to="/transactions"
-                      className={({ isActive }) =>
-                        isActive ? "header-nav-link active" : "header-nav-link"
-                      }
-                    >
-                      Transactions
-                    </NavLink>
-                    <NavLink
-                      to="/credit-lines"
-                      className={({ isActive }) =>
-                        isActive ? "header-nav-link active" : "header-nav-link"
-                      }
-                    >
-                      Credit Lines
-                    </NavLink>
-                    <NavLink
-                      to="/open-credit"
-                      className={({ isActive }) =>
-                        isActive ? "header-nav-link active" : "header-nav-link"
-                      }
-                    >
-                      Open Credit Line
-                    </NavLink>
-                    <NavLink
-                      to="/dutch-auctions"
-                      className={({ isActive }) =>
-                        isActive ? "header-nav-link active" : "header-nav-link"
-                      }
-                    >
-                      Dutch Auctions
-                    </NavLink>
-                  </nav>
-                  <button
-                    ref={settingsTriggerRef}
-                    type="button"
-                    className="header-nav-link"
-                    onClick={() => {
-                      setOpenedFromSettingsLink(true);
-                      setIsShortcutHelpOpen(true);
-                    }}
-                  >
-                    Settings
-                  </button>
-                  <button
-                    type="button"
-                    className="header-nav-link header-cmdk-btn"
-                    aria-label="Open command palette"
-                    aria-keyshortcuts="Control+K Meta+K"
-                    onClick={(e) => {
-                      paletteTriggerRef.current = e.currentTarget;
-                      setIsPaletteOpen(true);
-                    }}
-                  >
-                    <span aria-hidden="true">Search</span>
-                    <kbd className="header-cmdk-kbd" aria-hidden="true">⌘K</kbd>
-                  </button>
-                  <KycTriggerButton
-                    triggerRef={kycTriggerRef}
-                    onClick={() => setIsKycDrawerOpen(true)}
-                  />
-                  <QuickRepayTrigger />
-                  <WalletButton />
-                </header>
+                          This satisfies WCAG 2.1 AA requirements:
+                          - 1.4.1: Use of Color - active state uses color + other visual indicators
+                          - 2.4.7: Focus Visible - outline differs from active underline
+                          - 2.4.8: Location - aria-current="page" indicates current page
+                        */}
+                        <NavLink
+                          to="/"
+                          end
+                          className={({ isActive }) =>
+                            isActive ? "header-nav-link active" : "header-nav-link"
+                          }
+                        >
+                          Dashboard
+                        </NavLink>
+                        <NavLink
+                          to="/transactions"
+                          className={({ isActive }) =>
+                            isActive ? "header-nav-link active" : "header-nav-link"
+                          }
+                        >
+                          Transactions
+                        </NavLink>
+                        <NavLink
+                          to="/credit-lines"
+                          className={({ isActive }) =>
+                            isActive ? "header-nav-link active" : "header-nav-link"
+                          }
+                        >
+                          Credit Lines
+                        </NavLink>
+                        <NavLink
+                          to="/open-credit"
+                          className={({ isActive }) =>
+                            isActive ? "header-nav-link active" : "header-nav-link"
+                          }
+                        >
+                          Open Credit Line
+                        </NavLink>
+                        <NavLink
+                          to="/dutch-auctions"
+                          className={({ isActive }) =>
+                            isActive ? "header-nav-link active" : "header-nav-link"
+                          }
+                        >
+                          Dutch Auctions
+                        </NavLink>
+                      </nav>
+                      <button
+                        ref={settingsTriggerRef}
+                        type="button"
+                        className="header-nav-link"
+                        onClick={() => {
+                          setOpenedFromSettingsLink(true);
+                          setIsShortcutHelpOpen(true);
+                        }}
+                      >
+                        Settings
+                      </button>
+                      <button
+                        type="button"
+                        className="header-nav-link header-cmdk-btn"
+                        aria-label="Open command palette"
+                        aria-keyshortcuts="Control+K Meta+K"
+                        onClick={(e) => {
+                          paletteTriggerRef.current = e.currentTarget;
+                          setIsPaletteOpen(true);
+                        }}
+                      >
+                        <span aria-hidden="true">Search</span>
+                        <kbd className="header-cmdk-kbd" aria-hidden="true">⌘K</kbd>
+                      </button>
+                      <KycTriggerButton
+                        triggerRef={kycTriggerRef}
+                        onClick={() => setIsKycDrawerOpen(true)}
+                      />
+                      <QuickRepayTrigger />
+                      <WalletButton />
+                    </header>
 
-                {/* Wallet auto-reconnect timeout banner — self-dismissing,
-                    non-blocking; only visible when reconnect takes > 8 s. */}
-                <WalletReconnectBanner />
-                <main className="main">
-                  <TermsBanner />
-                  <NetworkMismatchBanner />
-                  <Routes>
-                    <Route path="/" element={<Dashboard />} />
-                    <Route path="/transactions" element={<TransactionHistory />} />
-                    <Route path="/credit-lines" element={<CreditLines />} />
-                    <Route path="/help" element={<HelpCenter />} />
-                    <Route path="/draw-credit" element={<DrawCreditPage />} />
-                    <Route
-                      path="/draw-credit/success"
-                      element={<DrawCreditPage />}
+                    {/* Wallet auto-reconnect timeout banner — self-dismissing,
+                        non-blocking; only visible when reconnect takes > 8 s. */}
+                    <WalletReconnectBanner />
+                    <main className="main">
+                      <TermsBanner />
+                      <NetworkMismatchBanner />
+                      <Routes>
+                        <Route path="/" element={<Dashboard />} />
+                        <Route path="/transactions" element={<TransactionHistory />} />
+                        <Route path="/credit-lines" element={<CreditLines />} />
+                        <Route path="/help" element={<HelpCenter />} />
+                        <Route path="/draw-credit" element={<DrawCreditPage />} />
+                        <Route
+                          path="/draw-credit/success"
+                          element={<DrawCreditPage />}
+                        />
+                        <Route path="/open-credit" element={<RequestEvaluation />} />
+                        <Route path="/dutch-auctions" element={<DutchAuctions />} />
+                        <Route path="/settings/account" element={<SettingsAccount />} />
+                        <Route path="/settings/theme" element={<Theme />} />
+                        <Route path="/linked-accounts" element={<LinkedAccounts />} />
+                        {/* Issue #581: Repay flow (now reachable from header /
+                            the "Repay" action on Credit Lines). */}
+                        <Route path="/repay" element={<RepayPage />} />
+                        <Route path="/repay/calendar" element={<RepayCalendar />} />
+                        <Route path="*" element={<NotFound />} />
+                      </Routes>
+                    </main>
+                    <ShortcutHelpOverlay
+                      isOpen={isShortcutHelpOpen}
+                      onClose={() => setIsShortcutHelpOpen(false)}
+                      triggerRef={openedFromSettingsLink ? settingsTriggerRef : undefined}
                     />
-                    <Route path="/open-credit" element={<RequestEvaluation />} />
-                    <Route path="/dutch-auctions" element={<DutchAuctions />} />
-                    <Route path="/settings/account" element={<SettingsAccount />} />
-                    <Route path="/linked-accounts" element={<LinkedAccounts />} />
-                    {/* Issue #581: Repay flow (now reachable from header /
-                        the "Repay" action on Credit Lines). */}
-                    <Route path="/repay" element={<RepayPage />} />
-                    <Route path="/repay/calendar" element={<RepayCalendar />} />
-                    <Route path="*" element={<NotFound />} />
-                  </Routes>
-                </main>
-                <ShortcutHelpOverlay
-                  isOpen={isShortcutHelpOpen}
-                  onClose={() => setIsShortcutHelpOpen(false)}
-                  triggerRef={openedFromSettingsLink ? settingsTriggerRef : undefined}
-                />
-                <KycDrawer
-                  isOpen={isKycDrawerOpen}
-                  onClose={() => setIsKycDrawerOpen(false)}
-                  onResume={(stepId) => {
-                    // Navigate to the KYC page with the step pre-selected.
-                    // Replace with router.push('/kyc?step=' + stepId) when the
-                    // full KYC page exists.
-                    console.info('[KYC] Resume at step:', stepId);
-                  }}
-                  triggerRef={kycTriggerRef}
-                />
-                {/* Mounted inside <RouteHeadProvider> so it can read the
-                    override context, and inside <BrowserRouter> so it can
-                    read useLocation().  Renders a sr-only polite status
-                    region for screen-reader route announcements. */}
-                <RouteAnnouncer />
-              </div>
-              </RouteHeadProvider>
-            </BrowserRouter>
-          </NotificationProvider>
-        </KycProvider>
-      </WalletProvider>
+                    <KycDrawer
+                      isOpen={isKycDrawerOpen}
+                      onClose={() => setIsKycDrawerOpen(false)}
+                      onResume={(stepId) => {
+                        // Navigate to the KYC page with the step pre-selected.
+                        // Replace with router.push('/kyc?step=' + stepId) when the
+                        // full KYC page exists.
+                        console.info('[KYC] Resume at step:', stepId);
+                      }}
+                      triggerRef={kycTriggerRef}
+                    />
+                    {/* Mounted inside <RouteHeadProvider> so it can read the
+                        override context, and inside <BrowserRouter> so it can
+                        read useLocation().  Renders a sr-only polite status
+                        region for screen-reader route announcements. */}
+                    <RouteAnnouncer />
+                  </div>
+                  </RouteHeadProvider>
+                </BrowserRouter>
+              </NotificationProvider>
+            </KycProvider>
+          </WalletProvider>
+        </ContrastProvider>
+      </ThemeProvider>
     </ErrorBoundary>
   );
 }

--- a/src/pages/settings/Theme.tsx
+++ b/src/pages/settings/Theme.tsx
@@ -1,0 +1,38 @@
+/**
+ * Theme settings page.
+ *
+ * Houses accessibility and display preferences, specifically the high-contrast
+ * toggle.
+ *
+ * Route: /settings/theme
+ */
+
+import { Settings as SettingsIcon } from 'lucide-react';
+import { HighContrastToggle } from '../../components/HighContrastToggle';
+
+export function Theme() {
+  return (
+    <div className="card card-large">
+      <h2>
+        <SettingsIcon className="icon" aria-hidden="true" />
+        Theme Settings
+      </h2>
+      <p>Customize your display preferences to suit your needs.</p>
+
+      {/* ── Accessibility section ─────────────────────────────────────── */}
+      <section
+        aria-labelledby="settings-a11y-heading"
+        style={{ marginTop: '2rem', display: 'grid', gap: '1.5rem' }}
+      >
+        <h3
+          id="settings-a11y-heading"
+          style={{ fontSize: '0.8rem', fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--muted)', margin: 0 }}
+        >
+          Accessibility
+        </h3>
+
+        <HighContrastToggle />
+      </section>
+    </div>
+  );
+}

--- a/src/pages/settings/__tests__/Theme.test.tsx
+++ b/src/pages/settings/__tests__/Theme.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Theme } from '../Theme';
+import { ContrastProvider } from '../../../context/ContrastContext';
+
+// Mock storage to prevent actual localStorage usage
+vi.mock('../../../utils/storage', () => ({
+  readJson: vi.fn(() => 'normal'),
+  writeJson: vi.fn(),
+}));
+
+describe('Theme Settings Page', () => {
+  it('renders the high contrast toggle', () => {
+    render(
+      <ContrastProvider>
+        <Theme />
+      </ContrastProvider>
+    );
+    expect(screen.getByText(/High Contrast/i)).toBeDefined();
+  });
+
+  it('toggles contrast mode when clicked', () => {
+    render(
+      <ContrastProvider>
+        <Theme />
+      </ContrastProvider>
+    );
+    const toggle = screen.getByRole('switch');
+    // Initially 'normal' -> aria-checked="false"
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+
+    fireEvent.click(toggle);
+    // After click -> 'high' -> aria-checked="true"
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+  });
+});


### PR DESCRIPTION
I have successfully implemented the high-contrast theme override toggle, updated the app's provider tree, created
  the new Theme settings page, and verified the changes with new unit tests. The task is complete.

  Adds a new Theme settings page (/settings/theme) to allow users to toggle high-contrast mode independently of the
  base theme.

  Changes:
   - Added ThemeProvider and ContrastProvider to the application's root provider tree in App.tsx to ensure consistent
     theme management.
   - Created the new Theme settings page (src/pages/settings/Theme.tsx) to house accessibility preferences.
   - Registered the /settings/theme route in App.tsx.
   - Added unit tests for the Theme settings page to verify functionality.

  Closes #454