### PR TITLE
feat: themed empty state on AgingTag page with CTA (GrantFox FWC26)

### DIFF
--- a/docs/EMPTY_STATE.md
+++ b/docs/EMPTY_STATE.md
@@ -44,12 +44,18 @@ whatever foreground colour the surrounding tone sets.
 | `NoDataGraph`      | Filters narrow transactions to zero results          |
 | `NoOutstandingDebt`| The user has nothing to repay (issue #581, Repay)    |
 | `NoRiskGauge`      | No risk score data available yet (issue #694)        |
+| `NoOverdue`        | No credit lines are past due (GrantFox FWC26)        |
 
 Add new illustrations next to these. Keep all SVGs `currentColor`-only
 so they theme through transparent token inheritance.
 
 ## Adopters
 
+- **`AgingTagPage`** (`src/pages/AgingTag.tsx`) — shows the `NoOverdue`
+  illustration with a success-tone empty state when no credit lines are
+  past due (GrantFox FWC26). The CTAs point to `/credit-lines` (view lines)
+  and `/` (dashboard). When delinquent lines exist, the page renders a
+  summary list with `AgingTag` badges and a "Repay Now" link per line.
 - **`RepayPage`** (`src/pages/RepayPage.tsx`) — replaces the bare fallback
   paragraph with the themed empty state when no credit line has
   `status === 'Active' && utilized > 0`. The CTAs point to `/open-credit`
@@ -88,3 +94,5 @@ so they theme through transparent token inheritance.
 - `src/pages/__tests__/RepayPage.empty.test.tsx` — RepayPage empty-state
   render path (separate file to avoid mock isolation with the populated
   suite in `RepayPage.test.tsx`).
+- `src/pages/__tests__/AgingTag.emptyState.test.tsx` — AgingTagPage empty
+  state and populated-path tests (12 tests).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import RepayCalendar from "./pages/RepayCalendar";
 import { SettingsAccount } from "./pages/SettingsAccount";
 import { Theme } from "./pages/settings/Theme";
 import { LinkedAccounts } from "./pages/LinkedAccounts";
+import AgingTagPage from "./pages/AgingTag";
 import { WalletReconnectBanner } from "./components/WalletReconnectBanner";
 import { SessionTimeoutBanner } from "./components/SessionTimeoutBanner";
 import { NetworkMismatchBanner } from "./components/notifications/NetworkMismatchBanner";
@@ -246,6 +247,7 @@ function App() {
                         <Route path="/settings/account" element={<SettingsAccount />} />
                         <Route path="/settings/theme" element={<Theme />} />
                         <Route path="/linked-accounts" element={<LinkedAccounts />} />
+                        <Route path="/aging" element={<AgingTagPage />} />
                         {/* Issue #581: Repay flow (now reachable from header /
                             the "Repay" action on Credit Lines). */}
                         <Route path="/repay" element={<RepayPage />} />

--- a/src/components/illustrations/EmptyStateIllustrations.tsx
+++ b/src/components/illustrations/EmptyStateIllustrations.tsx
@@ -162,6 +162,44 @@ export function NoRiskGauge(props: IllustrationProps) {
   );
 }
 
+/**
+ * NoOverdue — illustrated empty state for the AgingTag page.
+ *
+ * Composition: a stylised calendar page with a green checkmark badge,
+ * communicating that no credit lines are past due. The calendar motif
+ * was chosen because "aging" is inherently a time-based concept; the
+ * checkmark reinforces the positive "all current" message.
+ *
+ * Inherits `--accent` (or any other surrounding foreground) via `currentColor`
+ * so it stays consistent with light, dark, and high-contrast themes.
+ */
+export function NoOverdue(props: IllustrationProps) {
+  return (
+    <IllustrationFrame {...props}>
+      <svg viewBox="0 0 180 140" fill="none" focusable="false">
+        {/* calendar body */}
+        <rect x="24" y="26" width="132" height="100" rx="16" stroke="currentColor" strokeWidth="2" opacity="0.24" />
+        {/* calendar header bar */}
+        <path d="M24 42h132" stroke="currentColor" strokeWidth="2" opacity="0.12" />
+        {/* calendar page corners — hint of page curl */}
+        <path d="M140 126h-8v-8" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" opacity="0.15" />
+        {/* date grid dashes */}
+        <path d="M38 58h30" stroke="currentColor" strokeWidth="3" strokeLinecap="round" opacity="0.18" />
+        <path d="M38 72h104" stroke="currentColor" strokeWidth="3" strokeLinecap="round" opacity="0.14" />
+        <path d="M38 86h80" stroke="currentColor" strokeWidth="3" strokeLinecap="round" opacity="0.14" />
+        <path d="M38 100h56" stroke="currentColor" strokeWidth="3" strokeLinecap="round" opacity="0.10" />
+        {/* clock icon hint on the right */}
+        <circle cx="138" cy="76" r="14" stroke="currentColor" strokeWidth="2" opacity="0.30" />
+        <path d="M138 68v8l5 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" opacity="0.30" />
+        {/* large checkmark badge — the hero element */}
+        <circle cx="64" cy="108" r="20" stroke="currentColor" strokeWidth="2" opacity="0.85" />
+        <circle cx="64" cy="108" r="16" stroke="currentColor" strokeWidth="1" opacity="0.24" />
+        <path d="M56 108l5 5 11-11" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </IllustrationFrame>
+  );
+}
+
 export function NoOutstandingDebt(props: IllustrationProps) {
   return (
     <IllustrationFrame {...props}>

--- a/src/components/illustrations/index.ts
+++ b/src/components/illustrations/index.ts
@@ -1,1 +1,1 @@
-export { NoActivity, NoDataGraph, NoLines, NoOutstandingDebt, NoRiskGauge } from './EmptyStateIllustrations';
+export { NoActivity, NoDataGraph, NoLines, NoOutstandingDebt, NoOverdue, NoRiskGauge } from './EmptyStateIllustrations';

--- a/src/pages/AgingTag.css
+++ b/src/pages/AgingTag.css
@@ -1,0 +1,178 @@
+.aging-page {
+  padding: 1.5rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.aging-page-header {
+  margin-bottom: 1.5rem;
+}
+
+.aging-page-header h1 {
+  margin: 0 0 0.35rem;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.aging-page-subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.aging-line-count {
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+.aging-line-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.aging-line-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  transition: border-color 0.15s ease;
+}
+
+.aging-line-card:hover {
+  border-color: var(--accent);
+}
+
+.aging-line-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.aging-line-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.aging-line-name {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.aging-line-id {
+  font-size: 0.72rem;
+  color: var(--muted);
+  font-family: var(--font-mono, monospace);
+  white-space: nowrap;
+}
+
+.aging-line-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.aging-line-metrics {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.aging-line-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.aging-line-metric-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.aging-line-metric-value {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.aging-line-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.aging-line-repay-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  padding: 0.4rem 0.9rem;
+  border-radius: 6px;
+  color: var(--bg);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    filter 0.15s ease,
+    transform 0.15s ease;
+}
+
+.aging-line-repay-btn:hover {
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+}
+
+.aging-line-repay-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+@media (max-width: 480px) {
+  .aging-page {
+    padding: 1rem;
+  }
+
+  .aging-page-header h1 {
+    font-size: 1.25rem;
+  }
+
+  .aging-line-header {
+    flex-direction: column;
+  }
+
+  .aging-line-metrics {
+    gap: 1rem;
+  }
+}
+
+[data-contrast="high"] .aging-line-card {
+  border-color: var(--border);
+  outline: 1px solid transparent;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aging-line-card:hover {
+    border-color: var(--border);
+  }
+
+  .aging-line-repay-btn:hover {
+    transform: none;
+  }
+}

--- a/src/pages/AgingTag.tsx
+++ b/src/pages/AgingTag.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { AgingTag } from '../components/AgingTag';
+import { EmptyState } from '../components/EmptyState';
+import { NoOverdue } from '../components/illustrations';
+import { StatusBadge } from '../components/StatusBadge';
+import { MOCK_CREDIT_LINES } from '../data/mockData';
+import { COLOR, fmt } from '../utils/tokens';
+import type { CreditLine } from '../types/creditLine';
+import './AgingTag.css';
+
+function daysPastDue(line: CreditLine): number {
+  const overdueEntry = line.statusHistory
+    .filter((h) => h.status === 'Suspended' || h.status === 'Defaulted')
+    .pop();
+  if (!overdueEntry) return 0;
+  const diff = Math.abs(Date.now() - new Date(overdueEntry.date).getTime());
+  return Math.ceil(diff / (1000 * 60 * 60 * 24));
+}
+
+function CreditLineRow({ line }: { line: CreditLine }) {
+  const days = daysPastDue(line);
+
+  return (
+    <div className="aging-line-card">
+      <div className="aging-line-header">
+        <div className="aging-line-title-row">
+          <h3 className="aging-line-name">{line.name}</h3>
+          <StatusBadge status={line.status} />
+        </div>
+        <span className="aging-line-id">{line.id}</span>
+      </div>
+
+      <div className="aging-line-body">
+        <div className="aging-line-metrics">
+          <div className="aging-line-metric">
+            <span className="aging-line-metric-label">Limit</span>
+            <span className="aging-line-metric-value">{fmt(line.limit)}</span>
+          </div>
+          <div className="aging-line-metric">
+            <span className="aging-line-metric-label">Utilized</span>
+            <span className="aging-line-metric-value">{fmt(line.utilized)}</span>
+          </div>
+          <div className="aging-line-metric">
+            <span className="aging-line-metric-label">APR</span>
+            <span className="aging-line-metric-value">{line.apr}%</span>
+          </div>
+        </div>
+
+        <div className="aging-line-actions">
+          <AgingTag daysPastDue={days} />
+          <Link
+            to={`/repay?line=${line.id}`}
+            className="aging-line-repay-btn"
+            style={{
+              background: COLOR.accent,
+              border: `1px solid ${COLOR.accent}`,
+            }}
+          >
+            Repay Now
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AgingTagPage() {
+  const delinquentLines = useMemo(
+    () => MOCK_CREDIT_LINES.filter(
+      (cl) => cl.status === 'Defaulted' || cl.status === 'Suspended'
+    ),
+    [],
+  );
+
+  const hasDelinquent = delinquentLines.length > 0;
+
+  return (
+    <div className="aging-page">
+      <div className="aging-page-header">
+        <h1>Aging Credit Lines</h1>
+        <p className="aging-page-subtitle">
+          Credit lines that are past due or require attention
+        </p>
+      </div>
+
+      {!hasDelinquent ? (
+        <EmptyState
+          data-testid="aging-empty-state"
+          tone="success"
+          eyebrow="All caught up"
+          illustration={<NoOverdue className="empty-state-illustration--muted" />}
+          title="No overdue credit lines"
+          description="All your credit lines are current. There are no past-due balances to address right now."
+          primaryAction={{ label: 'View Credit Lines', to: '/credit-lines' }}
+          secondaryAction={{ label: 'Back to Dashboard', to: '/' }}
+        />
+      ) : (
+        <div className="aging-line-list" data-testid="aging-line-list">
+          <div className="aging-line-count" role="status" aria-live="polite">
+            {delinquentLines.length} credit line{delinquentLines.length !== 1 ? 's' : ''} past due
+          </div>
+          {delinquentLines.map((line) => (
+            <CreditLineRow key={line.id} line={line} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default AgingTagPage;

--- a/src/pages/__tests__/AgingTag.emptyState.test.tsx
+++ b/src/pages/__tests__/AgingTag.emptyState.test.tsx
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AgingTagPage } from '../AgingTag';
+
+/**
+ * Issue #??? — themed empty state on the AgingTag page (GrantFox FWC26).
+ *
+ * These tests verify the empty-state render path:
+ *
+ * - the `<EmptyState />` renders with the success tone when no credit
+ *   lines are delinquent
+ * - the `NoOverdue` illustration is decorative (aria-hidden)
+ * - the helpful CTAs (View Credit Lines + Back to Dashboard) are present
+ * - the delinquent-line list collapses when all lines are current
+ * - the region uses role="status" + aria-live="polite" + aria-labelledby
+ *
+ * The populated path is tested by verifying that when mockData includes
+ * Defaulted / Suspended lines, the list renders instead of the empty state.
+ */
+
+// Mock mockData to return no delinquent lines for the empty-state suite.
+// We keep Active and Closed lines — they should not trigger the list.
+vi.mock('../../data/mockData', () => ({
+  MOCK_CREDIT_LINES: [
+    {
+      id: 'CL-TEST-001',
+      name: 'Healthy Business Line',
+      status: 'Active',
+      limit: 200000,
+      utilized: 50000,
+      apr: 7.5,
+      riskScore: 750,
+      openedAt: '2024-01-01',
+      updatedAt: '2025-01-01T00:00:00Z',
+      transactions: [],
+      statusHistory: [{ status: 'Active', date: '2024-01-01', note: 'Line opened' }],
+    },
+    {
+      id: 'CL-TEST-002',
+      name: 'Closed Line',
+      status: 'Closed',
+      limit: 50000,
+      utilized: 0,
+      apr: 10.0,
+      riskScore: 700,
+      openedAt: '2023-06-01',
+      updatedAt: '2024-12-01T00:00:00Z',
+      transactions: [],
+      statusHistory: [
+        { status: 'Active', date: '2023-06-01', note: 'Line opened' },
+        { status: 'Closed', date: '2024-12-01', note: 'Fully repaid' },
+      ],
+    },
+  ],
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/aging']}>
+      <AgingTagPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('AgingTagPage — empty state (GrantFox FWC26)', () => {
+  it('renders the themed empty state when no credit lines are delinquent', () => {
+    renderPage();
+
+    expect(
+      screen.getByRole('heading', { name: 'No overdue credit lines' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/all your credit lines are current/i),
+    ).toBeInTheDocument();
+  });
+
+  it('displays the "All caught up" eyebrow', () => {
+    renderPage();
+
+    expect(screen.getByText('All caught up')).toBeInTheDocument();
+  });
+
+  it('exposes primary CTA to /credit-lines', () => {
+    renderPage();
+
+    const cta = screen.getByRole('link', { name: 'View Credit Lines' });
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveAttribute('href', '/credit-lines');
+  });
+
+  it('exposes a secondary CTA back to the dashboard', () => {
+    renderPage();
+
+    const secondary = screen.getByRole('link', { name: 'Back to Dashboard' });
+    expect(secondary).toBeInTheDocument();
+    expect(secondary).toHaveAttribute('href', '/');
+  });
+
+  it('exposes the empty-state region with role=status and aria-live=polite', () => {
+    renderPage();
+
+    const region = screen.getByTestId('aging-empty-state');
+    expect(region).toHaveAttribute('role', 'status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region).toHaveAttribute('aria-labelledby');
+    const labelId = region.getAttribute('aria-labelledby');
+    expect(document.getElementById(labelId!)).toHaveTextContent(
+      'No overdue credit lines',
+    );
+    expect(region).toHaveClass('empty-state--success');
+  });
+
+  it('renders a decorative illustration with aria-hidden', () => {
+    const { container } = renderPage();
+
+    const illustration = container.querySelector('.empty-state-illustration');
+    expect(illustration).not.toBeNull();
+    expect(illustration?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('hides the delinquent-line list when no past-due lines exist', () => {
+    renderPage();
+
+    expect(screen.queryByTestId('aging-line-list')).not.toBeInTheDocument();
+  });
+
+  it('keeps the page header visible in the empty state', () => {
+    renderPage();
+
+    expect(
+      screen.getByRole('heading', { name: 'Aging Credit Lines' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/past due or require attention/i),
+    ).toBeInTheDocument();
+  });
+});
+
+/**
+ * Populated state — verify that when mockData includes Defaulted or
+ * Suspended lines, the delinquent list renders instead of the empty state.
+ */
+describe('AgingTagPage — with delinquent lines', () => {
+  it('renders the delinquent-line list when past-due lines exist', async () => {
+    // Dynamic re-mock for this suite only
+    vi.doMock('../../data/mockData', () => ({
+      MOCK_CREDIT_LINES: [
+        {
+          id: 'CL-DEFAULTED-001',
+          name: 'Defaulted Line',
+          status: 'Defaulted',
+          limit: 75000,
+          utilized: 75000,
+          apr: 14.5,
+          riskScore: 490,
+          openedAt: '2023-01-01',
+          updatedAt: '2024-11-01T10:00:00Z',
+          transactions: [],
+          statusHistory: [
+            { status: 'Active', date: '2023-01-01', note: 'Line opened' },
+            { status: 'Defaulted', date: '2024-11-01', note: '90+ days overdue' },
+          ],
+        },
+        {
+          id: 'CL-SUSPENDED-001',
+          name: 'Suspended Line',
+          status: 'Suspended',
+          limit: 100000,
+          utilized: 45000,
+          apr: 11.0,
+          riskScore: 610,
+          openedAt: '2023-06-01',
+          updatedAt: '2025-01-15T16:45:00Z',
+          transactions: [],
+          statusHistory: [
+            { status: 'Active', date: '2023-06-01', note: 'Line opened' },
+            { status: 'Suspended', date: '2025-01-15', note: 'Missed payment' },
+          ],
+        },
+      ],
+    }));
+    vi.resetModules();
+
+    const { AgingTagPage: FreshPage } = await import('../AgingTag');
+
+    render(
+      <MemoryRouter initialEntries={['/aging']}>
+        <FreshPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('aging-line-list')).toBeInTheDocument();
+    expect(screen.queryByTestId('aging-empty-state')).not.toBeInTheDocument();
+    expect(screen.getByText('Defaulted Line')).toBeInTheDocument();
+    expect(screen.getByText('Suspended Line')).toBeInTheDocument();
+  });
+
+  it('shows an AgingTag badge on each delinquent line card', async () => {
+    vi.doMock('../../data/mockData', () => ({
+      MOCK_CREDIT_LINES: [
+        {
+          id: 'CL-DEFAULTED-002',
+          name: 'Delinquent Line',
+          status: 'Defaulted',
+          limit: 50000,
+          utilized: 50000,
+          apr: 13.0,
+          riskScore: 520,
+          openedAt: '2023-03-01',
+          updatedAt: '2024-10-01T08:00:00Z',
+          transactions: [],
+          statusHistory: [
+            { status: 'Active', date: '2023-03-01', note: 'Line opened' },
+            { status: 'Defaulted', date: '2024-10-01', note: 'Over 90 days' },
+          ],
+        },
+      ],
+    }));
+    vi.resetModules();
+
+    const { AgingTagPage: FreshPage } = await import('../AgingTag');
+
+    render(
+      <MemoryRouter initialEntries={['/aging']}>
+        <FreshPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('aging-line-list')).toBeInTheDocument();
+    const agingTag = screen.getByText(/days past due/i);
+    expect(agingTag).toBeInTheDocument();
+  });
+
+  it('renders a Repay Now link for each delinquent line', async () => {
+    vi.doMock('../../data/mockData', () => ({
+      MOCK_CREDIT_LINES: [
+        {
+          id: 'CL-DEFAULTED-003',
+          name: 'Repayable Line',
+          status: 'Defaulted',
+          limit: 30000,
+          utilized: 30000,
+          apr: 15.0,
+          riskScore: 480,
+          openedAt: '2023-04-01',
+          updatedAt: '2024-12-01T12:00:00Z',
+          transactions: [],
+          statusHistory: [
+            { status: 'Active', date: '2023-04-01', note: 'Line opened' },
+            { status: 'Defaulted', date: '2024-12-01', note: 'Overdue' },
+          ],
+        },
+      ],
+    }));
+    vi.resetModules();
+
+    const { AgingTagPage: FreshPage } = await import('../AgingTag');
+
+    render(
+      <MemoryRouter initialEntries={['/aging']}>
+        <FreshPage />
+      </MemoryRouter>,
+    );
+
+    const repayBtn = screen.getByRole('link', { name: 'Repay Now' });
+    expect(repayBtn).toBeInTheDocument();
+    expect(repayBtn).toHaveAttribute('href', '/repay?line=CL-DEFAULTED-003');
+  });
+
+  it('renders the overdue line count in a status region', async () => {
+    vi.doMock('../../data/mockData', () => ({
+      MOCK_CREDIT_LINES: [
+        {
+          id: 'CL-DEFAULTED-004',
+          name: 'Line One',
+          status: 'Defaulted',
+          limit: 50000,
+          utilized: 25000,
+          apr: 12.0,
+          riskScore: 550,
+          openedAt: '2023-05-01',
+          updatedAt: '2025-01-01T00:00:00Z',
+          transactions: [],
+          statusHistory: [
+            { status: 'Active', date: '2023-05-01', note: 'Line opened' },
+            { status: 'Defaulted', date: '2025-01-01', note: 'Overdue' },
+          ],
+        },
+        {
+          id: 'CL-SUSPENDED-002',
+          name: 'Line Two',
+          status: 'Suspended',
+          limit: 40000,
+          utilized: 10000,
+          apr: 9.5,
+          riskScore: 620,
+          openedAt: '2024-01-01',
+          updatedAt: '2025-02-01T00:00:00Z',
+          transactions: [],
+          statusHistory: [
+            { status: 'Active', date: '2024-01-01', note: 'Line opened' },
+            { status: 'Suspended', date: '2025-02-01', note: 'Missed payment' },
+          ],
+        },
+      ],
+    }));
+    vi.resetModules();
+
+    const { AgingTagPage: FreshPage } = await import('../AgingTag');
+
+    render(
+      <MemoryRouter initialEntries={['/aging']}>
+        <FreshPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('2 credit lines past due')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Themed empty state on AgingTag page (GrantFox FWC26)

Adds a dedicated `/aging` page that shows delinquent credit lines with their
aging badges. When no lines are past due, a themed `<EmptyState />` renders
with a helpful CTA to guide the user.

### Changes

- **`src/pages/AgingTag.tsx`** — New page with two render paths:
  - *Empty*: `EmptyState` with success tone, "All caught up" eyebrow,
    `NoOverdue` illustration, and dual CTAs (View Credit Lines → `/credit-lines`,
    Back to Dashboard → `/`)
  - *Populated*: List of delinquent lines with `StatusBadge`, `AgingTag`
    (days past due), key metrics, and "Repay Now" link per line
- **`src/pages/AgingTag.css`** — Responsive page styles using design tokens,
  with high-contrast and reduced-motion support
- **`src/components/illustrations/EmptyStateIllustrations.tsx`** — Added
  `NoOverdue` SVG (calendar + clock + checkmark, `currentColor`)
- **`src/components/illustrations/index.ts`** — Exported new illustration
- **`src/App.tsx`** — Registered `/aging` route
- **`docs/EMPTY_STATE.md`** — Documented `NoOverdue` + `AgingTagPage` adopter

### Testing

- 12 focused tests covering:
  - Empty-state render, eyebrow, CTA links
  - Accessibility: `role="status"`, `aria-live="polite"`, `aria-labelledby`
  - Decorative `aria-hidden` illustration
  - Populated list with `AgingTag` badges, "Repay Now" links, overdue count

### Accessibility (WCAG 2.1 AA)

- `role="status"` + `aria-live="polite"` for screen-reader announcements
- `aria-labelledby` linking region to heading
- Decorative illustration excluded from accessibility tree
- Focus-visible rings on interactive elements
- All colour conveys meaning alongside text/iconography (WCAG 1.4.1)

### Theming

- Design tokens throughout (`--text`, `--surface`, `--border`, `--accent`, etc.)
- `[data-contrast="high"]` border enforcement
- `prefers-reduced-motion` removes hover transforms
- Responsive at 480px breakpoint

Closes #838 