### PR TITLE
feat: smart suggested repayment

### DIFF
--- a/src/pages/RepayPage.tsx
+++ b/src/pages/RepayPage.tsx
@@ -97,6 +97,8 @@ export default function RepayPage() {
   // validation feedback.  The LiveRegion component renders this via
   // aria-live="polite" so screen readers pick it up without focus moves.
   const [srAnnouncement, setSrAnnouncement] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
   const helpTriggerRef = useRef<HTMLButtonElement>(null);
   const previewTriggerRef = useRef<HTMLButtonElement>(null);
   const { isReducedMotionActive } = useReducedMotion();

--- a/src/pages/__tests__/RepayPage.test.tsx
+++ b/src/pages/__tests__/RepayPage.test.tsx
@@ -141,6 +141,17 @@ describe('RepayPage', () => {
     expect(reviewBtn).not.toBeDisabled();
   });
 
+  it('Preview Consequences Modal button is rendered and enabled when amount is set', () => {
+    renderPage(['/repay?line=CL-2024-001']);
+    const previewBtn = screen.getByRole('button', { name: /preview consequences modal/i });
+    expect(previewBtn).toBeInTheDocument();
+    expect(previewBtn).toBeDisabled();
+
+    // Click Smart Pay to fill the amount, which should enable the preview button
+    fireEvent.click(screen.getByRole('button', { name: /smart pay/i }));
+    expect(previewBtn).not.toBeDisabled();
+  });
+
   describe('Focus-visible outline accessibility', () => {
     it('applies focus-visible classes on selection view back button and credit line options', () => {
       renderPage(['/repay']);


### PR DESCRIPTION
Closes #465 

Fix regression from merge conflicts: restore missing isLoading and isPreviewModalOpen state declarations in RepayPage.tsx that were dropped during conflict resolution. Without these, RepayPage crashes with ReferenceError.