### PR TITLE
Fix #658: Add sticky action bar primary actions on LinkedAccounts

### DIFF
--- a/src/pages/LinkedAccounts.test.tsx
+++ b/src/pages/LinkedAccounts.test.tsx
@@ -543,5 +543,54 @@ describe('LinkedAccounts', () => {
 
       expect(linkedAccountsService.initiateLinkAccount).toHaveBeenCalledWith({ provider: 'google' });
     });
+
+    it('has disconnect all button when accounts are linked', async () => {
+      vi.mocked(linkedAccountsService.fetchLinkedAccounts).mockResolvedValue(mockAccounts);
+
+      render(<LinkedAccounts />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /disconnect all accounts from toolbar/i })).toBeInTheDocument();
+      });
+    });
+
+    it('calls disconnectAccount for all connected accounts when disconnect all is confirmed', async () => {
+      const user = userEvent.setup();
+      const multiAccounts: LinkedAccount[] = [
+        ...mockAccounts,
+        {
+          id: 'github-456',
+          provider: 'github',
+          status: 'connected',
+          displayName: 'Test User',
+          externalId: 'test@github.com',
+          connectedAt: '2026-01-01T00:00:00Z',
+          lastVerified: '2026-06-28T00:00:00Z',
+        }
+      ];
+      
+      vi.mocked(linkedAccountsService.fetchLinkedAccounts)
+        .mockResolvedValueOnce(multiAccounts)
+        .mockResolvedValueOnce([]);
+      vi.mocked(linkedAccountsService.disconnectAccount).mockResolvedValue();
+
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+      render(<LinkedAccounts />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /disconnect all accounts from toolbar/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /disconnect all accounts from toolbar/i }));
+
+      expect(confirmSpy).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(linkedAccountsService.disconnectAccount).toHaveBeenCalledWith('google-123');
+        expect(linkedAccountsService.disconnectAccount).toHaveBeenCalledWith('github-456');
+      });
+
+      confirmSpy.mockRestore();
+    });
   });
 });

--- a/src/pages/LinkedAccounts.tsx
+++ b/src/pages/LinkedAccounts.tsx
@@ -292,6 +292,30 @@ export function LinkedAccounts() {
     }
   };
 
+  const handleDisconnectAll = async () => {
+    const connectedAccounts = accounts.filter(acc => acc.status === 'connected');
+    if (connectedAccounts.length === 0) return;
+
+    const confirmed = window.confirm(
+      'Are you sure you want to disconnect all your accounts? You can reconnect them later.'
+    );
+    if (!confirmed) return;
+
+    try {
+      setActionLoading(true);
+      setError(null);
+      
+      await Promise.all(connectedAccounts.map(acc => disconnectAccount(acc.id)));
+      showSuccessMessage('All accounts disconnected successfully');
+      await loadAccounts();
+    } catch (err) {
+      setError('Failed to disconnect some accounts. Please try again.');
+      console.error('Disconnect all error:', err);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
   const connectedCount = useMemo(
     () => accounts.filter((a) => a.status === 'connected').length,
     [accounts],
@@ -447,6 +471,17 @@ export function LinkedAccounts() {
               <LinkIcon className="icon-sm" aria-hidden="true" />
               <span className="sticky-action-bar__label">Connect</span>
             </PendingButton>
+            {connectedCount > 0 && (
+              <button
+                onClick={handleDisconnectAll}
+                disabled={actionLoading}
+                className="btn-danger btn-sm"
+                aria-label="Disconnect all accounts from toolbar"
+              >
+                <Unlink className="icon-sm" aria-hidden="true" />
+                <span className="sticky-action-bar__label">Disconnect All</span>
+              </button>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Pull Request: Add sticky action bar primary actions on LinkedAccounts

**Closes #658 **

## Summary

This PR addresses a UI/UX improvement for the GrantFox FWC26 campaign (Stellar Wave) by fully implementing the primary actions on the `LinkedAccounts` sticky bottom action bar. It introduces a `handleDisconnectAll` action and its corresponding "Disconnect All" button that appears on scroll when one or more accounts are connected, providing users with quick access to global connection management.

## Changes

### 1. `src/pages/LinkedAccounts.tsx` — Disconnect All Implementation
- Added a `handleDisconnectAll` function which filters for active accounts, triggers a native browser confirmation dialog, and executes concurrent API calls to gracefully disconnect all active providers.
- Integrated a new primary action button (`<button className="btn-danger btn-sm">`) to the `.sticky-action-bar__actions` container. 
- Used conditional rendering so the "Disconnect All" button is only visible when `connectedCount > 0`.

### 2. `src/pages/LinkedAccounts.test.tsx` — Test Coverage
- Added a rendering test: verifies that the "Disconnect all accounts from toolbar" button successfully mounts when linked accounts exist in the state.
- Added an interaction test: verifies that clicking the new button fires the `window.confirm` dialog and then correctly maps over and calls `disconnectAccount` for each active provider account ID.

## Accessibility (WCAG 2.1 AA)

- **Touch Targets:** The new button leverages the existing `.btn-sm` class which enforces a 44px minimum touch target height.
- **Focus Management:** The button includes the standard `focus-visible` outlines defined by the design system, ensuring keyboard users can clearly see when they reach the toolbar.
- **Aria Labels:** Included a descriptive `aria-label="Disconnect all accounts from toolbar"` attribute to differentiate it from individual card-level disconnect buttons for screen readers.
- **Color Contrast:** The button uses the `.btn-danger` variant ensuring it stands out functionally and maintains AA text-to-background contrast against the `bg-surface` bar.

## Test Results

Unit tests have been created to target the new component interactions and state rendering. All new tests pass alongside the existing suite. 