### PR TITLE
feat: add hover-preview card on WalletConnectionModal rows (#701)

### DIFF
--- a/src/components/WalletConnectionModal.css
+++ b/src/components/WalletConnectionModal.css
@@ -764,6 +764,142 @@
   font-weight: 300;
 }
 
+/* 
+   Wallet Hover-Preview Card
+   Appears on hover/focus of each wallet option row.
+   Follows the same design pattern as PreviewCard but adapted for
+   the wallet-selection context.  The list item serves as the
+   positioning anchor so the card can extend beyond the button.
+    */
+.wallet-option-wrapper {
+  position: relative;
+}
+
+.wallet-preview {
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%) scale(0.97);
+  z-index: 100;
+  width: 240px;
+  padding: var(--space-md);
+  background: var(--modal-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.3), 0 2px 6px rgba(0, 0, 0, 0.15);
+  color: var(--color-text);
+  font-family: inherit;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 160ms cubic-bezier(0.16, 1, 0.3, 1),
+              transform 160ms cubic-bezier(0.16, 1, 0.3, 1);
+  text-align: left;
+}
+
+/* Arrow pointing to the trigger button */
+.wallet-preview::after {
+  content: '';
+  position: absolute;
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%) rotate(45deg);
+  width: 10px;
+  height: 10px;
+  margin-right: -5px;
+  background: var(--modal-bg);
+  border-left: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+}
+
+/* Visible on hover/focus of the wrapper list item */
+.wallet-option-wrapper:hover .wallet-preview,
+.wallet-option-wrapper:focus-within .wallet-preview {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(-50%) scale(1);
+}
+
+/* Preview card header — icon + name */
+.wallet-preview__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+  padding-bottom: var(--space-sm);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.wallet-preview__header img {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  object-fit: contain;
+}
+
+.wallet-preview__name {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+/* Feature list */
+.wallet-preview__features {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.wallet-preview__feature {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-xs);
+}
+
+.wallet-preview__check {
+  flex-shrink: 0;
+  color: var(--color-success);
+  font-weight: 700;
+  font-size: 0.75rem;
+  margin-top: 0.1em;
+}
+
+/* Mobile: reposition below the trigger */
+@media (max-width: 640px) {
+  .wallet-preview {
+    position: static;
+    transform: none;
+    width: 100%;
+    margin-top: var(--space-xs);
+    margin-bottom: var(--space-xs);
+    border-radius: 8px;
+    box-shadow: none;
+    border-style: dashed;
+    opacity: 0;
+    max-height: 0;
+    overflow: hidden;
+    padding: 0 var(--space-md);
+    transition: opacity 200ms ease, max-height 200ms ease, padding 200ms ease;
+  }
+
+  .wallet-preview::after {
+    display: none;
+  }
+
+  .wallet-option-wrapper:hover .wallet-preview,
+  .wallet-option-wrapper:focus-within .wallet-preview {
+    opacity: 1;
+    max-height: 200px;
+    padding: var(--space-md);
+    transform: none;
+  }
+}
+
 /* Spinner */
 .wallet-option-spinner {
   width: 20px;
@@ -1101,6 +1237,10 @@
   
   .wallet-option:active:not(:disabled) {
     transform: none;
+  }
+  
+  .wallet-preview {
+    transition: none;
   }
 }
 

--- a/src/components/WalletConnectionModal.tsx
+++ b/src/components/WalletConnectionModal.tsx
@@ -42,6 +42,7 @@ interface WalletOption {
   icon: string;
   description: string;
   installUrl: string;
+  features: string[];
 }
 
 /**
@@ -55,6 +56,7 @@ const DEFAULT_WALLET_ORDER: WalletOption[] = [
     icon: '/assets/wallets/freighter.svg',
     description: 'Browser extension wallet for Stellar',
     installUrl: 'https://www.freighter.app',
+    features: ['Supports Soroban smart contracts', 'Ledger hardware wallet compatible', 'Open source'],
   },
   {
     id: 'albedo',
@@ -62,6 +64,7 @@ const DEFAULT_WALLET_ORDER: WalletOption[] = [
     icon: '/assets/wallets/albedo.svg',
     description: 'Web-based Stellar wallet',
     installUrl: 'https://albedo.link',
+    features: ['No installation required', 'Hardware wallet support', 'Built-in asset swap'],
   },
   {
     id: 'xbull',
@@ -69,6 +72,7 @@ const DEFAULT_WALLET_ORDER: WalletOption[] = [
     icon: '/assets/wallets/xbull.svg',
     description: 'Mobile and desktop Stellar wallet',
     installUrl: 'https://xbull.app',
+    features: ['Cross-platform (mobile + desktop)', 'Built-in DApp browser', 'Multi-account support'],
   },
   {
     id: 'rabet',
@@ -76,6 +80,7 @@ const DEFAULT_WALLET_ORDER: WalletOption[] = [
     icon: '/assets/wallets/rabet.svg',
     description: 'Stellar wallet for desktop',
     installUrl: 'https://rabet.io',
+    features: ['Lightweight desktop application', 'Clean minimal interface', 'Beginner-friendly setup'],
   },
 ];
 
@@ -425,8 +430,10 @@ export const WalletConnectionModal: React.FC<WalletConnectionModalProps> = ({
             const isConnecting = connectingId === wallet.id;
             const isDisabled = connectingId !== null;
 
+            const previewId = `wallet-preview-${wallet.id}`;
+
             return (
-              <li key={wallet.id} role="none">
+              <li key={wallet.id} role="none" className="wallet-option-wrapper">
                 <button
                   className={`wallet-option ${isDetected ? 'wallet-option--detected' : 'wallet-option--undetected'}`}
                   style={{ minHeight: '44px', minWidth: '44px' }}
@@ -439,7 +446,7 @@ export const WalletConnectionModal: React.FC<WalletConnectionModalProps> = ({
                       ? `Connect with ${wallet.name}${isConnecting ? ', connecting' : ''}`
                       : `Install ${wallet.name} wallet`
                   }
-                  aria-describedby={`wallet-status-${wallet.id}`}
+                  aria-describedby={`wallet-status-${wallet.id} ${previewId}`}
                   type="button"
                 >
                   {/* Icon */}
@@ -488,6 +495,33 @@ export const WalletConnectionModal: React.FC<WalletConnectionModalProps> = ({
                     )}
                   </span>
                 </button>
+
+                {/* Hover-preview card — shows wallet features on hover/focus */}
+                <div
+                  id={previewId}
+                  className="wallet-preview"
+                  role="tooltip"
+                  aria-hidden="true"
+                >
+                  <div className="wallet-preview__header">
+                    <img
+                      src={wallet.icon}
+                      alt=""
+                      width="28"
+                      height="28"
+                      aria-hidden="true"
+                    />
+                    <span className="wallet-preview__name">{wallet.name}</span>
+                  </div>
+                  <ul className="wallet-preview__features">
+                    {wallet.features.map((feat) => (
+                      <li key={feat} className="wallet-preview__feature">
+                        <span className="wallet-preview__check" aria-hidden="true">✓</span>
+                        {feat}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               </li>
             );
           })}

--- a/src/components/__tests__/WalletConnectionModal.test.tsx
+++ b/src/components/__tests__/WalletConnectionModal.test.tsx
@@ -679,4 +679,113 @@ describe('WalletConnectionModal Accessibility', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
+
+  // ── Hover-preview card ─────────────────────────────────────────────────
+
+  describe('wallet hover-preview card', () => {
+    function withFreighterDetected() {
+      vi.spyOn(walletUtils, 'getRecentWalletOrder').mockReturnValue([]);
+      vi.spyOn(walletUtils, 'getStoredWallet').mockReturnValue(null);
+    }
+
+    beforeEach(() => {
+      window.localStorage.clear();
+      withFreighterDetected();
+    });
+
+    it('renders a preview card for each wallet option', () => {
+      const { container } = render(
+        <TestWrapper
+          isOpen={true}
+          onClose={mockOnClose}
+          onConnect={mockOnConnect}
+          detectedWallets={['freighter']}
+        />,
+      );
+
+      const previews = container.querySelectorAll('.wallet-preview');
+      // 4 wallets → 4 preview cards
+      expect(previews).toHaveLength(4);
+    });
+
+    it('each preview card has role="tooltip" and is hidden from AT by default', () => {
+      const { container } = render(
+        <TestWrapper
+          isOpen={true}
+          onClose={mockOnClose}
+          onConnect={mockOnConnect}
+          detectedWallets={['freighter']}
+        />,
+      );
+
+      const previews = container.querySelectorAll('.wallet-preview');
+      previews.forEach((card) => {
+        expect(card).toHaveAttribute('role', 'tooltip');
+        expect(card).toHaveAttribute('aria-hidden', 'true');
+      });
+    });
+
+    it('links the wallet button to its preview card via aria-describedby', () => {
+      render(
+        <TestWrapper
+          isOpen={true}
+          onClose={mockOnClose}
+          onConnect={mockOnConnect}
+          detectedWallets={['freighter']}
+        />,
+      );
+
+      const freighterBtn = screen.getByLabelText('Connect with Freighter');
+      const describedBy = freighterBtn.getAttribute('aria-describedby') ?? '';
+      // Should reference both the status id and the preview id.
+      const ids = describedBy.split(/\s+/);
+      const previewId = ids.find((id) => id.startsWith('wallet-preview-'));
+      expect(previewId).toBeTruthy();
+      const previewEl = document.getElementById(previewId!);
+      expect(previewEl).toBeInTheDocument();
+      expect(previewEl).toHaveAttribute('role', 'tooltip');
+    });
+
+    it('preview card shows the wallet name in its header', () => {
+      render(
+        <TestWrapper
+          isOpen={true}
+          onClose={mockOnClose}
+          onConnect={mockOnConnect}
+          detectedWallets={['freighter']}
+        />,
+      );
+
+      // The first visible wallet header name in the DOM
+      const headers = document.querySelectorAll('.wallet-preview__name');
+      expect(headers.length).toBe(4);
+
+      // Freighter should be one of them
+      const names = Array.from(headers).map((h) => h.textContent);
+      expect(names).toContain('Freighter');
+      expect(names).toContain('Albedo');
+      expect(names).toContain('xBull');
+      expect(names).toContain('Rabet');
+    });
+
+    it('preview card lists wallet-specific features', () => {
+      render(
+        <TestWrapper
+          isOpen={true}
+          onClose={mockOnClose}
+          onConnect={mockOnConnect}
+          detectedWallets={['freighter']}
+        />,
+      );
+
+      // Each wallet has 3 features → expect 12 feature items total
+      const features = document.querySelectorAll('.wallet-preview__feature');
+      expect(features.length).toBe(12);
+
+      // Freighter-specific features should be present
+      const featureTexts = Array.from(features).map((f) => f.textContent);
+      expect(featureTexts.some((t) => t?.includes('Soroban'))).toBe(true);
+      expect(featureTexts.some((t) => t?.includes('Ledger'))).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds a CSS-driven hover-preview card to each wallet option row in the WalletConnectionModal. The card appears on hover/focus and shows wallet-specific features to help users make an informed choice.

## Changes

- **`WalletConnectionModal.tsx`**: 
  - Added `features: string[]` to the `WalletOption` interface with 3 features per wallet (Freighter, Albedo, xBull, Rabet)
  - Added a preview card (`<div class="wallet-preview" role="tooltip">`) inside each wallet `<li>` with wallet icon, name, and feature list
  - Linked each button to its preview card via `aria-describedby` for screen reader access

- **`WalletConnectionModal.css`**: 
  - Added `.wallet-preview` styles: positioned to the right of each row, hidden by default (`opacity: 0; pointer-events: none`), revealed on `:hover/:focus-within` of the wrapper
  - Arrow indicator pointing to the trigger button
  - Mobile responsive: appears below the trigger with expand animation
  - Reduced-motion: disables transitions

- **Tests**: Added 5 tests covering preview card rendering (4 cards), role/aria-hidden attributes, aria-describedby linkage, wallet name in header, and wallet-specific features

Closes #701