### PR TITLE
Fix #657: Polish Breadcrumb middle-ellipsis logic and increase thresh…

### DIFF
--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -31,14 +31,14 @@ export interface BreadcrumbProps {
  * Middle-ellipsis helper: trims the center of a string while preserving the
  * first and last few characters, inserting `\u2026` (…) in between.
  *
- * For a string of `n` characters we keep `head = ceil(n/3)` and
- * `tail = floor(n/3)` characters, which keeps both the recognisable prefix
- * and any file-extension / identifier suffix visible.
+ * It preserves as many characters as possible up to `maxLen` by dividing
+ * the remaining characters equally between the head and tail.
  */
 export function middleEllipsis(text: string, maxLen: number): string {
   if (text.length <= maxLen) return text;
-  const head = Math.ceil(maxLen / 3);
-  const tail = Math.floor(maxLen / 3);
+  const charsToKeep = Math.max(0, maxLen - 1);
+  const head = Math.ceil(charsToKeep / 2);
+  const tail = Math.floor(charsToKeep / 2);
   return `${text.slice(0, head)}\u2026${text.slice(-tail)}`;
 }
 

--- a/src/components/__tests__/Breadcrumb.test.tsx
+++ b/src/components/__tests__/Breadcrumb.test.tsx
@@ -25,8 +25,8 @@ describe('middleEllipsis', () => {
     const result = middleEllipsis('ABCDEFGHIJKLMNOP', 8);
     const parts = result.split('\u2026');
     expect(parts).toHaveLength(2);
-    expect(parts[0]).toBe('ABC');
-    expect(parts[1]).toBe('OP');
+    expect(parts[0]).toBe('ABCD');
+    expect(parts[1]).toBe('NOP');
   });
 });
 

--- a/src/pages/RepayCalendar.tsx
+++ b/src/pages/RepayCalendar.tsx
@@ -59,7 +59,7 @@ export default function RepayCalendar() {
 
   return (
     <div className="repay-calendar mx-auto max-w-4xl space-y-6 px-4 py-6 sm:py-8">
-      <Breadcrumb items={breadcrumbItems} />
+      <Breadcrumb items={breadcrumbItems} ellipsisThreshold={36} />
 
       <button
         type="button"


### PR DESCRIPTION
# Pull Request: Polish RepayCalendar breadcrumb overflow with middle-ellipsis

**Closes #657 **

## Summary

This PR addresses a UI/UX improvement for the GrantFox FWC26 campaign (Stellar Wave). It corrects a bug in the global `middleEllipsis` truncation logic that previously over-truncated strings, and specifically adjusts the `RepayCalendar` page to allow enough space for long credit line names within its breadcrumb layout. 

## Changes

### 1. `src/components/Breadcrumb.tsx` — Logic Correction
- Refactored the `middleEllipsis` math logic. The previous math unintentionally limited the string length to roughly ~2/3 of `maxLen`. 
- The updated calculation correctly allocates exactly `(maxLen - 1) / 2` characters to the `head` and `tail`, maximizing visible characters while preserving identifiers exactly up to the configured limit threshold.

### 2. `src/pages/RepayCalendar.tsx` — UI Polish
- Increased the `ellipsisThreshold` passed to the `<Breadcrumb />` component on this page from the default `24` up to `36`. 
- Since the text prefix alone (`"Repayment Calendar — "`) is 21 characters long, this increase ensures that long dynamic credit line names aren't severely clipped and remain recognizable on narrower viewports.

### 3. `src/components/__tests__/Breadcrumb.test.tsx` — Test Updates
- Updated the assertions targeting the `middleEllipsis` helper logic to correctly assert against the newly calculated distribution of string chunks.

## Accessibility (WCAG 2.1 AA)

- Semantic DOM landmarks and `title` properties on the truncated DOM elements remain fully intact; users relying on assistive technologies or pointer hovers will still be able to access the full unstructured label text regardless of the ellipsis truncation.
- Maintained all existing accessibility configurations like `<nav aria-label="Breadcrumb">` and native `aria-current="page"`.

## Test Results

The underlying `middleEllipsis` logic assertions were thoroughly adjusted and verified. All existing component-level truncation tests naturally passed since they rely on matching generic ellipsis formatting behavior.