### PR TITLE
feat(accessibility): add polite aria-live region to AttestationCard (…

### DIFF
--- a/src/components/AttestationCard.tsx
+++ b/src/components/AttestationCard.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router-dom';
+import { useEffect, useRef, useState } from 'react';
 import type { Attestation, AttestationStatus } from '../types/attestation';
 import { ATTESTATION_STATUS_COLOR, fmtDate } from '../utils/tokens';
+import { LiveRegion } from './LiveRegion';
 import './AttestationCard.css';
 
 const EXPIRING_WINDOW_DAYS = 14;
@@ -36,8 +38,32 @@ interface AttestationCardProps {
  * step for remediation.
  */
 export function AttestationCard({ attestations }: AttestationCardProps) {
+  const prevMapRef = useRef<Map<string, AttestationStatus>>(new Map());
+  const [announcement, setAnnouncement] = useState('');
+
+  useEffect(() => {
+    const currentMap = new Map<string, AttestationStatus>();
+    const changes: string[] = [];
+
+    for (const a of attestations) {
+      const status = getAttestationStatus(a);
+      currentMap.set(a.id, status);
+      const prev = prevMapRef.current.get(a.id);
+      if (prev && prev !== status) {
+        changes.push(`${a.label} status changed to ${STATUS_COPY[status]}`);
+      }
+    }
+
+    if (changes.length > 0) {
+      setAnnouncement(changes.join('. ') + '.');
+    }
+
+    prevMapRef.current = currentMap;
+  }, [attestations]);
+
   return (
     <div className="card attestation-card">
+      <LiveRegion message={announcement} politeness="polite" />
       <h2>
         <span className="icon">🪪</span> Attestations
       </h2>

--- a/src/components/__tests__/AttestationCard.test.tsx
+++ b/src/components/__tests__/AttestationCard.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AttestationCard } from '../AttestationCard';
+import type { Attestation } from '../../types/attestation';
+
+const BASE_DATE = new Date('2026-07-01T00:00:00Z').getTime();
+
+function makeAttestation(
+  overrides: Partial<Attestation> & { id: string },
+): Attestation {
+  return {
+    label: 'Test Attestation',
+    lastVerifiedAt: new Date(BASE_DATE - 30 * 86_400_000).toISOString(),
+    expiresAt: new Date(BASE_DATE + 150 * 86_400_000).toISOString(),
+    remediationStep: 1,
+    ...overrides,
+  };
+}
+
+describe('AttestationCard — live region announcements', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_DATE);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders with no announcement on initial mount', () => {
+    const attestations = [makeAttestation({ id: 'a1', label: 'Identity Bond' })];
+    render(<AttestationCard attestations={attestations} />);
+
+    const region = screen.getByRole('status');
+    expect(region).toHaveTextContent('');
+  });
+
+  it('announces when an attestation status changes', () => {
+    const verified = makeAttestation({ id: 'a1', label: 'Identity Bond' });
+    const { rerender } = render(<AttestationCard attestations={[verified]} />);
+
+    const expiring = makeAttestation({
+      id: 'a1',
+      label: 'Identity Bond',
+      expiresAt: new Date(BASE_DATE + 5 * 86_400_000).toISOString(),
+    });
+    rerender(<AttestationCard attestations={[expiring]} />);
+
+    const region = screen.getByRole('status');
+    expect(region).toHaveTextContent('Identity Bond status changed to Expiring soon.');
+  });
+
+  it('does not announce when statuses are unchanged', () => {
+    const att = makeAttestation({ id: 'a1', label: 'Identity Bond' });
+    const { rerender } = render(<AttestationCard attestations={[att]} />);
+
+    rerender(<AttestationCard attestations={[att]} />);
+
+    const region = screen.getByRole('status');
+    expect(region).toHaveTextContent('');
+  });
+
+  it('announces multiple status changes in a single message', () => {
+    const a1 = makeAttestation({ id: 'a1', label: 'Identity Bond' });
+    const a2 = makeAttestation({ id: 'a2', label: 'Revenue Proof' });
+    const { rerender } = render(<AttestationCard attestations={[a1, a2]} />);
+
+    const a1Expiring = makeAttestation({
+      id: 'a1',
+      label: 'Identity Bond',
+      expiresAt: new Date(BASE_DATE + 5 * 86_400_000).toISOString(),
+    });
+    const a2Missing = makeAttestation({
+      id: 'a2',
+      label: 'Revenue Proof',
+      lastVerifiedAt: undefined,
+      expiresAt: undefined,
+    });
+    rerender(<AttestationCard attestations={[a1Expiring, a2Missing]} />);
+
+    const region = screen.getByRole('status');
+    expect(region).toHaveTextContent(
+      'Identity Bond status changed to Expiring soon. Revenue Proof status changed to Missing.',
+    );
+  });
+
+  it('renders with polite aria-live and status role', () => {
+    const attestations = [makeAttestation({ id: 'a1' })];
+    render(<AttestationCard attestations={attestations} />);
+
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+  });
+});


### PR DESCRIPTION
## Summary
- Added `LiveRegion` (polite `aria-live`) to `AttestationCard` that announces attestation status changes (Verified → Expiring → Missing) to assistive technology
- Tracks previous statuses via `useRef` and compares on prop changes to detect deltas
- Announcements are batched when multiple attestations change simultaneously

## Testing
- `src/components/__tests__/AttestationCard.test.tsx`
  - Initial mount produces no announcement
  - Status change (Verified → Expiring) produces correct announcement text
  - Identical re-render does not re-announce
  - Multiple simultaneous changes are joined into one message
  - LiveRegion renders with `role="status"` and `aria-live="polite"`
- All 5 tests passing

Closes #859