### PR TITLE
fix: add tabular-nums to numeric displays on RepayPage (FWC26)

### DIFF
--- a/src/components/PayoffProjection.tsx
+++ b/src/components/PayoffProjection.tsx
@@ -126,7 +126,7 @@ export function PayoffProjection({
                 <p className="text-xs font-medium text-muted">Months saved</p>
               </div>
               <p
-                className="mt-1 text-2xl font-bold text-accent"
+                className="mt-1 text-2xl font-bold text-accent num-tabular"
                 role="status"
                 aria-live="polite"
               >
@@ -144,7 +144,7 @@ export function PayoffProjection({
                 <p className="text-xs font-medium text-muted">Interest saved</p>
               </div>
               <p
-                className="mt-1 text-2xl font-bold text-success"
+                className="mt-1 text-2xl font-bold text-success num-tabular"
                 role="status"
                 aria-live="polite"
               >
@@ -162,7 +162,7 @@ export function PayoffProjection({
               <p className="text-xs font-medium text-muted">
                 Utilization
               </p>
-              <span className="text-xs text-muted">
+              <span className="text-xs text-muted num-tabular">
                 {projection.currentUtilizationPct}% → {projection.newUtilizationPct}%
               </span>
             </div>
@@ -187,7 +187,7 @@ export function PayoffProjection({
           <div className="flex items-center justify-between">
             <div>
               <p className="text-xs font-medium text-muted">Monthly payment</p>
-              <p className="mt-0.5 text-sm font-semibold text-foreground">
+              <p className="mt-0.5 text-sm font-semibold text-foreground num-tabular">
                 {formatMoney(monthlyPayment)}
               </p>
             </div>

--- a/src/components/__tests__/PayoffProjection.test.tsx
+++ b/src/components/__tests__/PayoffProjection.test.tsx
@@ -77,4 +77,48 @@ describe('PayoffProjection', () => {
     );
     expect(screen.getByText('Monthly payment')).toBeInTheDocument();
   });
+
+  describe('tabular-nums on numeric displays (FWC26)', () => {
+    it('months saved value has num-tabular class', () => {
+      const { container } = render(<PayoffProjection {...BASE_PROPS} repayAmount={20_000} />);
+      const monthsSaved = container.querySelector('.text-2xl.font-bold.text-accent.num-tabular');
+      expect(monthsSaved).toBeInTheDocument();
+      expect(monthsSaved?.classList.contains('num-tabular')).toBe(true);
+    });
+
+    it('interest saved value has num-tabular class', () => {
+      const { container } = render(<PayoffProjection {...BASE_PROPS} repayAmount={20_000} />);
+      const interestSaved = container.querySelector('.text-2xl.font-bold.text-success.num-tabular');
+      expect(interestSaved).toBeInTheDocument();
+      expect(interestSaved?.classList.contains('num-tabular')).toBe(true);
+    });
+
+    it('utilization percentage span has num-tabular class', () => {
+      const { container } = render(<PayoffProjection {...BASE_PROPS} repayAmount={20_000} />);
+      const utilSpan = container.querySelector('.text-xs.text-muted.num-tabular');
+      expect(utilSpan).toBeInTheDocument();
+      expect(utilSpan?.classList.contains('num-tabular')).toBe(true);
+    });
+
+    it('monthly payment value has num-tabular class', () => {
+      const { container } = render(<PayoffProjection {...BASE_PROPS} repayAmount={20_000} />);
+      const monthlyPayment = container.querySelector('.text-sm.font-semibold.text-foreground.num-tabular');
+      expect(monthlyPayment).toBeInTheDocument();
+      expect(monthlyPayment?.classList.contains('num-tabular')).toBe(true);
+    });
+
+    it('months saved retains num-tabular in full payoff state', () => {
+      const { container } = render(<PayoffProjection {...BASE_PROPS} repayAmount={100_000} />);
+      const fullPayoffEl = container.querySelector('.text-2xl.font-bold.text-accent.num-tabular');
+      expect(fullPayoffEl).toBeInTheDocument();
+    });
+
+    it('interest saved retains num-tabular in empty state (no amount)', () => {
+      const { container } = render(<PayoffProjection {...BASE_PROPS} repayAmount={0} />);
+      // When no amount, the interest/months section isn't rendered, but the
+      // monthly payment is always shown and should still have num-tabular
+      const monthlyPayment = container.querySelector('.text-sm.font-semibold.text-foreground.num-tabular');
+      expect(monthlyPayment).toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/RepayPage.test.tsx
+++ b/src/pages/RepayPage.test.tsx
@@ -13,10 +13,9 @@
  * requires a real browser and visual regression testing.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { BrowserRouter } from 'react-router-dom';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import RepayPage from './RepayPage';
 
 // ── Module mocks ─────────────────────────────────────────────────────────
@@ -43,71 +42,107 @@ vi.mock('../utils/storage', () => ({
   writeJson: vi.fn(),
 }));
 
+vi.mock('../data/mockData', () => ({
+  MOCK_CREDIT_LINES: [
+    {
+      id: 'CL-2024-001',
+      name: 'Primary Business Line',
+      status: 'Active',
+      limit: 500000,
+      utilized: 187500,
+      apr: 8.5,
+      riskScore: 720,
+      collateral: 'Commercial Real Estate',
+      openedAt: '2024-03-15',
+      updatedAt: '2025-02-20T14:32:00Z',
+      nextPaymentDate: '2025-03-01',
+      nextPaymentAmount: 3200,
+      transactions: [],
+      statusHistory: [],
+      aprHistory: [],
+    },
+  ],
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Render the RepayPage with a preselected credit line and advance fake timers
+ * past the initial loading skeleton timeout (800 ms).
+ */
+function renderWithLine(initialEntries = ['/?line=CL-2024-001']) {
+  const result = render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <RepayPage />
+    </MemoryRouter>,
+  );
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+  return result;
+}
+
+/**
+ * Render the RepayPage without a preselected line (credit line selection screen).
+ */
+function renderWithoutLine() {
+  const result = render(
+    <MemoryRouter initialEntries={['/repay']}>
+      <RepayPage />
+    </MemoryRouter>,
+  );
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+  return result;
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────
 
 describe('RepayPage — tabular-nums on numeric displays (FWC26)', () => {
-  function renderRepayPageWithLine() {
-    return render(
-      <BrowserRouter>
-        <RepayPage />
-      </BrowserRouter>,
-      {
-        initialEntries: ['/?line=credit-line-1'],
-      }
-    );
-  }
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   describe('Credit line selection screen (no line preselected)', () => {
     it('should render utilization percentage with num-tabular class', () => {
-      const { container } = render(
-        <BrowserRouter>
-          <RepayPage />
-        </BrowserRouter>
-      );
+      const { container } = renderWithoutLine();
 
-      // The credit lines list displays utilization as "X% utilized"
-      // with the percentage wrapped in num-tabular
       const pctSpans = container.querySelectorAll('.num-tabular');
-      // At minimum, there should be utilization percentages
       expect(pctSpans.length).toBeGreaterThan(0);
     });
 
     it('should render credit line utilized amount with num-tabular class', () => {
-      const { container } = render(
-        <BrowserRouter>
-          <RepayPage />
-        </BrowserRouter>
-      );
+      const { container } = renderWithoutLine();
 
-      // The utilization percentage elements should have num-tabular
       const pctElements = container.querySelectorAll(
-        '.text-right p:first-child, .text-right .num-tabular'
+        '.text-right p:first-child, .text-right .num-tabular',
       );
-      // Verify at least one numeric display element exists
       expect(pctElements.length).toBeGreaterThanOrEqual(0);
     });
   });
 
   describe('Input step — numeric displays', () => {
     it('current debt value should carry num-tabular class', () => {
-      const { container } = renderRepayPageWithLine();
+      const { container } = renderWithLine();
 
-      // Look for the "Current debt" section with a large value
       const debtValue = container.querySelector(
-        '.text-3xl.font-bold.num-tabular'
+        '.text-3xl.font-bold.num-tabular',
       );
       expect(debtValue).toBeInTheDocument();
       expect(debtValue?.classList.contains('num-tabular')).toBe(true);
     });
 
     it('utilization limit should carry num-tabular class', () => {
-      const { container } = renderRepayPageWithLine();
+      const { container } = renderWithLine();
 
-      // "X% of $Y limit" — both should have num-tabular
       const pctElements = container.querySelectorAll(
-        '.text-xs.text-muted .num-tabular'
+        '.text-xs.text-muted .num-tabular',
       );
-      // Should find at least the percentage and limit amount
       expect(pctElements.length).toBeGreaterThanOrEqual(2);
       pctElements.forEach((el) => {
         expect(el.classList.contains('num-tabular')).toBe(true);
@@ -115,104 +150,91 @@ describe('RepayPage — tabular-nums on numeric displays (FWC26)', () => {
     });
 
     it('wallet balance should carry num-tabular class', () => {
-      const { container } = renderRepayPageWithLine();
+      const { container } = renderWithLine();
 
-      // "Wallet: $X" in the Amount to repay section
-      const walletSpan = container.querySelector(
-        '.text-xs.text-muted:has(.num-tabular)'
-      );
-      // Verify wallet balance is displayed (may be 0 in mock)
       const tabularSpans = Array.from(
-        container.querySelectorAll('.text-xs.text-muted .num-tabular')
+        container.querySelectorAll('.text-xs.text-muted .num-tabular'),
       );
       expect(tabularSpans.length).toBeGreaterThan(0);
     });
 
     it('preview: remaining debt should carry num-tabular class', () => {
-      const { container } = renderRepayPageWithLine();
+      const { container } = renderWithLine();
 
-      // Enter a repay amount to trigger preview updates
       const input = container.querySelector(
-        'input[id="repay-amount"]'
+        'input[id="repay-amount"]',
       ) as HTMLInputElement;
       expect(input).toBeInTheDocument();
 
-      // The remaining debt values in the preview section should have num-tabular
-      const previewSpans = container.querySelectorAll(
-        '.rounded-lg.border.border-border.bg-surface p:last-of-type .num-tabular'
-      );
-      // Verify tabular-nums class is applied (may be 0+ depending on layout)
       const allTabularInPreview = Array.from(
-        container.querySelectorAll('.space-y-3 .num-tabular')
+        container.querySelectorAll('.space-y-3 .num-tabular'),
       );
       expect(allTabularInPreview.length).toBeGreaterThanOrEqual(0);
     });
 
     it('preview: utilization percentage (new and old) should carry num-tabular class', () => {
-      const { container } = renderRepayPageWithLine();
+      const { container } = renderWithLine();
 
-      // Look for "New utilization" section with both old and new percentages
-      // Both the new and old (strikethrough) percentages should be wrapped in num-tabular
       const allTabularSpans = container.querySelectorAll('.num-tabular');
-      // Should include percentages from the preview section
       allTabularSpans.forEach((span) => {
         expect(span.classList.contains('num-tabular')).toBe(true);
       });
     });
 
-    it('APR in header should carry num-tabular class', () => {
-      const { container } = renderRepayPageWithLine();
+    it('APR in header should carry num-tabular class (FWC26)', () => {
+      const { container } = renderWithLine();
 
-      // APR is displayed as "X% APR" in the header
       const aprSpan = container.querySelector(
-        'p.text-sm.text-muted .num-tabular'
+        'p.text-sm.text-muted .num-tabular',
       );
-      // APR percentage should be wrapped
-      if (aprSpan) {
-        expect(aprSpan.classList.contains('num-tabular')).toBe(true);
-      }
+      expect(aprSpan).toBeInTheDocument();
+      expect(aprSpan?.classList.contains('num-tabular')).toBe(true);
+    });
+
+    it('repay amount input should carry num-tabular class (FWC26)', () => {
+      const { container } = renderWithLine();
+
+      const input = container.querySelector('input#repay-amount');
+      expect(input).toBeInTheDocument();
+      expect(input?.classList.contains('num-tabular')).toBe(true);
     });
   });
 
   describe('Review step — numeric displays', () => {
-    it('review: amount to repay should carry num-tabular class', async () => {
-      const { container } = renderRepayPageWithLine();
+    it('review: amount to repay should carry num-tabular class', () => {
+      const { container } = renderWithLine();
 
-      // Enter a valid amount to trigger review
       const input = container.querySelector(
-        'input[id="repay-amount"]'
+        'input[id="repay-amount"]',
       ) as HTMLInputElement;
-      const user = userEvent.setup();
-      await user.type(input, '100');
+      fireEvent.change(input, { target: { value: '100' } });
 
-      // Find and click the Review button
       const reviewBtn = screen.queryByText(/Review Repayment/i);
       if (reviewBtn) {
-        await user.click(reviewBtn);
+        fireEvent.click(reviewBtn);
 
-        // In review step, the amount should have num-tabular class
-        const reviewAmount = container.querySelector('.text-4xl.font-bold.num-tabular');
+        const reviewAmount = container.querySelector(
+          '.text-4xl.font-bold.num-tabular',
+        );
         expect(reviewAmount).toBeInTheDocument();
         expect(reviewAmount?.classList.contains('num-tabular')).toBe(true);
       }
     });
 
-    it('review: remaining debt after should carry num-tabular class', async () => {
-      const { container } = renderRepayPageWithLine();
+    it('review: remaining debt after should carry num-tabular class', () => {
+      const { container } = renderWithLine();
 
       const input = container.querySelector(
-        'input[id="repay-amount"]'
+        'input[id="repay-amount"]',
       ) as HTMLInputElement;
-      const user = userEvent.setup();
-      await user.type(input, '50');
+      fireEvent.change(input, { target: { value: '50' } });
 
       const reviewBtn = screen.queryByText(/Review Repayment/i);
       if (reviewBtn) {
-        await user.click(reviewBtn);
+        fireEvent.click(reviewBtn);
 
-        // Verify remaining debt is wrapped in num-tabular
         const debtElements = container.querySelectorAll(
-          '.space-y-3 .font-semibold.num-tabular'
+          '.space-y-3 .font-semibold.num-tabular',
         );
         expect(debtElements.length).toBeGreaterThan(0);
         debtElements.forEach((el) => {
@@ -221,22 +243,20 @@ describe('RepayPage — tabular-nums on numeric displays (FWC26)', () => {
       }
     });
 
-    it('review: wallet balance should carry num-tabular class', async () => {
-      const { container } = renderRepayPageWithLine();
+    it('review: wallet balance should carry num-tabular class', () => {
+      const { container } = renderWithLine();
 
       const input = container.querySelector(
-        'input[id="repay-amount"]'
+        'input[id="repay-amount"]',
       ) as HTMLInputElement;
-      const user = userEvent.setup();
-      await user.type(input, '100');
+      fireEvent.change(input, { target: { value: '100' } });
 
       const reviewBtn = screen.queryByText(/Review Repayment/i);
       if (reviewBtn) {
-        await user.click(reviewBtn);
+        fireEvent.click(reviewBtn);
 
-        // Wallet balance in review should have num-tabular
         const balanceSpans = container.querySelectorAll(
-          '.text-success.num-tabular'
+          '.text-success.num-tabular',
         );
         expect(balanceSpans.length).toBeGreaterThan(0);
         balanceSpans.forEach((el) => {
@@ -247,60 +267,54 @@ describe('RepayPage — tabular-nums on numeric displays (FWC26)', () => {
   });
 
   describe('Success step — numeric displays', () => {
-    it('success: repaid amount should carry num-tabular class', async () => {
-      const { container } = renderRepayPageWithLine();
+    it('success: repaid amount should carry num-tabular class', () => {
+      const { container } = renderWithLine();
 
       const input = container.querySelector(
-        'input[id="repay-amount"]'
+        'input[id="repay-amount"]',
       ) as HTMLInputElement;
-      const user = userEvent.setup();
-      await user.type(input, '100');
+      fireEvent.change(input, { target: { value: '100' } });
 
-      // Click Review
       const reviewBtn = screen.queryByText(/Review Repayment/i);
       if (reviewBtn) {
-        await user.click(reviewBtn);
+        fireEvent.click(reviewBtn);
 
-        // Click Confirm (if no verification needed)
         const confirmBtn = screen.queryByText(/Confirm Repayment/i);
         if (confirmBtn && !confirmBtn.hasAttribute('disabled')) {
-          await user.click(confirmBtn);
+          fireEvent.click(confirmBtn);
 
-          // Check success text includes tabular-nums on the amount
           const successText = container.querySelector(
-            'h2.text-2xl.font-bold.text-foreground'
+            'h2.text-2xl.font-bold.text-foreground',
           );
           if (successText) {
             const tabularInSuccess = successText.querySelector('.num-tabular');
             expect(tabularInSuccess).toBeInTheDocument();
             expect(tabularInSuccess?.classList.contains('num-tabular')).toBe(
-              true
+              true,
             );
           }
         }
       }
     });
 
-    it('success: remaining debt should carry num-tabular class', async () => {
-      const { container } = renderRepayPageWithLine();
+    it('success: remaining debt should carry num-tabular class', () => {
+      const { container } = renderWithLine();
 
       const input = container.querySelector(
-        'input[id="repay-amount"]'
+        'input[id="repay-amount"]',
       ) as HTMLInputElement;
-      const user = userEvent.setup();
-      await user.type(input, '50');
+      fireEvent.change(input, { target: { value: '50' } });
 
       const reviewBtn = screen.queryByText(/Review Repayment/i);
       if (reviewBtn) {
-        await user.click(reviewBtn);
+        fireEvent.click(reviewBtn);
 
         const confirmBtn = screen.queryByText(/Confirm Repayment/i);
         if (confirmBtn && !confirmBtn.hasAttribute('disabled')) {
-          await user.click(confirmBtn);
+          fireEvent.click(confirmBtn);
 
-          // In success card, remaining debt should have num-tabular
           const successDebt = container.querySelector(
-            '.bg-surface.p-4.text-left .num-tabular'
+            '.bg-surface.p-4.text-left .num-tabular',
           );
           expect(successDebt).toBeInTheDocument();
           expect(successDebt?.classList.contains('num-tabular')).toBe(true);
@@ -308,28 +322,26 @@ describe('RepayPage — tabular-nums on numeric displays (FWC26)', () => {
       }
     });
 
-    it('success: utilization percentage should carry num-tabular class', async () => {
-      const { container } = renderRepayPageWithLine();
+    it('success: utilization percentage should carry num-tabular class', () => {
+      const { container } = renderWithLine();
 
       const input = container.querySelector(
-        'input[id="repay-amount"]'
+        'input[id="repay-amount"]',
       ) as HTMLInputElement;
-      const user = userEvent.setup();
-      await user.type(input, '75');
+      fireEvent.change(input, { target: { value: '75' } });
 
       const reviewBtn = screen.queryByText(/Review Repayment/i);
       if (reviewBtn) {
-        await user.click(reviewBtn);
+        fireEvent.click(reviewBtn);
 
         const confirmBtn = screen.queryByText(/Confirm Repayment/i);
         if (confirmBtn && !confirmBtn.hasAttribute('disabled')) {
-          await user.click(confirmBtn);
+          fireEvent.click(confirmBtn);
 
-          // The percentage reduction ("Reduced to X%") should have num-tabular
           const successText = container.textContent;
           if (successText?.includes('Reduced to')) {
             const reducedText = container.querySelector(
-              '.bg-surface.p-4.text-left'
+              '.bg-surface.p-4.text-left',
             );
             const pctElement = reducedText?.querySelector('.num-tabular');
             expect(pctElement).toBeInTheDocument();
@@ -342,14 +354,13 @@ describe('RepayPage — tabular-nums on numeric displays (FWC26)', () => {
 
   describe('CSS class utility verification', () => {
     it('should not have style regressions at mobile breakpoint', () => {
-      // Verify that num-tabular class exists and is applied
-      const { container } = renderRepayPageWithLine();
+      const { container } = renderWithLine();
       const tabularElements = container.querySelectorAll('.num-tabular');
       expect(tabularElements.length).toBeGreaterThan(0);
     });
 
     it('all num-tabular elements should be valid DOM nodes', () => {
-      const { container } = renderRepayPageWithLine();
+      const { container } = renderWithLine();
       const tabularElements = container.querySelectorAll('.num-tabular');
       tabularElements.forEach((el) => {
         expect(el).toBeInstanceOf(Element);

--- a/src/pages/RepayPage.tsx
+++ b/src/pages/RepayPage.tsx
@@ -99,8 +99,6 @@ export default function RepayPage() {
   // validation feedback.  The LiveRegion component renders this via
   // aria-live="polite" so screen readers pick it up without focus moves.
   const [srAnnouncement, setSrAnnouncement] = useState('');
-  const [isLoading, setIsLoading] = useState(true);
-  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
   const helpTriggerRef = useRef<HTMLButtonElement>(null);
   const previewTriggerRef = useRef<HTMLButtonElement>(null);
   const { isReducedMotionActive } = useReducedMotion();
@@ -387,7 +385,7 @@ export default function RepayPage() {
               : 'Make a repayment'}
           </h1>
           <p className="text-sm text-muted">
-            {selectedLine.name} &middot; {selectedLine.apr}% APR
+            {selectedLine.name} &middot; <span className="num-tabular">{selectedLine.apr}%</span> APR
           </p>
         </header>
 
@@ -484,7 +482,7 @@ export default function RepayPage() {
                       min={1}
                       step={0.01}
                       aria-invalid={validation?.feedback.severity === 'danger' || undefined}
-                      className={`rp-amount-input w-full rounded-lg border bg-background px-3 py-3 pl-8 text-lg font-semibold text-foreground outline-none focus:ring-2 focus:ring-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${motionClasses(isReducedMotionActive, 'transition-colors')}`}
+                      className={`rp-amount-input num-tabular w-full rounded-lg border bg-background px-3 py-3 pl-8 text-lg font-semibold text-foreground outline-none focus:ring-2 focus:ring-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${motionClasses(isReducedMotionActive, 'transition-colors')}`}
                       style={{
                         // Task tokens-v7: token-referenced colors only — no raw hex.
                         borderColor:


### PR DESCRIPTION
## 📋 Summary

**Closes #662** — Apply `font-variant-numeric: tabular-nums` to numeric displays on RepayPage (GrantFox FWC26 / Stellar Wave campaign).

This PR ensures all monetary amounts, percentages, and counts on the RepayPage (including its embedded PayoffProjection component) use tabular numerals so digits align vertically and don't cause horizontal "jitter" as values change during live repayment previews or step transitions.

---

## 🔍 Problem

When users type a repayment amount or step through the RepayPage flow, numeric values (e.g., `$1,000.00` → `$10,000.00`) shift horizontally because proportional-width digits vary in advance width. This is disorienting, especially in side-by-side before/after comparisons like "New utilization: 38% ~~45%~~".

The existing `.num-tabular` class (defined in `src/styles/typography.css`) was already applied to *most* RepayPage numeric displays, but several were missed — notably the PayoffProjection component rendered inline on the page, the APR percentage in the header, and the amount input field.

---

## ✅ Changes

### 1. `src/components/PayoffProjection.tsx` — 4 numeric displays
Added `num-tabular` class to:

| Element | Before | After |
|---|---|---|
| Months saved count | `text-2xl font-bold text-accent` | `text-2xl font-bold text-accent num-tabular` |
| Interest saved amount | `text-2xl font-bold text-success` | `text-2xl font-bold text-success num-tabular` |
| Utilization % span | `text-xs text-muted` | `text-xs text-muted num-tabular` |
| Monthly payment value | `text-sm font-semibold text-foreground` | `text-sm font-semibold text-foreground num-tabular` |

Non-numeric values (`'—'` for full payoff) are unaffected — `font-variant-numeric` only affects digit glyphs.

### 2. `src/pages/RepayPage.tsx` — 2 numeric displays + 1 bug fix

| Change | Detail |
|---|---|
| APR in header | Wrapped `{selectedLine.apr}%` in `<span className="num-tabular">` |
| Amount input field | Added `num-tabular` to `#repay-amount` `<input>` class (matches `AmountInput` component pattern) |
| **Bug fix** | Removed duplicate `useState` declarations for `isLoading` and `isPreviewModalOpen` — both were declared twice, causing "already been declared" errors at compile time |

### 3. `src/styles/typography.css` — No changes needed
The `.num-tabular` utility class already exists with:
```css
.num-tabular,
.tabular-nums,
.amount,
[data-amount] {
  font-variant-numeric: tabular-nums;
  font-feature-settings: "tnum" 1;
}
```

### 4. `src/components/__tests__/PayoffProjection.test.tsx` — +6 tests
New `tabular-nums on numeric displays (FWC26)` describe block:
- Months saved value has `num-tabular`
- Interest saved value has `num-tabular`
- Utilization percentage span has `num-tabular`
- Monthly payment value has `num-tabular`
- Retains class in full payoff state (`'—'`)
- Retains class in empty state (no repayment amount)

### 5. `src/pages/RepayPage.test.tsx` — 4 bug fixes + 2 new/strengthened tests

**Bug fixes (pre-existing):**
| Issue | Fix |
|---|---|
| `BrowserRouter` used but doesn't support `initialEntries` | Changed to `MemoryRouter` |
| `credit-line-1` doesn't exist in mock data | Changed to `CL-2024-001` |
| No `vi.useFakeTimers()`, so 800ms loading skeleton never resolves | Added `beforeEach`/`afterEach` with `vi.useFakeTimers()` + `act(advanceTimersByTime(1000))` |
| `MOCK_CREDIT_LINES` not mocked, tests hit loading skeleton forever | Added module mock with `CL-2024-001` |

**New/strengthened:**
- **New:** Repay amount input carries `num-tabular` class (FWC26)
- **Strengthened:** APR header test — was conditional `if (aprSpan)`, now strict `expect(aprSpan).toBeInTheDocument()`
- Replaced `userEvent.type` (timed out with fake timers) with `fireEvent.change` for review/success step interactions

---

## 🧪 Test Results

```
 ✓ src/components/__tests__/PayoffProjection.test.tsx (17 tests) 
 ✓ src/pages/RepayPage.test.tsx (17 tests)

 Test Files  2 passed (2)
      Tests  34 passed (34)
```

Pre-existing failures in `src/components/__tests__/tabular-nums.test.tsx` (2/7 fail) are **unrelated** — they involve `AmountInput` label ambiguity and preset chip assertions that predate this PR.

---

## 🎨 Design Decisions

1. **Why `num-tabular` and not inline `style`?** — The `.num-tabular` class is the project's established pattern (used in 30+ components). It also applies `font-feature-settings: "tnum" 1` for broader browser support.

2. **Why add `num-tabular` to `'—'` (em dash) displays?** — `font-variant-numeric` only affects digit glyphs. Applying the class to the container is harmless for non-numeric text and keeps the code simple.

3. **Why add `num-tabular` to `<input type="number">`?** — Browsers handle number-input font rendering inconsistently (Firefox may ignore it), but Chrome/Edge respect it. This matches the existing `AmountInput` component pattern.

4. **Why not add `num-tabular` to preset buttons (`25%`, `50%`, etc.)?** — These are UI labels/buttons, not dynamic numeric displays that change during interaction. Tabular-nums is primarily needed where values update live (preview amounts, utilization recalculations).

---

## ♿ Accessibility

- **WCAG 1.4.1 (Use of Color):** `font-variant-numeric` is purely typographic — no color dependency, no contrast implications.
- **WCAG 2.2.2 (Pause, Stop, Hide):** Tabular numerals reduce visual movement/jitter, helping users with vestibular disorders.
- **Screen readers:** Unaffected — `aria-live` regions and `role="status"` announcements remain unchanged.

---

## ✅ Checklist

- [x] `num-tabular` applied to all numeric displays on RepayPage and PayoffProjection
- [x] Focused tests added for both components (34 tests pass)
- [x] Pre-existing test bugs fixed (router, timers, mock data, ID mismatch)
- [x] Duplicate `useState` declarations removed from RepayPage
- [x] Dark-mode consistent (`.num-tabular` is color-agnostic)
- [x] Responsive (no breakpoint-specific styles needed)
- [x] No changes to design tokens or typography.css required
- [x] No API or prop interface changes