### PR TITLE
feat: Dashboard empty state

### DIFF
--- a/docs/EMPTY_STATE.md
+++ b/docs/EMPTY_STATE.md
@@ -58,6 +58,12 @@ so they theme through transparent token inheritance.
   `src/pages/TransactionHistory.test.tsx` still pass with the local
   styling. Migration to the shared component is a separate task.
 - **`CreditLines`** — same history; same future migration note.
+- **`Dashboard`** (`src/pages/Dashboard.tsx`) — replaces the raw dashboard
+  grid with the shared empty state when the wallet has zero credit lines
+  (`status === 'success' && !hasLines`). Uses `NoLines`, matching the
+  illustration convention used by `CreditLines` and `TransactionHistory`
+  for the same "zero credit lines" condition. The CTA links to
+  `/open-credit` (issue #561).
 
 ## Theming / a11y contract
 

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -16,6 +16,19 @@ vi.mock('../context/WalletContext', () => ({
   }),
 }));
 
+const { mockCreditLinesArray } = vi.hoisted(() => {
+  return { mockCreditLinesArray: [] as unknown[] };
+});
+
+vi.mock('../data/mockData', async () => {
+  const actual = await vi.importActual<typeof import('../data/mockData')>('../data/mockData');
+  mockCreditLinesArray.push(...actual.MOCK_CREDIT_LINES);
+  return {
+    ...actual,
+    MOCK_CREDIT_LINES: mockCreditLinesArray,
+  };
+});
+
 const { mockReadJson, mockWriteJson, mockStorageStore } = vi.hoisted(() => {
   const store: Record<string, unknown> = {};
   return {
@@ -610,6 +623,7 @@ describe('Dashboard color-blind pattern classes (v7)', () => {
     expect(patternsCssSource).toMatch(/\.util-fill--medium::before/);
     expect(patternsCssSource).toMatch(/\.util-fill--high::before/);
     vi.useRealTimers();
+  });
 });
 
 describe('Dashboard KbdHint', () => {
@@ -747,5 +761,76 @@ describe('Dashboard reduced-motion fallback (Issue #500)', () => {
 
     restore();
     vi.useRealTimers();
+  });
+});
+
+// Issue #561 — Dashboard empty state (no credit lines yet).
+describe('Dashboard empty state (no credit lines)', () => {
+  let savedCreditLines: unknown[] = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    savedCreditLines = mockCreditLinesArray.splice(0, mockCreditLinesArray.length);
+  });
+
+  afterEach(() => {
+    mockCreditLinesArray.splice(0, mockCreditLinesArray.length, ...savedCreditLines);
+    vi.useRealTimers();
+  });
+
+  it('renders the shared EmptyState with the NoLines illustration once loading succeeds', async () => {
+    const { container } = render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(
+      screen.getByRole('heading', { name: 'No credit lines yet' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Start your credit journey by requesting a credit evaluation/i),
+    ).toBeInTheDocument();
+
+    // Distinguishes the `NoLines` illustration from other shared illustrations
+    // (e.g. `NoDataGraph`, used for zero-result *filters* elsewhere) by a path
+    // unique to its SVG markup.
+    expect(container.innerHTML).toContain('M42 58H138');
+    expect(container.innerHTML).not.toContain('M38 96H142');
+  });
+
+  it('exposes the empty state as a polite, labelled status region', async () => {
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    const status = screen.getByRole('status', { name: 'No credit lines yet' });
+    expect(status).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('links the primary action to the credit evaluation request flow', async () => {
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    const cta = screen.getByRole('link', { name: 'Request Credit Evaluation' });
+    expect(cta).toHaveAttribute('href', '/open-credit');
   });
 });

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect, useRef, useCallback, type CSSProperties } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import ActivityFeed from "../components/ActivityFeed";
 import { CopyToClipboard } from "../components/CopyToClipboard";
 import { CopyLoanButton } from "../components/CopyLoanButton";
@@ -26,7 +26,8 @@ import {
 import "./Dashboard.css";
 import "../styles/focus.css";
 import { Skeleton } from "../components/Skeleton";
-import { NoDataGraph } from "../components/illustrations";
+import { NoLines } from "../components/illustrations";
+import { EmptyState } from "../components/EmptyState";
 import { useInertBackdrop } from "../hooks/useInertBackdrop";
 import { useBodyScrollLock } from "../hooks/useBodyScrollLock";
 import { WhatChanged } from "../components/WhatChanged";
@@ -344,7 +345,7 @@ export function Dashboard() {
           )}
         </div>
         <EmptyState
-          illustration={<NoDataGraph className="empty-state-illustration--muted" />}
+          illustration={<NoLines className="empty-state-illustration--muted" />}
           title="No credit lines yet"
           description="Start your credit journey by requesting a credit evaluation. We'll analyze your on-chain activity to determine your credit limit and terms."
           primaryAction={{

--- a/src/pages/__tests__/Dashboard.emptyState.test.tsx
+++ b/src/pages/__tests__/Dashboard.emptyState.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { Dashboard } from '../Dashboard';
@@ -26,7 +26,7 @@ vi.mock('../../data/mockData', () => ({
 }));
 
 describe('Dashboard — empty state (issue #501)', () => {
-  it('renders the shared EmptyState component when no credit lines are present', () => {
+  it('renders the shared EmptyState component when no credit lines are present', async () => {
     vi.useFakeTimers();
 
     render(
@@ -36,8 +36,8 @@ describe('Dashboard — empty state (issue #501)', () => {
     );
 
     // Fast-forward dashboard loading delay (500ms)
-    act(() => {
-      vi.advanceTimersByTime(500);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
     });
 
     // Check that empty state content is visible
@@ -54,6 +54,3 @@ describe('Dashboard — empty state (issue #501)', () => {
     vi.useRealTimers();
   });
 });
-
-// React 18 act import shim helper
-import { act } from 'react';


### PR DESCRIPTION
## Summary

The Dashboard's "no credit lines yet" empty state was completely broken, not just
unpolished: it referenced the shared `<EmptyState>` component and called
`useNavigate()` without importing either, so the branch threw a `ReferenceError`
and crashed instead of rendering. It also used the `NoDataGraph` illustration,
which elsewhere in the app is reserved for "filtered to zero results" — `CreditLines`
and `TransactionHistory` both use `NoLines` for the "zero credit lines" condition.

- Import `EmptyState` and `useNavigate` in `Dashboard.tsx`
- Swap the illustration from `NoDataGraph` to `NoLines` to match the existing
  convention for this empty-state condition
- Add 3 focused tests covering the illustration, the polite status region, and
  the CTA link
- Fix a pre-existing missing closing brace in `Dashboard.test.tsx` that silently
  nested every `describe` block after it and prevented the whole file from
  running at all
- Fix the same broken fake-timer/microtask flush pattern in the pre-existing
  duplicate empty-state test (`Dashboard.emptyState.test.tsx`, issue #501)
- Document `Dashboard` as an `EmptyState` adopter in `docs/EMPTY_STATE.md`

No new UI was designed — this wires the Dashboard up to the same shared,
already-compliant `EmptyState` component used elsewhere in the app, so the
existing WCAG 2.1 AA behaviour (`role="status"`, `aria-live="polite"`,
labelled heading), design-token theming (`currentColor` illustration, CSS
custom properties, dark/high-contrast support), and responsive layout carry
over unchanged.

## Test plan

- [x] `npx vitest run src/pages/Dashboard.test.tsx` — new empty-state describe
      block passes (3/3)
- [x] `npx vitest run src/pages/__tests__/Dashboard.emptyState.test.tsx` — fixed
      duplicate test passes (1/1)
- [x] Confirmed via `git stash` diff that dependent test files
      (`src/styles/focus.test.tsx`, `src/styles/typography.test.tsx`) went from
      10 failed/46 passed → 5 failed/71 passed after this change — a net
      improvement with no regressions. Remaining failures are pre-existing and
      unrelated (a risk-explainer trigger bug, a tabular-nums check).
- [x] `npx tsc -b` shows no errors in `Dashboard.tsx` or its tests (pre-existing,
      unrelated build breakage exists elsewhere in the repo — untouched by this PR)
- [ ] Manual click-through in a browser (`npm run dev`, disconnect/empty wallet
      state) — recommend a maintainer/reviewer confirm visually 

## Screenshots

_Illustration is the existing `NoLines` SVG (already used on `CreditLines` and
`TransactionHistory`), so no new visual asset — happy to add a screenshot on
request._

I fixed two bugs that were blocking Dashboard from rendering the empty state at all (missing useNavigate and EmptyState imports), plus a syntax bug in the test file. These are outside the literal wording of #561 but were necessary to actually verify and ship the fix — I've called them out explicitly in the description so any reviewers aren't surprised.

Closes #561