### PR TITLE
feat: add visible focus-visible outlines on CreditLines interactive e…

### DIFF
--- a/src/pages/CreditLines.tsx
+++ b/src/pages/CreditLines.tsx
@@ -171,6 +171,7 @@ function CreditLineCard({
                checked={isSelected}
                onChange={onToggle}
                aria-label={`Select ${line.name} for comparison`}
+               className="focus-ring"
              />
              <span>Compare</span>
            </label>
@@ -824,7 +825,7 @@ export default function CreditLines({ defaultLoading = true }: { defaultLoading?
               <li>Competitive rates from 7.5% APR</li>
               <li>Quick approval with digital collateral</li>
             </ul>
-            <Link to="/open-credit" className="cl-primary-btn">
+            <Link to="/open-credit" className="cl-primary-btn focus-ring">
               Open Credit Line
             </Link>
           }

--- a/src/styles/focus.css
+++ b/src/styles/focus.css
@@ -234,12 +234,26 @@
 /*
   GrantFox FWC26 (Stellar Wave) — "Visible focus outline on keyboard-only
   nav for CreditLines" requirement.
+
+  Every interactive element on the CreditLines page that is reachable via
+  Tab must show a visible focus ring on keyboard navigation (:focus-visible).
+
+  Covered here:
+    .cl-primary-btn             — header action buttons / links
+    .cl-sort-dir                — sort-direction toggle button
+    .cl-card                    — credit-line cards (keyboard-focusable container)
+    .cl-filters select          — status / sort-by dropdowns
+    .cl-row-select input        — per-card compare checkboxes
+    [aria-haspopup="true"]      — CreditLineRowMenu 3-dot trigger (belt-and-suspenders
+                                  fallback in case Tailwind utilities aren't active)
 */
 
 .cl-primary-btn:focus-visible,
 .cl-sort-dir:focus-visible,
 .cl-card:focus-visible,
-.cl-filters select:focus-visible {
+.cl-filters select:focus-visible,
+.cl-row-select input:focus-visible,
+.cl-card [aria-haspopup="true"]:focus-visible {
   outline: var(--focus-ring-width, 2px) solid var(--focus-ring-color, #58a6ff);
   outline-offset: var(--focus-ring-offset, 3px);
   border-radius: var(--focus-ring-radius, 6px);

--- a/src/styles/focus.test.tsx
+++ b/src/styles/focus.test.tsx
@@ -201,12 +201,27 @@ describe('Dashboard — focus-ring classes on interactive elements (FWC26)', () 
 // ── CreditLines integration tests ─────────────────────────────────────────
 
 describe('CreditLines — focus-ring classes on interactive elements (FWC26)', () => {
+  const cssPath = resolve(__dirname, '../styles/focus.css');
+  const css = readFileSync(cssPath, 'utf-8');
+
   it('defines CreditLines-specific focus rules in focus.css', () => {
-    const cssPath = resolve(__dirname, '../styles/focus.css');
-    const css = readFileSync(cssPath, 'utf-8');
     expect(css).toContain('.cl-primary-btn:focus-visible');
     expect(css).toContain('.cl-sort-dir:focus-visible');
     expect(css).toContain('.cl-card:focus-visible');
+  });
+
+  it('defines focus rule for filter dropdown selects', () => {
+    expect(css).toContain('.cl-filters select:focus-visible');
+  });
+
+  it('defines focus rule for compare checkboxes in CreditLineCard rows', () => {
+    expect(css).toContain('.cl-row-select input:focus-visible');
+  });
+
+  it('defines focus fallback for CreditLineRowMenu 3-dot trigger button', () => {
+    // The trigger uses aria-haspopup="true" — our fallback ensures
+    // a visible ring even if Tailwind utilities are unavailable.
+    expect(css).toContain('.cl-card [aria-haspopup="true"]:focus-visible');
   });
 });
 


### PR DESCRIPTION
…lements

- Add focus-ring class to empty state 'Open Credit Line' Link
- Add focus-ring class to compare checkbox inputs in CreditLineCard
- Add .cl-row-select input:focus-visible rule to focus.css
- Add .cl-card [aria-haspopup=true]:focus-visible fallback for CreditLineRowMenu
- Expand focus.css CreditLines documentation with all covered elements
- Add focused tests for new focus rules in focus.test.tsx

Closes #661