### PR TITLE
fix(SettingsAccount): static state under prefers-reduced-motion: reduce

### DIFF
--- a/src/pages/SettingsAccount.css
+++ b/src/pages/SettingsAccount.css
@@ -134,11 +134,37 @@
 /* ── Reduced motion ──────────────────────────────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
-  .settings-account__panel {
+  .settings-account__collapsible {
+    transition: none;
+  }
+
+  .settings-account__toggle {
     transition: none;
   }
 
   .settings-account__chevron {
     transition: none;
   }
+
+  .settings-account__panel {
+    transition: none;
+  }
+}
+
+/* In-app override via ReducedMotionContext (data-motion="reduced") */
+
+[data-motion="reduced"] .settings-account__collapsible {
+  transition: none !important;
+}
+
+[data-motion="reduced"] .settings-account__toggle {
+  transition: none !important;
+}
+
+[data-motion="reduced"] .settings-account__chevron {
+  transition: none !important;
+}
+
+[data-motion="reduced"] .settings-account__panel {
+  transition: none !important;
 }

--- a/src/pages/SettingsAccount.test.tsx
+++ b/src/pages/SettingsAccount.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import { ContrastProvider } from '../context/ContrastContext';
 import { ReducedMotionProvider } from '../context/ReducedMotionContext';
 import { SettingsAccount } from './SettingsAccount';
@@ -283,6 +285,61 @@ describe('SettingsAccount', () => {
       expect(rule.cssText).toContain('cursor: default');
 
       document.head.removeChild(style);
+    });
+  });
+
+  // ─── Reduced-motion CSS tests ───────────────────────────────────────────
+
+  describe('reduced-motion CSS rules', () => {
+    const cssPath = resolve(__dirname, './SettingsAccount.css');
+    const css = readFileSync(cssPath, 'utf-8');
+
+    it('contains @media (prefers-reduced-motion: reduce) block', () => {
+      expect(css).toContain('@media (prefers-reduced-motion: reduce)');
+    });
+
+    it('disables transition on .settings-account__collapsible under prefers-reduced-motion', () => {
+      const rmBlock = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'));
+      expect(rmBlock).toMatch(/\.settings-account__collapsible\s*\{[^}]*transition:\s*none/);
+    });
+
+    it('disables transition on .settings-account__toggle under prefers-reduced-motion', () => {
+      const rmBlock = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'));
+      expect(rmBlock).toMatch(/\.settings-account__toggle\s*\{[^}]*transition:\s*none/);
+    });
+
+    it('disables transition on .settings-account__chevron under prefers-reduced-motion', () => {
+      const rmBlock = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'));
+      expect(rmBlock).toMatch(/\.settings-account__chevron\s*\{[^}]*transition:\s*none/);
+    });
+
+    it('disables transition on .settings-account__panel under prefers-reduced-motion', () => {
+      const rmBlock = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'));
+      expect(rmBlock).toMatch(/\.settings-account__panel\s*\{[^}]*transition:\s*none/);
+    });
+
+    it('contains [data-motion="reduced"] block', () => {
+      expect(css).toContain('[data-motion="reduced"]');
+    });
+
+    it('disables transition on .settings-account__collapsible under [data-motion="reduced"]', () => {
+      const pattern = /\[data-motion=["']reduced["']\]\s*\.settings-account__collapsible\s*\{[^}]*transition:\s*none/;
+      expect(css).toMatch(pattern);
+    });
+
+    it('disables transition on .settings-account__toggle under [data-motion="reduced"]', () => {
+      const pattern = /\[data-motion=["']reduced["']\]\s*\.settings-account__toggle\s*\{[^}]*transition:\s*none/;
+      expect(css).toMatch(pattern);
+    });
+
+    it('disables transition on .settings-account__chevron under [data-motion="reduced"]', () => {
+      const pattern = /\[data-motion=["']reduced["']\]\s*\.settings-account__chevron\s*\{[^}]*transition:\s*none/;
+      expect(css).toMatch(pattern);
+    });
+
+    it('disables transition on .settings-account__panel under [data-motion="reduced"]', () => {
+      const pattern = /\[data-motion=["']reduced["']\]\s*\.settings-account__panel\s*\{[^}]*transition:\s*none/;
+      expect(css).toMatch(pattern);
     });
   });
 });


### PR DESCRIPTION
## Description

Implements **static state** under `prefers-reduced-motion: reduce` for all `SettingsAccount` animations (GrantFox FWC26). Previously only the chevron and panel transitions were disabled — the collapsible section's `border-color` transition and the toggle button's `background` transition were still animating on hover.

Also adds the in-app `[data-motion="reduced"]` override block (set by `ReducedMotionContext`) so the runtime toggle has parity with the OS-level media query.

## Changes

### `src/pages/SettingsAccount.css`
- **`@media (prefers-reduced-motion: reduce)`** — added `transition: none` for `.settings-account__collapsible` and `.settings-account__toggle` (the panel and chevron were already covered)
- **`[data-motion="reduced"]`** — new block with `transition: none !important` on all four animated elements, matching the project convention used by `BottomNav`, `Dashboard`, `CreditLines`, etc.

### `src/pages/SettingsAccount.test.tsx`
- Added 10 CSS source-assertion tests verifying `transition: none` under both the OS media query and the `[data-motion="reduced"]` attribute selector for all four selectors

## Testing

- All 30 SettingsAccount tests pass (18 existing + 10 new + 2 existing from print tests)
- Pre-existing failures in unrelated files (`RepayPage`, `RepaySuccess`) are unchanged

## Accessibility

- WCAG 2.1 AA — respects OS `prefers-reduced-motion` and the in-app toggle
- Design-token driven, dark-mode consistent


## Closes #857 