### PR TITLE
Wire Tooltip primitive to icon-only FAQ anchor on HelpCenter

### DIFF
--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Tooltip } from './Tooltip';
+import { exec } from 'node:child_process';
 
 describe('Tooltip Component', () => {
   beforeEach(() => {
@@ -113,4 +114,126 @@ describe('Tooltip Component', () => {
 
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
-});
+
+  test('attaches aria-describedby to the child element, no the wrapper span, once visible', () => {
+    render(
+      <Tooltip label="Copy link">
+        <button>Anchor</button>
+      </Tooltip>
+    );
+
+    const button = screen.getByRole('button', { name: 'Anchor'});
+    const wrapper = button.closest('.tooltip-wrapper')!;
+    const tooltip = screen.getByRole('tooltip', { hidden: true});
+
+    //Before showing: neither element is described yet.
+    expect(button).not.toHaveAttribute('aria-describedby');
+    expect(wrapper).not.toHaveAttribute('aria-describedby');
+
+    fireEvent.focus(wrapper);
+
+    //After showing: the button (focusable child) carries aria-describedby
+    //pointing at the tooltip's id - the wrapper span never does.
+    expect(button).toHaveAttribute('aria-describedby', tooltip.id);
+    expect(wrapper).not.toHaveAttribute('aria-describedby');
+  });
+
+  test('merges tooltip id into an existing aria-describedby instead of overwriting it', () => {
+    render(
+        <Tooltip label="Copy link">
+          <button aria-describedby='existing-error-id'>Anchor</button>
+        </Tooltip>
+      );
+
+    const button = screen.getByRole('button', {name: 'Anchor' });
+    const wrapper = button.closest('.tooltip-wrapper')!;
+    const tooltip = screen.getByRole('tooltip', { hidden: true});
+
+    //before showing: the child's own aria-describedby is untouched.
+    expect(button).toHaveAttribute('aria-describedby', 'existing-error-id');
+
+    fireEvent.focus(wrapper);
+
+    //After showing: both ids are present, space-separated, existing one first.
+    expect(button).toHaveAttribute(
+      'aria-describedby',
+      `existing-error-id ${tooltip.id}`
+    );
+  });
+
+    test('Escape dimisses the tooltip while it is visible', () => {
+      render(
+        <Tooltip label='Escape test tooltip'>
+          <button>Anchor</button>
+        </Tooltip>
+      );
+
+      const wrapper = screen.getByText('Anchor').closest('.tooltip-wrapper')!;
+      fireEvent.focus(wrapper);
+      expect(screen.getByRole('tooltip')).toHaveClass('is-visible');
+
+      fireEvent.keyDown(wrapper, { key: 'Escape'});
+      expect(screen.getByRole('tooltip', { hidden: true })).not.toHaveClass('is-visible');
+    });
+
+    test('Escape does not stop propagation, so a parent listener still fires', () => {
+      const parentHandler = vi.fn();
+
+      render(
+        <div onKeyDown={parentHandler}>
+          <Tooltip label='Escape propagation test'>
+            <button>Anchor</button>
+          </Tooltip>
+        </div>
+      );
+
+      const wrapper = screen.getByText('Anchor').closest('.tooltip-wrapper')!;
+      fireEvent.focus(wrapper);
+      fireEvent.keyDown(wrapper, { key: 'Escape' });
+
+      expect(parentHandler).toHaveBeenCalledTimes(1);
+    });
+    
+    test('touchmove cancels a pending long-press before it fires', () => {
+      render(
+        <Tooltip label='Touchmove test' longPressDelay={500}>
+          <button>Touch me</button>
+        </Tooltip>
+      );
+
+      const wrapper = screen.getByText('Touch me').closest('.tooltip-wrapper')!;
+      fireEvent.touchStart(wrapper);
+
+      //Finger moves before the 500ms therehold - this should cancel the timer.
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+      fireEvent.touchMove(wrapper);
+
+      //Even after the original delay would have elapsed, tooltip never shows.
+      act(() =>  {
+        vi.advanceTimersByTime(400);
+      });
+      expect(screen.getByRole('tooltip', { hidden: true})).not.toHaveClass('is-visible');
+    });
+
+    test('touchmove after the tooltip is already visible does not hide it', () => {
+      render(
+        <Tooltip label='Touchmove no-op test' longPressDelay={500}>
+          <button>Touch me</button>
+        </Tooltip>
+      );
+
+      const wrapper = screen.getByText('Touch me').closest('.tooltip-wrapper')!;
+      fireEvent.touchStart(wrapper);
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(screen.getByRole('tooltip')).toHaveClass('is-visible');
+
+      //Moving after it's already shown is a no-op (clearTimer on a null timer).
+      fireEvent.touchMove(wrapper);
+      expect(screen.getByRole('tooltip')).toHaveClass('is-visible');
+    });
+  });

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { useId, useState, useRef, useEffect, type ReactNode, type HTMLAttributes } from 'react';
+import { useId, useState, useRef, useEffect, cloneElement, isValidElement, type ReactNode, type ReactElement, type HTMLAttributes  } from 'react';
 import './Tooltip.css';
 
 export interface TooltipProps extends HTMLAttributes<HTMLSpanElement> {
@@ -66,6 +66,12 @@ export function Tooltip({
     clearTimer();
     setIsVisible(false);
   };
+//Cancel a pending tooltip display if the user moves their finger on the screen, indicating they are scrolling rather than intending to long-press.
+//No-op once the tooltip has already fired, since timerRef will be null and clearTimer will do nothing.
+
+  const handleTouchMove = () => {
+    clearTimer();
+  };
 
   const handleFocus = () => {
     if (disabled || !label) return;
@@ -78,6 +84,17 @@ export function Tooltip({
     setIsVisible(false);
   };
 
+  //Escape dimisses the tooltip. Propagation is not stopped, so a parent dialog 
+  // or modal can also handle the Escape key if needed. This is a common pattern 
+  // in accessible UI components.
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key === 'Escape' && isVisible) {
+      clearTimer();
+      setIsVisible(false);
+    }
+  };
+
   useEffect(() => {
     return clearTimer;
   }, []);
@@ -85,6 +102,17 @@ export function Tooltip({
   if (disabled || !label) {
     return <>{children}</>;
   }
+
+  const child = isValidElement(children) ? (children as ReactElement<any>) : null;
+
+  const existingDescribedBy: string | undefined = child?.props?.['aria-describedby']
+  const describedBy = isVisible
+  ? [existingDescribedBy, tooltipId].filter(Boolean).join(' ')
+  : existingDescribedBy;
+
+  const wrappedChild = child
+  ? cloneElement(child, {'aria-describedby': describedBy || undefined })
+  : children;
 
   return (
     <span
@@ -94,12 +122,13 @@ export function Tooltip({
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
       onTouchCancel={handleTouchEnd}
+      onTouchMove={handleTouchMove}
       onFocus={handleFocus}
       onBlur={handleBlur}
-      aria-describedby={isVisible ? tooltipId : undefined}
+      onKeyDown={handleKeyDown}
       {...props}
     >
-      {children}
+      {wrappedChild}
       <span
         id={tooltipId}
         role="tooltip"

--- a/src/pages/HelpCenter.test.tsx
+++ b/src/pages/HelpCenter.test.tsx
@@ -202,4 +202,30 @@ describe("HelpCenter", () => {
     expect(faqButton).toHaveAttribute("aria-current", "true");
     expect(faqButton).toHaveAttribute("aria-expanded", "true");
   });
+
+  it("shows a tooltip on the FAQ anchor after hover delay, without breaking its accesible name", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true});
+    const user = userEvent.setup({ delay: null});
+
+    render(
+      <MemoryRouter>
+        <HelpCenter />
+      </MemoryRouter>
+    );
+
+    const faqAnchor = screen.getByRole("link", { name: /direct link to faq: what is creditra\?/i });
+    //accessible name is untouched by the tooltip wiring.
+    expect(faqAnchor).toHaveAttribute("aria-label", "Direct link to FAQ: What is Creditra?");
+
+    await user.hover(faqAnchor);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toHaveClass("is-visible");
+    expect(faqAnchor).toHaveAttribute("aria-describedby", tooltip.id);
+
+    vi.useRealTimers();
+  })
 });

--- a/src/pages/HelpCenter.tsx
+++ b/src/pages/HelpCenter.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Search, ChevronDown } from "lucide-react";
 import { useLocation } from "react-router-dom";
 import SupportForm from "../components/SupportForm";
-
+import { Tooltip } from "../components/Tooltip";
 import { VideoThumbnail } from "../components/VideoThumbnail";
 import { useActiveSection } from "../hooks/useActiveSection";
 import { useReducedMotion } from "../context/ReducedMotionContext";
@@ -229,7 +229,7 @@ export default function HelpCenter() {
               return (
                 <div key={item.id} id={item.id} className="help-center__faq-item">
                   <div className="help-center__faq-header">
-                    <a
+                    <Tooltip label="Copy link"><a
                       href={`#${item.id}`}
                       className="help-center__faq-anchor"
                       aria-current={isCurrent ? "true" : undefined}
@@ -237,7 +237,8 @@ export default function HelpCenter() {
                       onClick={(e) => handleFaqAnchorClick(e, item.id)}
                     >
                       #
-                    </a>
+                      </a>
+                    </Tooltip>
                     <button
                       onClick={() => handleFaqToggle(item.id)}
                       className="help-center__faq-btn"


### PR DESCRIPTION
Closes #862 

## What changed

Wired the shared `Tooltip` primitive to the icon-only FAQ anchor link on HelpCenter (`#` link before each FAQ question — the only icon-only interactive element on this page; the FAQ toggle button and video-play button both carry visible text. alongside their icons, so they're out of scope for this issue).

## Tooltip.tsx fixes

While wiring the anchor, found and fixed three accessibility bugs that were blocking WCAG 2.1 AA compliance:

1. `aria-describedby` was set on the non-focusable wrapper `<span>` instead of the focusable child — screen readers never announced the tooltip on keyboard focus. Now cloned onto the child via `cloneElement`, merging with any existing `aria-describedby` the child already carries instead of overwriting it.
2. Missing `Escape` dismissal (WCAG SC 1.4.13 requires this). Added, without `stopPropagation` so a parent modal/dialog listening for Escape isn't blocked.
3. Long-press timer wasn't cancelled on `touchmove`, so scrolling past an icon-only button while touching it could fire the tooltip unintentionally. Now cancelled.

## Tests

- 6 new tests in `Tooltip.test.tsx` covering the three fixes above.
- 1 new test in `HelpCenter.test.tsx` confirming the FAQ anchor shows a tooltip after the hover delay without breaking its existing `aria-label`/`aria-current` behavior.
- All 8 pre-existing `HelpCenter.test.tsx` tests and all 6 pre-existing `Tooltip.test.tsx` tests still pass unmodified.

## Verified out of scope

Ran the full suite (`npx vitest run`) and `npx tsc --noEmit`, and confirmed via `git stash` that pre-existing failures (48 unrelated test files, 23 pre-existing TS syntax errors in `CreditLineSelector.tsx`, `PreviewSection.tsx`, `RiskGauge.test.tsx`, `CreditLines.tsx`) are present with or without this change — unrelated to this PR.