### PR TITLE
docs(accessibility): document transaction status patterns

### DIFF
--- a/src/styles/docs/ACCESSIBILITY.md
+++ b/src/styles/docs/ACCESSIBILITY.md
@@ -1,0 +1,23 @@
+## Transaction Status Accessibility
+
+Transaction history status chips use both color and CSS patterns to ensure
+statuses remain distinguishable for users with color-vision deficiencies.
+
+Patterns are defined in:
+
+src/styles/patterns.css
+
+Current mappings:
+
+| Status | Pattern |
+|---------|---------|
+| Completed | Diagonal stripes |
+| Pending | Dotted pattern |
+| Failed | Cross-hatch pattern |
+
+When adding new transaction statuses:
+
+- Do not rely on color alone.
+- Add a unique pattern variant.
+- Ensure WCAG 2.1 AA compliance.
+- Update associated tests in TransactionHistory.test.tsx.


### PR DESCRIPTION
**Closes #697**

## Summary

Documented the TransactionHistory status pattern system used for color-blind accessibility.

## Changes

- Added documentation describing status-chip pattern usage
- Documented mapping between statuses and pattern styles
- Added contributor guidance for future status additions
- Clarified WCAG 2.1 AA accessibility expectations

## Testing

Documentation-only change.

## Result

- Accessibility implementation is now documented
- Future contributors have guidance for maintaining color-blind support