### PR TITLE
Add AttestationCard to Dashboard

### DIFF
--- a/src/components/AttestationCard.css
+++ b/src/components/AttestationCard.css
@@ -1,0 +1,106 @@
+.attestation-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.attestation-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.875rem 0;
+    border-bottom: 1px solid var(--border);
+    gap: 0.75rem;
+}
+
+.attestation-row:last-of-type {
+    border-bottom: none;
+}
+
+.attestation-row__main {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    min-width: 0;
+}
+
+.attestation-row__label {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--text);
+    white-space: nowrap;
+}
+
+.attestation-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.15rem 0.45rem;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    line-height: var(--lh-small);
+    white-space: nowrap;
+}
+
+.attestation-pill__cue {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 0.85rem;
+    height: 0.85rem;
+    border: 1px solid currentColor;
+    border-radius: 50%;
+    font-size: 0.55rem;
+    font-weight: 700;
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+.attestation-row__meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-shrink: 0;
+}
+
+.attestation-row__verified {
+    font-size: 0.7rem;
+    color: var(--muted);
+    white-space: nowrap;
+}
+
+.attestation-row__cta {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--accent);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.attestation-row__cta:hover,
+.attestation-row__cta:focus-visible {
+    text-decoration: underline;
+}
+
+/* Compact row mode: stack meta below the label and guarantee 44px touch targets */
+@media (max-width: 480px) {
+    .attestation-row {
+        flex-wrap: wrap;
+        align-items: flex-start;
+    }
+
+    .attestation-row__meta {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .attestation-row__cta {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        min-width: 44px;
+    }
+}

--- a/src/components/AttestationCard.tsx
+++ b/src/components/AttestationCard.tsx
@@ -1,0 +1,82 @@
+import { Link } from 'react-router-dom';
+import type { Attestation, AttestationStatus } from '../types/attestation';
+import { ATTESTATION_STATUS_COLOR, fmtDate } from '../utils/tokens';
+import './AttestationCard.css';
+
+const EXPIRING_WINDOW_DAYS = 14;
+
+const STATUS_CUE: Record<AttestationStatus, string> = {
+  Verified: '✓',
+  Expiring: '!',
+  Missing: '✕',
+};
+
+const STATUS_COPY: Record<AttestationStatus, string> = {
+  Verified: 'Verified',
+  Expiring: 'Expiring soon',
+  Missing: 'Missing',
+};
+
+function getAttestationStatus(attestation: Attestation): AttestationStatus {
+  if (!attestation.lastVerifiedAt || !attestation.expiresAt) return 'Missing';
+  const expiresAt = new Date(attestation.expiresAt).getTime();
+  if (expiresAt <= Date.now()) return 'Missing';
+  const daysUntilExpiry = Math.ceil((expiresAt - Date.now()) / 86400000);
+  return daysUntilExpiry <= EXPIRING_WINDOW_DAYS ? 'Expiring' : 'Verified';
+}
+
+interface AttestationCardProps {
+  attestations: Attestation[];
+}
+
+/**
+ * Summarizes each attestation (identity bond, revenue proof, ...) with
+ * its verification status, last-verified time, and — when action is
+ * needed — a CTA that deep-links into the relevant `RequestEvaluation`
+ * step for remediation.
+ */
+export function AttestationCard({ attestations }: AttestationCardProps) {
+  return (
+    <div className="card attestation-card">
+      <h2>
+        <span className="icon">🪪</span> Attestations
+      </h2>
+      <ul className="attestation-list">
+        {attestations.map((attestation) => {
+          const status = getAttestationStatus(attestation);
+          const { bg, color, border } = ATTESTATION_STATUS_COLOR[status];
+          const needsRemediation = status !== 'Verified';
+
+          return (
+            <li key={attestation.id} className="attestation-row">
+              <div className="attestation-row__main">
+                <span className="attestation-row__label">{attestation.label}</span>
+                <span
+                  className="attestation-pill"
+                  style={{ background: bg, color, borderColor: border }}
+                  aria-label={`${attestation.label} attestation status: ${STATUS_COPY[status]}`}
+                  title={STATUS_COPY[status]}
+                >
+                  <span className="attestation-pill__cue" aria-hidden="true">
+                    {STATUS_CUE[status]}
+                  </span>
+                  <span>{STATUS_COPY[status]}</span>
+                </span>
+              </div>
+              <div className="attestation-row__meta">
+                <span className="attestation-row__verified">
+                  {attestation.lastVerifiedAt ? `Last verified ${fmtDate(attestation.lastVerifiedAt)}` : 'Never verified'}
+                </span>
+                {needsRemediation && (
+                  <Link to={`/open-credit?step=${attestation.remediationStep}`} className="attestation-row__cta">
+                    {status === 'Missing' ? 'Submit attestation' : 'Renew attestation'} →
+                  </Link>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,4 +1,5 @@
 import type { CreditLine, AprHistoryEntry } from '../types/creditLine';
+import type { Attestation } from '../types/attestation';
 
 // ─── APR history generation helper ───────────────────────────────────────────
 /**
@@ -180,6 +181,30 @@ export const MOCK_CREDIT_LINES: CreditLine[] = [
       { status: 'Active', date: '2025-01-15', note: 'Line opened and activated' },
     ],
     aprHistory: generateAprHistory(7.5, 365, 606),
+  },
+];
+
+// ─── Attestations mock data ───────────────────────────────────────────────────
+
+export const MOCK_ATTESTATIONS: Attestation[] = [
+  {
+    id: 'identity-bond',
+    label: 'Identity Bond',
+    lastVerifiedAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+    expiresAt: new Date(Date.now() + 150 * 24 * 60 * 60 * 1000).toISOString(),
+    remediationStep: 2,
+  },
+  {
+    id: 'revenue-proof',
+    label: 'Revenue Proof',
+    lastVerifiedAt: new Date(Date.now() - 170 * 24 * 60 * 60 * 1000).toISOString(),
+    expiresAt: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(),
+    remediationStep: 2,
+  },
+  {
+    id: 'bank-ownership',
+    label: 'Bank Account Ownership',
+    remediationStep: 2,
   },
 ];
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import ActivityFeed from "../components/ActivityFeed";
 import { CopyToClipboard } from "../components/CopyToClipboard";
 import { CopyLoanButton } from "../components/CopyLoanButton";
 import { StatusBadge } from "../components/StatusBadge";
+import { AttestationCard } from "../components/AttestationCard";
 import { CreditLineRowMenu } from "../components/CreditLineRowMenu";
 import { KbdHint } from "../components/KbdHint";
 import { DashboardTour } from "../components/DashboardTour";
@@ -13,7 +14,7 @@ import { RiskBandsPanel } from "../components/RiskBandsPanel";
 import { WhatsChangedPanel } from "../components/WhatsChangedPanel";
 import { RiskExplainerOverlay } from "../components/RiskExplainerOverlay";
 import { ContinuePrompt } from "../components/ContinuePrompt";
-import { MOCK_CREDIT_LINES } from "../data/mockData";
+import { MOCK_CREDIT_LINES, MOCK_ATTESTATIONS } from "../data/mockData";
 import type { Transaction } from "../types/creditLine";
 import {
   COLOR,
@@ -658,6 +659,8 @@ export function Dashboard() {
               />
             )}
           </div>
+
+          {status === 'success' && <AttestationCard attestations={MOCK_ATTESTATIONS} />}
 
            <div
              className="card"

--- a/src/pages/RequestEvaluation.tsx
+++ b/src/pages/RequestEvaluation.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { AccessibleTooltip } from '@/components/AccessibleTooltip';
 import { FormMessage } from '@/components/FormMessage';
 import { PendingButton } from '@/components/PendingButton';
@@ -80,7 +80,12 @@ interface EvalResult {
 
 export function RequestEvaluation() {
   const { isReducedMotionActive } = useReducedMotion();
-  const [step, setStep] = useState<Step>(1);
+  const [searchParams] = useSearchParams();
+  // Attestation remediation CTAs deep-link here with `?step=2` (Optional
+  // Information), where the revenue attestation upload and identity bond
+  // checkbox live. Other steps depend on in-progress evaluation state and
+  // aren't valid deep-link targets.
+  const [step, setStep] = useState<Step>(() => (searchParams.get('step') === '2' ? 2 : 1));
   const [evalState, setEvalState] = useState<EvalState>('idle');
   const [progress, setProgress] = useState(0);
   const [eta, setEta] = useState(45); // seconds

--- a/src/types/attestation.ts
+++ b/src/types/attestation.ts
@@ -1,0 +1,22 @@
+/**
+ * Verification state of a single attestation. `Missing` covers both a
+ * never-submitted attestation and one that has already lapsed — both
+ * require the same remediation.
+ */
+export type AttestationStatus = 'Verified' | 'Expiring' | 'Missing';
+
+/**
+ * A single attestation tracked against the connected wallet (identity
+ * bond, revenue proof, etc.). Backs the Dashboard's AttestationCard.
+ */
+export interface Attestation {
+  id: string;
+  /** Human-readable label, e.g. "Identity Bond". */
+  label: string;
+  /** ISO 8601 timestamp of the last successful verification. Absent when never verified. */
+  lastVerifiedAt?: string;
+  /** ISO 8601 timestamp the attestation lapses. Absent when never verified. */
+  expiresAt?: string;
+  /** `RequestEvaluation` step (`?step=<n>`) the remediation CTA deep-links to. */
+  remediationStep: number;
+}

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -12,6 +12,7 @@
  * canonical catalogue.
  */
 import type { CreditLineStatus, UtilizationLevel } from '../types/creditLine';
+import type { AttestationStatus } from '../types/attestation';
 import type React from 'react';
 
 // ─── Design tokens ────────────────────────────────────────────────────────────
@@ -46,6 +47,12 @@ export const STATUS_COLOR: Record<CreditLineStatus, { bg: string; color: string;
   Defaulted: { bg: 'rgba(248,81,73,0.14)', color: '#ffb0aa', border: 'rgba(248,81,73,0.46)' },
   Closed: { bg: 'rgba(139,148,158,0.16)', color: '#c4ccd6', border: 'rgba(139,148,158,0.42)' },
   Frozen: { bg: 'rgba(88,166,255,0.12)', color: '#79c0ff', border: 'rgba(88,166,255,0.38)' },
+};
+
+export const ATTESTATION_STATUS_COLOR: Record<AttestationStatus, { bg: string; color: string; border: string }> = {
+  Verified: { bg: 'rgba(63,185,80,0.16)', color: '#8ee99d', border: 'rgba(63,185,80,0.44)' },
+  Expiring: { bg: 'rgba(210,153,34,0.16)', color: '#f0c96a', border: 'rgba(210,153,34,0.46)' },
+  Missing: { bg: 'rgba(248,81,73,0.14)', color: '#ffb0aa', border: 'rgba(248,81,73,0.46)' },
 };
 
 /**


### PR DESCRIPTION
Adds an AttestationCard to the Dashboard summarizing attestation status (Verified/Expiring/Missing), with a remediation CTA that deep-links into RequestEvaluation.

Closes #174