### PR TITLE
feat: add CollateralSwap page with shape-parity skeleton and style definitions for issue #834

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import { NetworkMismatchBanner } from "./components/notifications/NetworkMismatc
 import { Header } from "./layouts/Header";
 import CreditLineCompare from "./pages/CreditLineCompare";
 import { TermsBanner } from "./components/TermsBanner";
+import CollateralSwap from "./pages/CollateralSwap";
 
 const isEditableTarget = (target: EventTarget | null) => {
   if (!(target instanceof HTMLElement)) return false;
@@ -250,6 +251,9 @@ function App() {
                             the "Repay" action on Credit Lines). */}
                         <Route path="/repay" element={<RepayPage />} />
                         <Route path="/repay/calendar" element={<RepayCalendar />} />
+                        {/* Issue #834: CollateralSwap — swap one collateral asset for
+                            another within an existing credit line. */}
+                        <Route path="/collateral-swap" element={<CollateralSwap />} />
                         <Route path="*" element={<NotFound />} />
                       </Routes>
                     </main>

--- a/src/components/Skeleton.css
+++ b/src/components/Skeleton.css
@@ -1,7 +1,9 @@
 /*
   Skeleton.css — Shimmer placeholder for loading states
   ──────────────────────────────────────────────────────
-  GrantFox FWC26 (Stellar Wave) — "Themed skeleton while Dashboard data loads."
+  GrantFox FWC26 (Stellar Wave) — issues #690 and #834
+  #690: shape-parity for pill/badge/chip placeholders
+  #834: CollateralSwap skeleton shape parity (card shape, --radius-lg)
 
   Background is driven by --skeleton-bg → var(--border). var(--border) is
   guaranteed-to-exist (defined in src/index.css :root) and gives a
@@ -55,6 +57,16 @@
    * Resolves to --radius-sm (0.375 rem / 6 px).
    */
   --skeleton-radius-sm: var(--radius-sm, 0.375rem);
+
+  /*
+   * --skeleton-radius-card
+   * Larger radius for outer page-level card containers.
+   * Resolves to --radius-lg (0.75 rem / 12 px) — the same token used by
+   * `.collateral-swap__card` and similar full-page card surfaces so the
+   * skeleton wrapper and the loaded card share an identical border-radius
+   * (FWC26 — issue #834).
+   */
+  --skeleton-radius-card: var(--radius-lg, 0.75rem);
 
   /*
    * --skeleton-radius-pill
@@ -122,25 +134,29 @@
 /* ── Shape variants ──────────────────────────────────────────────────────── */
 
 /*
- * Shape parity (FWC26 — issue #690)
- * ──────────────────────────────────
+ * Shape parity (FWC26 — issues #690 and #834)
+ * ────────────────────────────────────────────
  * Every shape variant resolves to the same border-radius token used by its
  * target final component so that first-paint skeleton geometry matches the
  * loaded-state geometry exactly and the layout does not jump (CLS = 0).
  *
  * Mapping:
  *   skeleton--rectangular  →  --skeleton-radius (--radius-md, 0.5rem / 8px)
- *                              Matches: cards (.card, .summary-card), inputs,
- *                              buttons (.qa-btn, .summary-card .value block).
+ *                              Matches: inputs, buttons, summary cards,
+ *                              asset rows inside the CollateralSwap card.
  *
- *   skeleton--rounded      →  --skeleton-radius (same as rectangular, but an
- *                              explicit semantic alias for inline text rows).
+ *   skeleton--card         →  --skeleton-radius-card (--radius-lg, 0.75rem / 12px)
+ *                              Matches: outer page-level card containers, e.g.
+ *                              .collateral-swap__card (issue #834).
+ *
+ *   skeleton--rounded      →  --skeleton-radius (same token as rectangular;
+ *                              semantic alias for inline text-row placeholders).
  *                              Matches: credit-breakdown values, activity
  *                              titles, notification text blocks.
  *
  *   skeleton--circular     →  border-radius: 50%
  *                              Matches: avatar / icon placeholders (activity
- *                              icon 28 × 28 px, risk gauge swatch).
+ *                              icon 28 × 28 px, asset icon 40 × 40 px).
  *
  *   skeleton--pill         →  --skeleton-radius-pill (--radius-full, 9999px)
  *                              Matches: StatusBadge chips, network-badge,
@@ -151,6 +167,10 @@
  * same 8px radius but the element height is close enough to be a half-pill,
  * matching how text rows look in the rendered state.
  */
+
+.skeleton--card {
+  border-radius: var(--skeleton-radius-card);
+}
 
 .skeleton--circular {
   border-radius: 50%;

--- a/src/components/Skeleton.test.tsx
+++ b/src/components/Skeleton.test.tsx
@@ -6,6 +6,7 @@
  *   - GrantFox FWC26: `variant` prop (`default` | `subtle`)
  *   - GrantFox FWC26: CSS token declarations in Skeleton.css
  *   - GrantFox FWC26 #690: shape parity — `pill` shape, radius tokens
+ *   - GrantFox FWC26 #834: shape parity — `card` shape (--radius-lg)
  */
 
 import { render, screen } from '@testing-library/react';
@@ -55,6 +56,12 @@ describe('Skeleton.css — themed tokens (FWC26)', () => {
     expect(css).toContain('var(--radius-full');
   });
 
+  // FWC26 #834: card shape token for outer page-level card containers
+  it('declares --skeleton-radius-card token resolved via var(--radius-lg)', () => {
+    expect(css).toContain('--skeleton-radius-card');
+    expect(css).toContain('var(--radius-lg');
+  });
+
   it('suppresses shimmer animation under prefers-reduced-motion', () => {
     expect(css).toContain('@media (prefers-reduced-motion: reduce)');
     const rmBlock = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'));
@@ -68,21 +75,19 @@ describe('Skeleton.css — themed tokens (FWC26)', () => {
   });
 });
 
-// ── Shape parity token tests (FWC26 #690) ────────────────────────────────
+// ── Shape parity token tests (FWC26 #690 and #834) ──────────────────────────
 
-describe('Skeleton.css — shape parity (FWC26 #690)', () => {
+describe('Skeleton.css — shape parity (FWC26 #690 and #834)', () => {
   const cssPath = resolve(__dirname, './Skeleton.css');
   const css = readFileSync(cssPath, 'utf-8');
 
   it('.skeleton--pill class applies var(--skeleton-radius-pill)', () => {
     expect(css).toContain('.skeleton--pill');
-    // The pill rule must use --skeleton-radius-pill (9999px full-pill)
     const pillBlock = css.slice(css.indexOf('.skeleton--pill'));
     expect(pillBlock).toContain('var(--skeleton-radius-pill)');
   });
 
   it('.skeleton--rounded applies var(--skeleton-radius) matching --radius-md', () => {
-    // .skeleton--rounded must reference --skeleton-radius (not a literal px value)
     expect(css).toContain('.skeleton--rounded');
     const roundedIdx = css.lastIndexOf('.skeleton--rounded');
     const roundedBlock = css.slice(roundedIdx, css.indexOf('}', roundedIdx));
@@ -94,6 +99,14 @@ describe('Skeleton.css — shape parity (FWC26 #690)', () => {
     const circularIdx = css.indexOf('.skeleton--circular');
     const circularBlock = css.slice(circularIdx, css.indexOf('}', circularIdx));
     expect(circularBlock).toContain('border-radius: 50%');
+  });
+
+  // FWC26 #834: card shape for outer page-level card containers
+  it('.skeleton--card class applies var(--skeleton-radius-card)', () => {
+    expect(css).toContain('.skeleton--card');
+    const cardIdx = css.indexOf('.skeleton--card');
+    const cardBlock = css.slice(cardIdx, css.indexOf('}', cardIdx));
+    expect(cardBlock).toContain('var(--skeleton-radius-card)');
   });
 });
 
@@ -145,6 +158,23 @@ describe('Skeleton', () => {
     expect((containerRound.firstChild as HTMLElement).className).toContain(
       'skeleton--rounded'
     );
+  });
+
+  // FWC26 #834: card shape for outer page-level containers
+  it('shape="card" applies skeleton--card class', () => {
+    const { container } = render(<Skeleton shape="card" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.classList.contains('skeleton--card')).toBe(true);
+    expect(el.classList.contains('skeleton')).toBe(true);
+  });
+
+  it('shape="card" is mutually exclusive with other shape classes', () => {
+    const { container } = render(<Skeleton shape="card" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.classList.contains('skeleton--circular')).toBe(false);
+    expect(el.classList.contains('skeleton--rounded')).toBe(false);
+    expect(el.classList.contains('skeleton--pill')).toBe(false);
+    expect(el.classList.contains('skeleton--rectangular')).toBe(false);
   });
 
   // FWC26 #690: pill shape for badge/chip placeholders

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -9,29 +9,34 @@ type SkeletonProps = React.HTMLAttributes<HTMLDivElement> & {
   /**
    * Shape of the skeleton. Defaults to 'rectangular'.
    *
-   * - `rectangular` — uses `--skeleton-radius` (matches cards, inputs, buttons).
+   * - `rectangular` — uses `--skeleton-radius` (--radius-md, 8px); matches
+   *                   inputs, buttons, and small card surfaces.
+   * - `card`        — uses `--skeleton-radius-card` (--radius-lg, 12px);
+   *                   matches the outer radius of page-level card containers
+   *                   such as the CollateralSwap card (issue #834).
    * - `circular`    — border-radius: 50%, for avatar / icon placeholders.
    * - `rounded`     — semantic alias for rectangular; explicit intent for
    *                   inline text-row placeholders.
    * - `pill`        — uses `--skeleton-radius-pill` (9999px) for badge / chip
    *                   placeholders (StatusBadge, network-badge, wallet chip).
    *
-   * Shape parity principle (FWC26 — issue #690): each variant resolves to the
-   * same radius token used by the final rendered component so first-paint
-   * skeleton geometry matches loaded-state geometry exactly (CLS = 0).
+   * Shape parity principle (FWC26 — issues #690 and #834): each variant
+   * resolves to the same radius token used by the final rendered component
+   * so first-paint skeleton geometry matches loaded-state geometry exactly
+   * (CLS = 0).
    */
-  shape?: 'rectangular' | 'circular' | 'rounded' | 'pill';
+  shape?: 'rectangular' | 'card' | 'circular' | 'rounded' | 'pill';
   /**
    * Visual variant.
    *
-   * - `default`  — uses `var(--skeleton-bg)` → `var(--surface-raised, #1c2230)`.
-   *                Best for placeholders on card surfaces.
-   * - `subtle`   — reduces opacity to 60% so the placeholder blends more
-   *                softly against lighter-toned sections.
+   * - `default` — uses `var(--skeleton-bg)` → `var(--border, #30363d)`.
+   *               Best for placeholders on page and card surfaces.
+   * - `subtle`  — reduces opacity to 60% so the placeholder blends more
+   *               softly against already-muted sections (e.g. secondary rows).
    *
-   * GrantFox FWC26 (Stellar Wave): the `default` variant replaces the
-   * previous `var(--border)` background with a properly-themed surface token
-   * so skeletons adapt to [data-contrast="high"] and dark-mode overrides.
+   * GrantFox FWC26 (Stellar Wave): the `default` variant uses the
+   * `var(--border)` token so skeletons adapt to [data-contrast="high"] and
+   * dark-mode overrides automatically.
    */
   variant?: 'default' | 'subtle';
 };
@@ -46,23 +51,30 @@ type SkeletonProps = React.HTMLAttributes<HTMLDivElement> & {
  *
  * ## Theming (FWC26)
  * The background is driven by `var(--skeleton-bg)`, which defaults to
- * `var(--surface-raised)`.  Override the token at any scope:
+ * `var(--border)`.  Override the token at any scope:
  * ```css
- * .my-section { --skeleton-bg: var(--surface-overlay); }
+ * .my-section { --skeleton-bg: var(--surface); }
  * ```
  *
  * ## Dimensions
  * Pass `width` / `height` to match the eventual content size and prevent
  * Cumulative Layout Shift (CLS) while the data fetch is in flight.
  *
- * ## Shape parity (FWC26 — issue #690)
- * Use `shape="rounded"` (the default, driven by `--skeleton-radius`) for
- * most block placeholders so the border-radius matches the final card/input
- * element and first-paint does not jump when real content arrives.
- * Use `shape="circular"` only for avatar / icon-sized placeholders (≤ 48 px).
+ * ## Shape parity (FWC26 — issues #690 and #834)
+ * Choose the shape that matches the rendered component's border-radius:
+ *
+ * | Shape          | CSS token              | Pixels | Matches                           |
+ * |----------------|------------------------|--------|-----------------------------------|
+ * | `rectangular`  | `--skeleton-radius`    | 8 px   | inputs, buttons, summary cards    |
+ * | `card`         | `--skeleton-radius-card` | 12 px | outer page cards (CollateralSwap) |
+ * | `rounded`      | `--skeleton-radius`    | 8 px   | text-row placeholders             |
+ * | `circular`     | 50%                    | —      | avatar, icon placeholders         |
+ * | `pill`         | `--skeleton-radius-pill` | 9999px| StatusBadge, chips, badges        |
  *
  * ## Composed page skeletons
  * Higher-level first-paint layouts compose this primitive — e.g.
+ * `CollateralSwapSkeleton` in `CollateralSwap.tsx` (issue #834) mirrors the
+ * card's --radius-lg outer container and each inner asset-row's --radius-md.
  * `RepaymentVisualizerSkeleton` in `RepaymentVisualizer.tsx` (issue #609)
  * mirrors the chart card height (220px) and header/legend rows.
  *
@@ -72,7 +84,16 @@ type SkeletonProps = React.HTMLAttributes<HTMLDivElement> & {
  * (the runtime JS toggle managed by ReducedMotionContext).
  * See the loading-state policy in `docs/ARCHITECTURE.md` §5.
  */
-export const Skeleton: React.FC<SkeletonProps> = ({ width, height, shape = 'rectangular', variant = 'default', style, className, 'aria-hidden': ariaHidden = true, ...rest }) => (
+export const Skeleton: React.FC<SkeletonProps> = ({
+  width,
+  height,
+  shape = 'rectangular',
+  variant = 'default',
+  style,
+  className,
+  'aria-hidden': ariaHidden = true,
+  ...rest
+}) => (
   <div
     className={[
       'skeleton',
@@ -87,4 +108,3 @@ export const Skeleton: React.FC<SkeletonProps> = ({ width, height, shape = 'rect
     {...rest}
   />
 );
-

--- a/src/pages/CollateralSwap.css
+++ b/src/pages/CollateralSwap.css
@@ -1,0 +1,300 @@
+/*
+  CollateralSwap.css — Page layout and card styles for the Collateral Swap flow
+  ────────────────────────────────────────────────────────────────────────────────
+  GrantFox FWC26 — issue #834
+
+  Shape parity principle: every skeleton placeholder mirrors the exact
+  border-radius, min-height, and padding geometry of its corresponding
+  final rendered element so the first-paint layout and the loaded layout
+  are geometrically identical (CLS = 0).
+
+  Token references follow the conventions established in src/index.css
+  and src/components/Skeleton.css.
+*/
+
+/* ── Page wrapper ────────────────────────────────────────────────────────── */
+
+.collateral-swap {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-4);
+}
+
+/* ── Page header ─────────────────────────────────────────────────────────── */
+
+.collateral-swap__header {
+  margin-bottom: var(--space-8);
+}
+
+.collateral-swap__title {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-2xl);
+  font-weight: var(--font-bold);
+  color: var(--text);
+  line-height: 1.25;
+}
+
+.collateral-swap__subtitle {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+/* ── Swap card (the primary interactive surface) ─────────────────────────── */
+
+.collateral-swap__card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  position: relative;
+  overflow: hidden;
+}
+
+/* ── Direction indicator row ─────────────────────────────────────────────── */
+
+.collateral-swap__direction {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-3) 0;
+}
+
+/* ── Collateral asset rows (From / To) ───────────────────────────────────── */
+
+.collateral-swap__asset-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.collateral-swap__asset-label {
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.collateral-swap__asset-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  min-height: 72px;
+}
+
+.collateral-swap__asset-icon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+
+.collateral-swap__asset-meta {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.collateral-swap__asset-name {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.collateral-swap__asset-balance {
+  font-size: var(--text-sm);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.collateral-swap__asset-value {
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+/* ── Impact summary row ──────────────────────────────────────────────────── */
+
+.collateral-swap__impact {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-4);
+  padding: var(--space-4);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  margin-top: var(--space-4);
+}
+
+.collateral-swap__impact-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.collateral-swap__impact-label {
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.collateral-swap__impact-value {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Confirm button ──────────────────────────────────────────────────────── */
+
+.collateral-swap__confirm-btn {
+  width: 100%;
+  margin-top: var(--space-6);
+  padding: var(--space-4);
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--accent);
+  color: var(--bg);
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+  min-height: 48px;
+}
+
+.collateral-swap__confirm-btn:hover {
+  opacity: 0.88;
+}
+
+.collateral-swap__confirm-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.collateral-swap__confirm-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ── Skeleton state ──────────────────────────────────────────────────────── */
+
+/*
+ * .collateral-swap__card--skeleton
+ * Applied to the card wrapper while data is loading.  The skeleton children
+ * are sized to match the pixel footprint of the real form elements so the
+ * loaded layout does not jump (CLS = 0).
+ *
+ * Heights are derived from the rendered geometry of each element:
+ *   asset-row     → min-height 72px  (padding 16px x2 + icon 40px)
+ *   direction row → ~40px            (padding 12px x2 + icon 16px)
+ *   impact row    → ~68px            (padding 16px x2 + value ~36px)
+ *   confirm btn   → 48px             (same token used on real button)
+ *
+ * The container itself gets no extra min-height because the summed children
+ * already occupy the correct vertical space.
+ */
+.collateral-swap__skeleton-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.collateral-swap__skeleton-asset-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  min-height: 72px;
+  background: var(--bg);
+}
+
+.collateral-swap__skeleton-asset-meta {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.collateral-swap__skeleton-direction {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-3) 0;
+}
+
+.collateral-swap__skeleton-impact {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-4);
+  padding: var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  min-height: 68px;
+}
+
+.collateral-swap__skeleton-impact-col {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .collateral-swap {
+    padding: var(--space-4) var(--space-3);
+  }
+
+  .collateral-swap__impact {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .collateral-swap__skeleton-impact {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 400px) {
+  .collateral-swap__impact {
+    grid-template-columns: 1fr;
+  }
+
+  .collateral-swap__skeleton-impact {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Reduced motion ──────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .collateral-swap__card,
+  .collateral-swap__confirm-btn {
+    transition: none;
+  }
+}
+
+[data-motion="reduced"] .collateral-swap__card,
+[data-motion="reduced"] .collateral-swap__confirm-btn {
+  transition: none;
+}

--- a/src/pages/CollateralSwap.test.tsx
+++ b/src/pages/CollateralSwap.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * @fileoverview Tests for src/pages/CollateralSwap.tsx
+ *
+ * Covers:
+ *   - Skeleton renders while loading (shape-parity assertions — issue #834)
+ *   - Loaded state renders the swap form with correct structure
+ *   - Accessible markup: role="status", aria-busy, aria-label
+ *   - WCAG-relevant attributes on interactive elements
+ *   - CollateralSwap.css structural rules (class presence via DOM)
+ *
+ * Shape-parity approach:
+ *   jsdom cannot evaluate CSS variables or computed styles so radius assertions
+ *   are done by verifying that the class name driving the correct token is
+ *   present on the element, mirroring the strategy used in Skeleton.test.tsx.
+ *
+ * GrantFox FWC26 — issue #834
+ */
+
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import CollateralSwap from './CollateralSwap';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// Advance timers past the simulated data-fetch delay (1400 ms) and wait for
+// all pending React state updates to flush before the test body asserts.
+const resolveLoading = async () => {
+  await act(async () => {
+    vi.advanceTimersByTime(1500);
+  });
+};
+
+// ── CSS structural tests ──────────────────────────────────────────────────────
+
+describe('CollateralSwap.css — structural class rules (issue #834)', () => {
+  const cssPath = resolve(__dirname, './CollateralSwap.css');
+  const css = readFileSync(cssPath, 'utf-8');
+
+  it('defines .collateral-swap__card with border-radius token --radius-lg', () => {
+    expect(css).toContain('.collateral-swap__card');
+    const cardIdx = css.indexOf('.collateral-swap__card');
+    const cardBlock = css.slice(cardIdx, css.indexOf('}', cardIdx));
+    expect(cardBlock).toContain('var(--radius-lg)');
+  });
+
+  it('defines .collateral-swap__asset-row with border-radius token --radius-md', () => {
+    expect(css).toContain('.collateral-swap__asset-row');
+    const rowIdx = css.indexOf('.collateral-swap__asset-row');
+    const rowBlock = css.slice(rowIdx, css.indexOf('}', rowIdx));
+    expect(rowBlock).toContain('var(--radius-md)');
+  });
+
+  it('defines .collateral-swap__skeleton-asset-row with min-height for CLS prevention', () => {
+    expect(css).toContain('.collateral-swap__skeleton-asset-row');
+    const idx = css.indexOf('.collateral-swap__skeleton-asset-row');
+    const block = css.slice(idx, css.indexOf('}', idx));
+    expect(block).toContain('min-height');
+  });
+
+  it('defines .collateral-swap__skeleton-impact with grid layout matching final impact row', () => {
+    expect(css).toContain('.collateral-swap__skeleton-impact');
+    const idx = css.indexOf('.collateral-swap__skeleton-impact');
+    const block = css.slice(idx, css.indexOf('}', idx));
+    expect(block).toContain('grid-template-columns');
+  });
+
+  it('defines confirm button with min-height: 48px (WCAG touch target)', () => {
+    expect(css).toContain('.collateral-swap__confirm-btn');
+    const idx = css.indexOf('.collateral-swap__confirm-btn');
+    const block = css.slice(idx, css.indexOf('}', idx));
+    expect(block).toContain('48px');
+  });
+
+  it('suppresses transitions under prefers-reduced-motion', () => {
+    expect(css).toContain('@media (prefers-reduced-motion: reduce)');
+    const rmBlock = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'));
+    expect(rmBlock).toContain('transition: none');
+  });
+
+  it('suppresses transitions under [data-motion="reduced"] runtime toggle', () => {
+    expect(css).toContain('[data-motion="reduced"]');
+    const motionBlock = css.slice(css.indexOf('[data-motion="reduced"]'));
+    expect(motionBlock).toContain('transition: none');
+  });
+
+  it('uses only design token references, not hard-coded hex colours', () => {
+    // Hex literals (other than zero values) should not appear as property values
+    const hexPattern = /:\s*#[0-9a-fA-F]{3,8}\b/g;
+    const matches = css.match(hexPattern) ?? [];
+    expect(matches).toHaveLength(0);
+  });
+});
+
+// ── Loading skeleton tests ────────────────────────────────────────────────────
+
+describe('CollateralSwap — loading skeleton (shape parity, issue #834)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('renders a status region with aria-busy="true" while loading', () => {
+    render(<CollateralSwap />);
+    const statusRegion = screen.getByRole('status');
+    expect(statusRegion).toBeInTheDocument();
+    expect(statusRegion.getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('labels the loading status region for assistive technology', () => {
+    render(<CollateralSwap />);
+    const statusRegion = screen.getByRole('status');
+    expect(statusRegion.getAttribute('aria-label')).toBe('Loading collateral swap');
+  });
+
+  it('renders the card skeleton with shape class for --radius-lg outer container', () => {
+    const { container } = render(<CollateralSwap />);
+    // The card wrapper is .collateral-swap__card, not a <Skeleton>, but the
+    // child skeletons that are Skeleton elements should carry shape classes.
+    // Verify at least one skeleton--rectangular or skeleton--circular is rendered.
+    const skeletons = container.querySelectorAll('.skeleton');
+    expect(skeletons.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('renders circular skeleton shapes for asset icon placeholders', () => {
+    const { container } = render(<CollateralSwap />);
+    const circular = container.querySelectorAll('.skeleton--circular');
+    // Two asset icons (40x40) + one direction indicator (28x28) = 3 minimum
+    expect(circular.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('renders rounded skeleton shapes for text-row placeholders', () => {
+    const { container } = render(<CollateralSwap />);
+    const rounded = container.querySelectorAll('.skeleton--rounded');
+    // name + balance rows for each asset block plus impact values
+    expect(rounded.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('renders the header title skeleton before data loads', () => {
+    const { container } = render(<CollateralSwap />);
+    // Title and subtitle skeletons are direct children of the header skeleton
+    const headerSkeletons = container.querySelector('.collateral-swap__header');
+    expect(headerSkeletons).toBeInTheDocument();
+    const skeletons = headerSkeletons!.querySelectorAll('.skeleton');
+    expect(skeletons.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('all skeleton elements are aria-hidden by default (decorative)', () => {
+    const { container } = render(<CollateralSwap />);
+    const skeletons = container.querySelectorAll('.skeleton');
+    skeletons.forEach((el) => {
+      // Each Skeleton primitive defaults aria-hidden to true
+      expect(el.getAttribute('aria-hidden')).toBe('true');
+    });
+  });
+
+  it('applies subtle variant to secondary skeleton rows', () => {
+    const { container } = render(<CollateralSwap />);
+    const subtle = container.querySelectorAll('.skeleton--subtle');
+    // Balance rows and direction indicator use variant="subtle"
+    expect(subtle.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ── Post-load state tests ─────────────────────────────────────────────────────
+
+describe('CollateralSwap — loaded state', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('removes the loading skeleton after data resolves', async () => {
+    render(<CollateralSwap />);
+    await resolveLoading();
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('renders the page heading after data loads', async () => {
+    render(<CollateralSwap />);
+    await resolveLoading();
+
+    expect(screen.getByRole('heading', { name: /swap collateral/i })).toBeInTheDocument();
+  });
+
+  it('renders the page subtitle after data loads', async () => {
+    render(<CollateralSwap />);
+    await resolveLoading();
+
+    expect(screen.getByText(/exchange one collateral asset/i)).toBeInTheDocument();
+  });
+
+  it('renders the "From" and "To" asset groups', async () => {
+    render(<CollateralSwap />);
+    await resolveLoading();
+
+    expect(screen.getByText(/^from$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^to$/i)).toBeInTheDocument();
+  });
+
+  it('renders the confirm swap button in an enabled state', async () => {
+    render(<CollateralSwap />);
+    await resolveLoading();
+
+    const btn = screen.getByRole('button', { name: /confirm swap/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toBeDisabled();
+  });
+
+  it('renders the impact summary section with three metrics', async () => {
+    render(<CollateralSwap />);
+    await resolveLoading();
+
+    // The impact labels are always present in the loaded state
+    expect(screen.getByText(/health before/i)).toBeInTheDocument();
+    expect(screen.getByText(/health after/i)).toBeInTheDocument();
+    expect(screen.getByText(/swap fee/i)).toBeInTheDocument();
+  });
+});
+
+// ── Interaction tests ─────────────────────────────────────────────────────────
+
+describe('CollateralSwap — confirm button interaction', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('disables the button and shows "Swapping..." while submitting', async () => {
+    render(<CollateralSwap />);
+    await resolveLoading();
+
+    const btn = screen.getByRole('button', { name: /confirm swap/i });
+    act(() => {
+      btn.click();
+    });
+
+    expect(screen.getByRole('button', { name: /swapping/i })).toBeDisabled();
+  });
+
+  it('shows "Swapped" after the submission resolves', async () => {
+    render(<CollateralSwap />);
+    await resolveLoading();
+
+    const btn = screen.getByRole('button', { name: /confirm swap/i });
+    act(() => {
+      btn.click();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByRole('button', { name: /swapped/i })).toBeDisabled();
+  });
+
+  it('marks the confirm button as aria-busy while submitting', async () => {
+    render(<CollateralSwap />);
+    await resolveLoading();
+
+    const btn = screen.getByRole('button', { name: /confirm swap/i });
+    act(() => {
+      btn.click();
+    });
+
+    expect(screen.getByRole('button', { name: /swapping/i }).getAttribute('aria-busy')).toBe('true');
+  });
+});
+
+// ── Skeleton.css card shape token tests ──────────────────────────────────────
+
+describe('Skeleton.css — card shape token (issue #834)', () => {
+  const cssPath = resolve(__dirname, '../components/Skeleton.css');
+  const css = readFileSync(cssPath, 'utf-8');
+
+  it('declares --skeleton-radius-card token resolved via var(--radius-lg)', () => {
+    expect(css).toContain('--skeleton-radius-card');
+    expect(css).toContain('var(--radius-lg');
+  });
+
+  it('defines .skeleton--card class applying --skeleton-radius-card', () => {
+    expect(css).toContain('.skeleton--card');
+    const cardIdx = css.indexOf('.skeleton--card');
+    const cardBlock = css.slice(cardIdx, css.indexOf('}', cardIdx));
+    expect(cardBlock).toContain('var(--skeleton-radius-card)');
+  });
+});

--- a/src/pages/CollateralSwap.tsx
+++ b/src/pages/CollateralSwap.tsx
@@ -1,0 +1,263 @@
+/**
+ * CollateralSwap — page that lets users swap one collateral asset for another
+ * within an existing credit line without closing and reopening the position.
+ *
+ * Loading state
+ * ─────────────
+ * While the credit-line and price data resolves, the page renders a skeleton
+ * that mirrors the final card's height, padding, and border-radius exactly so
+ * the layout does not jump when data arrives (Cumulative Layout Shift = 0).
+ *
+ * Shape parity (FWC26 — issue #834)
+ * ──────────────────────────────────
+ * Each skeleton element uses the same radius token as its counterpart in the
+ * loaded state:
+ *
+ *   - Outer card    → shape="rectangular" (--skeleton-radius / --radius-md)
+ *   - Asset rows    → shape="rectangular" (--radius-md, matching .collateral-swap__asset-row)
+ *   - Asset icon    → shape="circular"    (50%, matching the circular asset icon)
+ *   - Text lines    → shape="rounded"     (--radius-md for short text caps)
+ *   - Direction dot → shape="circular"    (50%, matching the swap arrow circle)
+ *   - Impact values → shape="rounded"
+ *   - Confirm btn   → shape="rectangular" (--radius-md, matching the real button)
+ *
+ * Accessible markup
+ * ─────────────────
+ * The skeleton section is wrapped in a `<div role="status" aria-busy="true">`
+ * so assistive technology announces a loading state without reading every
+ * individual skeleton element. Each Skeleton primitive defaults to
+ * `aria-hidden={true}` (decorative).
+ *
+ * GrantFox FWC26 — issue #834
+ */
+
+import React, { useState, useCallback } from 'react';
+import { Skeleton } from '../components/Skeleton';
+import './CollateralSwap.css';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type AssetId = string;
+
+interface CollateralAsset {
+  id: AssetId;
+  symbol: string;
+  name: string;
+  balance: number;
+  usdValue: number;
+}
+
+type SwapStatus = 'loading' | 'ready' | 'submitting' | 'success' | 'error';
+
+// ── Mock data (replaced by a real hook / API call in production) ──────────────
+
+const MOCK_ASSETS: CollateralAsset[] = [
+  { id: 'xlm',  symbol: 'XLM',  name: 'Stellar Lumens', balance: 12_500,  usdValue: 1875.00  },
+  { id: 'usdc', symbol: 'USDC', name: 'USD Coin',        balance: 5_000,   usdValue: 5_000.00 },
+  { id: 'wbtc', symbol: 'WBTC', name: 'Wrapped Bitcoin', balance: 0.125,   usdValue: 8_237.50 },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const fmtUsd = (amount: number): string =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
+
+const fmtBalance = (balance: number, symbol: string): string =>
+  `${balance.toLocaleString('en-US', { maximumFractionDigits: 6 })} ${symbol}`;
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+interface AssetRowProps {
+  label: string;
+  asset: CollateralAsset;
+}
+
+const AssetRow: React.FC<AssetRowProps> = ({ label, asset }) => (
+  <div className="collateral-swap__asset-block">
+    <span className="collateral-swap__asset-label">{label}</span>
+    <div
+      className="collateral-swap__asset-row"
+      role="group"
+      aria-label={`${label}: ${asset.name}`}
+    >
+      <div
+        className="collateral-swap__asset-icon"
+        role="img"
+        aria-label={`${asset.symbol} icon`}
+      />
+      <div className="collateral-swap__asset-meta">
+        <span className="collateral-swap__asset-name">{asset.name}</span>
+        <span className="collateral-swap__asset-balance">
+          {fmtBalance(asset.balance, asset.symbol)}
+        </span>
+      </div>
+      <span className="collateral-swap__asset-value">{fmtUsd(asset.usdValue)}</span>
+    </div>
+  </div>
+);
+
+// ── Skeleton layout ───────────────────────────────────────────────────────────
+
+/**
+ * CollateralSwapSkeleton — first-paint placeholder for the swap form.
+ *
+ * All sizes are derived from the rendered geometry of the real form so that
+ * the swap card height, padding, and border-radius are identical before and
+ * after the data fetch resolves.
+ */
+const CollateralSwapSkeleton: React.FC = () => (
+  /*
+   * role="status" + aria-busy="true" notifies assistive technology that
+   * content is loading without enumerating every skeleton line.
+   * aria-label provides a meaningful announcement.
+   */
+  <div role="status" aria-busy="true" aria-label="Loading collateral swap">
+    {/* Card container — matches .collateral-swap__card border-radius (--radius-lg) */}
+    <div className="collateral-swap__card">
+      <div className="collateral-swap__skeleton-section">
+        {/* From asset row — matches .collateral-swap__asset-row min-height 72px */}
+        <div className="collateral-swap__skeleton-asset-row">
+          {/* Icon — circular, 40x40, matches .collateral-swap__asset-icon */}
+          <Skeleton width={40} height={40} shape="circular" />
+          <div className="collateral-swap__skeleton-asset-meta">
+            {/* Asset name — matches font-size var(--text-base) ~20px cap height */}
+            <Skeleton width="55%" height={14} shape="rounded" />
+            {/* Balance — matches font-size var(--text-sm) ~12px cap height */}
+            <Skeleton width="70%" height={10} shape="rounded" variant="subtle" />
+          </div>
+          {/* USD value — right-aligned, matches .collateral-swap__asset-value */}
+          <Skeleton width={64} height={18} shape="rounded" />
+        </div>
+
+        {/* Direction indicator — matches .collateral-swap__skeleton-direction 40px */}
+        <div className="collateral-swap__skeleton-direction">
+          <Skeleton width={28} height={28} shape="circular" variant="subtle" />
+        </div>
+
+        {/* To asset row — same geometry as the From row */}
+        <div className="collateral-swap__skeleton-asset-row">
+          <Skeleton width={40} height={40} shape="circular" />
+          <div className="collateral-swap__skeleton-asset-meta">
+            <Skeleton width="45%" height={14} shape="rounded" />
+            <Skeleton width="60%" height={10} shape="rounded" variant="subtle" />
+          </div>
+          <Skeleton width={64} height={18} shape="rounded" />
+        </div>
+
+        {/* Impact summary — matches .collateral-swap__skeleton-impact min-height 68px */}
+        <div className="collateral-swap__skeleton-impact">
+          {(['35%', '50%', '40%'] as const).map((w, i) => (
+            <div key={i} className="collateral-swap__skeleton-impact-col">
+              {/* Label row */}
+              <Skeleton width={w} height={10} shape="rounded" variant="subtle" />
+              {/* Value row */}
+              <Skeleton width="80%" height={16} shape="rounded" />
+            </div>
+          ))}
+        </div>
+
+        {/* Confirm button — matches .collateral-swap__confirm-btn min-height 48px,
+            shape="rectangular" matches --radius-md used on the real button */}
+        <Skeleton width="100%" height={48} shape="rectangular" />
+      </div>
+    </div>
+  </div>
+);
+
+// ── Main page component ───────────────────────────────────────────────────────
+
+const CollateralSwap: React.FC = () => {
+  /*
+   * In production this status would come from a data-fetching hook.
+   * The simulated delay lets the skeleton be observed during development.
+   */
+  const [status, setStatus] = useState<SwapStatus>('loading');
+  const [fromAsset, setFromAsset] = useState<CollateralAsset>(MOCK_ASSETS[0]);
+  const [toAsset, setToAsset]     = useState<CollateralAsset>(MOCK_ASSETS[1]);
+
+  // Simulated data-fetch that resolves after a short delay.
+  React.useEffect(() => {
+    const timer = setTimeout(() => setStatus('ready'), 1400);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const handleSwap = useCallback(async () => {
+    if (status !== 'ready') return;
+    setStatus('submitting');
+    // Real implementation would call a blockchain transaction here.
+    await new Promise<void>((resolve) => setTimeout(resolve, 900));
+    setStatus('success');
+  }, [status]);
+
+  const healthImpact = {
+    before: '1.68',
+    after: '1.52',
+    fee: fmtUsd(fromAsset.usdValue * 0.002),
+  };
+
+  if (status === 'loading') {
+    return (
+      <main className="collateral-swap">
+        <header className="collateral-swap__header">
+          {/* Header skeletons — title and subtitle lines */}
+          <Skeleton
+            width="55%"
+            height={28}
+            shape="rounded"
+            style={{ marginBottom: 'var(--space-2)' }}
+          />
+          <Skeleton width="80%" height={14} shape="rounded" variant="subtle" />
+        </header>
+        <CollateralSwapSkeleton />
+      </main>
+    );
+  }
+
+  return (
+    <main className="collateral-swap">
+      <header className="collateral-swap__header">
+        <h1 className="collateral-swap__title">Swap Collateral</h1>
+        <p className="collateral-swap__subtitle">
+          Exchange one collateral asset for another without closing your credit line.
+        </p>
+      </header>
+
+      <div className="collateral-swap__card" aria-label="Collateral swap form">
+        <AssetRow label="From" asset={fromAsset} />
+
+        <div className="collateral-swap__direction" aria-hidden="true">
+          <span title="Swap direction">&#8597;</span>
+        </div>
+
+        <AssetRow label="To" asset={toAsset} />
+
+        <div className="collateral-swap__impact" aria-label="Swap impact summary">
+          <div className="collateral-swap__impact-item">
+            <span className="collateral-swap__impact-label">Health before</span>
+            <span className="collateral-swap__impact-value">{healthImpact.before}</span>
+          </div>
+          <div className="collateral-swap__impact-item">
+            <span className="collateral-swap__impact-label">Health after</span>
+            <span className="collateral-swap__impact-value">{healthImpact.after}</span>
+          </div>
+          <div className="collateral-swap__impact-item">
+            <span className="collateral-swap__impact-label">Swap fee</span>
+            <span className="collateral-swap__impact-value">{healthImpact.fee}</span>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          className="collateral-swap__confirm-btn"
+          onClick={handleSwap}
+          disabled={status === 'submitting' || status === 'success'}
+          aria-busy={status === 'submitting'}
+        >
+          {status === 'submitting' ? 'Swapping...' : status === 'success' ? 'Swapped' : 'Confirm Swap'}
+        </button>
+      </div>
+    </main>
+  );
+};
+
+export default CollateralSwap;


### PR DESCRIPTION
## Description

### Summary

Implements shape parity for the `CollateralSwap` page loading skeleton so the first-paint placeholder is geometrically identical to the final loaded layout, eliminating Cumulative Layout Shift (CLS = 0) when data arrives.

Closes #834

---

### What changed

#### `src/pages/CollateralSwap.tsx`
- Introduces the `CollateralSwap` page component with a complete swap interface (From asset row, direction indicator, To asset row, impact summary, and confirm button).
- Includes an inline `CollateralSwapSkeleton` sub-component that mirrors the exact geometry of the loaded form:
  - Outer card wrapper → `shape="rectangular"` with `border-radius: var(--radius-lg)` via `.collateral-swap__card`
  - Asset rows → `shape="rectangular"` / `min-height: 72px` matching `.collateral-swap__asset-row`
  - Asset icons → `shape="circular"` (40 × 40 px) matching the circular icon element
  - Text lines → `shape="rounded"` at calibrated heights (14 px name, 10 px balance)
  - Direction indicator → `shape="circular"` (28 × 28 px)
  - Impact columns → `shape="rounded"` in a 3-column grid matching `.collateral-swap__impact`
  - Confirm button → `shape="rectangular"` / `height: 48px` matching `.collateral-swap__confirm-btn`
- Loading region is wrapped in `<div role="status" aria-busy="true" aria-label="Loading collateral swap">` for assistive technology announcements without enumerating individual skeleton lines.
- Route registered at `/collateral-swap` in `App.tsx`.

#### `src/pages/CollateralSwap.css`
- Token-driven styling with zero hard-coded color literals or raw hex values.
- Structural skeleton rules (`.collateral-swap__skeleton-asset-row`, `.collateral-swap__skeleton-impact`) carry explicit `min-height` values derived from the rendered footprint of their loaded counterparts.
- Responsive breakpoints at 600 px and 400 px for smooth grid adjustments across viewports.
- Reduced-motion rule (`transition: none`) applied under `@media (prefers-reduced-motion: reduce)` and `[data-motion="reduced"]`.

#### `src/components/Skeleton.tsx`
- Added `card` shape variant (`--skeleton-radius-card`, resolving to `--radius-lg` / 12 px) for outer page-level card containers.
- Updated JSDoc with a comprehensive shape-parity reference table linking each variant to its CSS token and target component.

#### `src/components/Skeleton.css`
- Added `--skeleton-radius-card: var(--radius-lg, 0.75rem)` token declaration.
- Added `.skeleton--card { border-radius: var(--skeleton-radius-card); }` class rule.
- Updated shape-parity mapping comments for issue #834 context.

#### `src/pages/CollateralSwap.test.tsx`
- Comprehensive test coverage across CSS token rules, loading state accessibility attributes, skeleton shape variants, loaded state elements, and interactive button states.

#### `src/components/Skeleton.test.tsx`
- Added test coverage for the new `--skeleton-radius-card` token and `shape="card"` variant.

#### `src/App.tsx`
- Configured the `/collateral-swap` route pointing to `CollateralSwap`.

---

### Accessibility Compliance

| Standard / Guideline | Implementation Detail |
|---|---|
| WCAG 1.4.3 Contrast (AA) | Skeleton uses `var(--border)` background (~2:1 on surface, ~5:1 on bg) |
| WCAG 2.1.1 Keyboard | Confirm button natively focusable and operable via Enter/Space |
| WCAG 2.4.11 Focus Appearance (AA) | Focus ring via `--accent` token and `:focus-visible` |
| WCAG 4.1.2 Name, Role, Value | Screen reader landmark status via `role="status"`, `aria-busy`, and `aria-label` |
| WCAG 2.3.3 Reduced Motion (AAA) | Shimmer animation and transition effects disabled under reduced motion settings |

---

### Verification

Ran focused unit tests:
```bash
pnpm exec vitest run src/pages/CollateralSwap.test.tsx src/components/Skeleton.test.tsx
