### PR TITLE
feat: enable DrawSummaryBar on all breakpoints

### DIFF
--- a/src/components/DrawSummaryBar.css
+++ b/src/components/DrawSummaryBar.css
@@ -40,12 +40,7 @@
   animation: draw-summary-bar-mount 0.18s ease-out both;
 }
 
-/* Sticky summary is mobile-only — desktop uses the sidebar preview. */
-@media (min-width: 768px) {
-  .draw-summary-bar {
-    display: none;
-  }
-}
+/* Sticky summary is now visible on all breakpoints. */
 
 @supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
   .draw-summary-bar {

--- a/src/components/DrawSummaryBar.test.tsx
+++ b/src/components/DrawSummaryBar.test.tsx
@@ -82,21 +82,7 @@ describe("DrawSummaryBar", () => {
       expect(container.firstChild).toBeNull();
     });
 
-    it("renders nothing at md breakpoint and above", () => {
-      mockUseMediaQuery.mockReturnValue(false);
-
-      const { container } = render(
-        <DrawSummaryBar
-          creditLine={standardLine}
-          amount={1000}
-          step="amount"
-        />,
-      );
-
-      expect(container.firstChild).toBeNull();
-    });
-
-    it("shows the bar on the `amount` step below md once a line is selected", () => {
+    it("shows the bar on the `amount` step once a line is selected", () => {
       const { container } = render(
         <DrawSummaryBar
           creditLine={standardLine}

--- a/src/components/DrawSummaryBar.tsx
+++ b/src/components/DrawSummaryBar.tsx
@@ -5,9 +5,8 @@
  *
  * Visibility
  * ──────────
- * Shown only below the `md` breakpoint (max-width 767px) on the `amount`
- * step once a credit line is selected. Desktop uses the sidebar
- * `PreviewSection`; `select`, `confirm`, and `status` steps are excluded
+ * Shown on all breakpoints on the `amount` step once a credit line is
+ * selected. `select`, `confirm`, and `status` steps are excluded
  * (see VISIBLE_STEPS).
  *
  * Scroll behaviour
@@ -29,7 +28,6 @@ import { getDrawPricingQuote } from "@/lib/draw-credit-pricing";
 import { formatMoney } from "@/utils/amountValidation";
 import { useDebounceValue } from "@/hooks/useDebounceValue";
 import { useScrollCollapse } from "@/hooks/useScrollCollapse";
-import { BELOW_MD_MEDIA, useMediaQuery } from "@/hooks/useMediaQuery";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import "./DrawSummaryBar.css";
 
@@ -69,8 +67,7 @@ export function DrawSummaryBar({
   amount,
   step,
 }: DrawSummaryBarProps) {
-  const isBelowMd = useMediaQuery(BELOW_MD_MEDIA);
-  const isVisible = !!creditLine && VISIBLE_STEPS.has(step) && isBelowMd;
+  const isVisible = !!creditLine && VISIBLE_STEPS.has(step);
   const isCollapsed = useScrollCollapse(isVisible);
   const prefersReducedMotion = usePrefersReducedMotion();
 


### PR DESCRIPTION
The task was to update the DrawSummaryBar to be sticky and visible across all breakpoints, rather than restricted to
  mobile.

  Changes
   * src/components/DrawSummaryBar.tsx: Removed the useMediaQuery hook, which restricted visibility to BELOW_MD_MEDIA.
     Updated the isVisible logic to only depend on the current step and the existence of a creditLine. Updated
     component documentation to reflect these changes.
   * src/components/DrawSummaryBar.css: Removed the @media (min-width: 768px) block that hidden the component on larger
     screens, making it visible on all breakpoints.
   * src/components/DrawSummaryBar.test.tsx: Updated tests to remove the breakpoint-specific visibility test and
     verified that the component now renders correctly based on the step regardless of media query context.

  Verification
   * Ran existing test suite (vitest src/components/DrawSummaryBar.test.tsx) and verified all tests passed, confirming
     the component's visibility and functionality logic is sound.

closes #485 