### PR TITLE
feat: wire Tooltip primitive onto LinkedAccounts toolbar icon buttons

### DIFF
--- a/src/components/AccessibleTooltip.css
+++ b/src/components/AccessibleTooltip.css
@@ -99,6 +99,27 @@
   transform: translate(-50%, 0);
 }
 
+/* Bottom placement — flips the content below the trigger and mirrors the arrow. */
+.accessible-tooltip--bottom .accessible-tooltip__content {
+  bottom: auto;
+  top: calc(100% + 8px);
+  transform: translate(-50%, -4px);
+}
+
+.accessible-tooltip--bottom .accessible-tooltip__content::after {
+  top: auto;
+  bottom: 100%;
+  border-right: 0;
+  border-bottom: 0;
+  border-left: 1px solid var(--border);
+  border-top: 1px solid var(--border);
+  transform: translate(-50%, 4px) rotate(45deg);
+}
+
+.accessible-tooltip--bottom .accessible-tooltip__content.is-visible {
+  transform: translate(-50%, 0);
+}
+
 @media (forced-colors: active) {
   .accessible-tooltip__label {
     text-decoration-color: LinkText;

--- a/src/components/AccessibleTooltip.tsx
+++ b/src/components/AccessibleTooltip.tsx
@@ -1,26 +1,67 @@
-import { useId, useState, useRef, useEffect, type ReactNode } from 'react';
+import {
+  useId,
+  useState,
+  useRef,
+  useEffect,
+  cloneElement,
+  isValidElement,
+  type ReactNode,
+  type ReactElement,
+  type KeyboardEvent,
+} from 'react';
 import './AccessibleTooltip.css';
 
 interface AccessibleTooltipProps {
   /** Plain-text label surfaced visually and to assistive tech via `aria-describedby`. */
   label: string;
-  /** Optional inline content to render as the interactive glossary trigger. */
+  /**
+   * Optional content to render as the tooltip trigger. When this is a
+   * single interactive element (e.g. a `<button>`), that element itself
+   * becomes the focusable trigger — its own `aria-describedby` is merged
+   * with the tooltip id instead of the wrapper stealing focus/label. When
+   * it is plain text (or omitted), the built-in "i" info affordance is
+   * rendered instead.
+   */
   children?: ReactNode;
+  /** Tooltip placement relative to the trigger. @default 'top' */
+  position?: 'top' | 'bottom';
+  /** Delay (ms) before a mouse hover reveals the tooltip. @default 400 */
+  hoverDelay?: number;
+  /** Delay (ms) before a touch long-press reveals the tooltip. @default 500 */
+  longPressDelay?: number;
+  /** When true, the tooltip never shows (hover/focus/touch are no-ops). */
+  disabled?: boolean;
 }
 
 /**
- * Compact keyboard-focusable info trigger.
+ * Compact keyboard-focusable tooltip trigger.
  *
- * Renders a small "i" affordance that surfaces `label` as a tooltip on
- * hover and keyboard focus. The trigger is `tabIndex={0}` (focusable
- * without being a button so it can sit inline next to labels), carries
- * `aria-label="More information"`, and is wired to the tooltip via
- * `aria-describedby` — so screen readers announce the label as the
- * trigger's accessible description.
+ * Two modes:
+ * - No children (or plain-text children): renders a small "i" (or
+ *   underlined-text) affordance that is itself the focusable trigger.
+ * - A single interactive element as children (e.g. a `<button>`): that
+ *   element becomes the trigger. Its `aria-describedby` is merged with the
+ *   tooltip id only while the tooltip is visible, so screen readers never
+ *   announce a stale reference to hidden content, and the child's own
+ *   label/semantics are preserved (no extra focus stop, no `aria-label`
+ *   override).
+ *
+ * Shows on hover (after `hoverDelay`), touch long-press (after
+ * `longPressDelay`, cancelled by `touchmove`), and keyboard focus. Escape
+ * dismisses it without stopping propagation, so an enclosing dialog's own
+ * Escape handler still fires.
  */
-export function AccessibleTooltip({ label, children }: AccessibleTooltipProps) {
+export function AccessibleTooltip({
+  label,
+  children,
+  position = 'top',
+  hoverDelay = 400,
+  longPressDelay = 500,
+  disabled = false,
+}: AccessibleTooltipProps) {
   const tooltipId = useId();
   const hasInlineContent = Boolean(children);
+  const isInteractiveChild = isValidElement(children);
   const [isVisible, setIsVisible] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -31,9 +72,17 @@ export function AccessibleTooltip({ label, children }: AccessibleTooltipProps) {
     }
   };
 
-  const handleMouseEnter = () => {
+  const scheduleShow = (delay: number) => {
     clearTimer();
-    timerRef.current = setTimeout(() => setIsVisible(true), 400); // hover delay
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      setIsVisible(true);
+    }, delay);
+  };
+
+  const handleMouseEnter = () => {
+    if (disabled) return;
+    scheduleShow(hoverDelay);
   };
 
   const handleMouseLeave = () => {
@@ -42,8 +91,8 @@ export function AccessibleTooltip({ label, children }: AccessibleTooltipProps) {
   };
 
   const handleTouchStart = () => {
-    clearTimer();
-    timerRef.current = setTimeout(() => setIsVisible(true), 500); // long press delay
+    if (disabled) return;
+    scheduleShow(longPressDelay);
   };
 
   const handleTouchEnd = () => {
@@ -51,7 +100,14 @@ export function AccessibleTooltip({ label, children }: AccessibleTooltipProps) {
     setIsVisible(false);
   };
 
+  const handleTouchMove = () => {
+    // Cancels a still-pending long-press; a no-op once already visible
+    // (timerRef is already null by then).
+    clearTimer();
+  };
+
   const handleFocus = () => {
+    if (disabled) return;
     clearTimer();
     setIsVisible(true);
   };
@@ -61,36 +117,78 @@ export function AccessibleTooltip({ label, children }: AccessibleTooltipProps) {
     setIsVisible(false);
   };
 
+  const handleKeyDown = (event: KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key === 'Escape' && isVisible) {
+      setIsVisible(false);
+    }
+    // Deliberately no stopPropagation — an enclosing dialog/menu's own
+    // Escape handler must still run.
+  };
+
   useEffect(() => {
     return clearTimer;
   }, []);
 
+  const wrapperClassName = [
+    'accessible-tooltip',
+    'tooltip-wrapper',
+    hasInlineContent ? 'accessible-tooltip--inline' : '',
+    position === 'bottom' ? 'accessible-tooltip--bottom' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  let trigger: ReactNode;
+  if (isInteractiveChild) {
+    const child = children as ReactElement<{ 'aria-describedby'?: string }>;
+    const existingDescribedBy = child.props['aria-describedby'];
+    const describedBy = isVisible
+      ? [existingDescribedBy, tooltipId].filter(Boolean).join(' ')
+      : existingDescribedBy;
+    trigger = cloneElement(child, {
+      'aria-describedby': describedBy || undefined,
+    });
+  } else if (hasInlineContent) {
+    trigger = (
+      <span
+        tabIndex={0}
+        className="accessible-tooltip__trigger accessible-tooltip__trigger--text"
+        aria-label="More information"
+        aria-describedby={tooltipId}
+      >
+        <span className="accessible-tooltip__label">{children}</span>
+      </span>
+    );
+  } else {
+    trigger = (
+      <span
+        tabIndex={0}
+        className="accessible-tooltip__trigger"
+        aria-label="More information"
+        aria-describedby={tooltipId}
+      >
+        <span aria-hidden="true">i</span>
+      </span>
+    );
+  }
+
   return (
-    <span 
-      className={`accessible-tooltip${hasInlineContent ? ' accessible-tooltip--inline' : ''}`}
+    <span
+      className={wrapperClassName}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
       onTouchCancel={handleTouchEnd}
+      onTouchMove={handleTouchMove}
       onFocus={handleFocus}
       onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
     >
+      {trigger}
       <span
-        tabIndex={0}
-        className={`accessible-tooltip__trigger${hasInlineContent ? ' accessible-tooltip__trigger--text' : ''}`}
-        aria-label="More information"
-        aria-describedby={tooltipId}
-      >
-        {hasInlineContent ? (
-          <span className="accessible-tooltip__label">{children}</span>
-        ) : (
-          <span aria-hidden="true">i</span>
-        )}
-      </span>
-      <span 
-        id={tooltipId} 
-        role="tooltip" 
+        id={tooltipId}
+        role="tooltip"
         className={`accessible-tooltip__content${isVisible ? ' is-visible' : ''}`}
       >
         {label}

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -1,9 +1,16 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Tooltip } from './Tooltip';
-import { exec } from 'node:child_process';
 
 describe('Tooltip (alias for AccessibleTooltip)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('renders with a label and exposes the tooltip content', () => {
     render(<Tooltip label="This is a helpful hint" />);
     // The trigger with aria-label "More information"

--- a/src/pages/LinkedAccounts.test.tsx
+++ b/src/pages/LinkedAccounts.test.tsx
@@ -10,8 +10,8 @@
  * - ARIA attributes
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor, within, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, within, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { LinkedAccounts } from './LinkedAccounts';
 import * as linkedAccountsService from '../services/linkedAccounts';
@@ -591,6 +591,50 @@ describe('LinkedAccounts', () => {
       });
 
       confirmSpy.mockRestore();
+    });
+  });
+
+  describe('Toolbar Tooltips', () => {
+    it('shows a tooltip for the toolbar connect button on hover after a delay', async () => {
+      vi.mocked(linkedAccountsService.fetchLinkedAccounts).mockResolvedValue([]);
+
+      render(<LinkedAccounts />);
+
+      const connectButton = await screen.findByRole('button', {
+        name: /connect new account from toolbar/i,
+      });
+
+      vi.useFakeTimers();
+      try {
+        fireEvent.mouseEnter(connectButton.closest('.tooltip-wrapper')!);
+        expect(screen.getByText('Connect a new account')).not.toHaveClass('is-visible');
+
+        act(() => {
+          vi.advanceTimersByTime(400);
+        });
+
+        const tooltip = screen.getByText('Connect a new account');
+        expect(tooltip).toHaveClass('is-visible');
+        expect(connectButton).toHaveAttribute('aria-describedby', tooltip.id);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('shows a tooltip for the toolbar disconnect-all button on keyboard focus', async () => {
+      vi.mocked(linkedAccountsService.fetchLinkedAccounts).mockResolvedValue(mockAccounts);
+
+      render(<LinkedAccounts />);
+
+      const disconnectAllButton = await screen.findByRole('button', {
+        name: /disconnect all accounts from toolbar/i,
+      });
+
+      fireEvent.focus(disconnectAllButton.closest('.tooltip-wrapper')!);
+
+      const tooltip = screen.getByText('Disconnect all linked accounts');
+      expect(tooltip).toHaveClass('is-visible');
+      expect(disconnectAllButton).toHaveAttribute('aria-describedby', tooltip.id);
     });
   });
 });

--- a/src/pages/LinkedAccounts.tsx
+++ b/src/pages/LinkedAccounts.tsx
@@ -28,6 +28,7 @@ import type { LinkedAccount, AccountProvider, AccountLinkError } from '../types/
 import { Skeleton } from '../components/Skeleton';
 import { PendingButton } from '../components/PendingButton';
 import { LiveRegion } from '../components/LiveRegion';
+import { Tooltip } from '../components/Tooltip';
 import { accountStripeStyle, colorFromId } from '../utils/colorFromId';
 import './LinkedAccounts.css';
 
@@ -461,26 +462,40 @@ export function LinkedAccounts() {
             )}
           </div>
           <div className="sticky-action-bar__actions">
-            <PendingButton
-              onClick={() => handleConnect('google')}
-              disabled={actionLoading}
-              pending={false}
-              className="btn-secondary btn-sm"
-              aria-label="Connect new account from toolbar"
+            <Tooltip
+              label="Connect a new account"
+              position="top"
+              hoverDelay={400}
+              longPressDelay={500}
             >
-              <LinkIcon className="icon-sm" aria-hidden="true" />
-              <span className="sticky-action-bar__label">Connect</span>
-            </PendingButton>
-            {connectedCount > 0 && (
-              <button
-                onClick={handleDisconnectAll}
+              <PendingButton
+                onClick={() => handleConnect('google')}
                 disabled={actionLoading}
-                className="btn-danger btn-sm"
-                aria-label="Disconnect all accounts from toolbar"
+                pending={false}
+                className="btn-secondary btn-sm"
+                aria-label="Connect new account from toolbar"
               >
-                <Unlink className="icon-sm" aria-hidden="true" />
-                <span className="sticky-action-bar__label">Disconnect All</span>
-              </button>
+                <LinkIcon className="icon-sm" aria-hidden="true" />
+                <span className="sticky-action-bar__label">Connect</span>
+              </PendingButton>
+            </Tooltip>
+            {connectedCount > 0 && (
+              <Tooltip
+                label="Disconnect all linked accounts"
+                position="top"
+                hoverDelay={400}
+                longPressDelay={500}
+              >
+                <button
+                  onClick={handleDisconnectAll}
+                  disabled={actionLoading}
+                  className="btn-danger btn-sm"
+                  aria-label="Disconnect all accounts from toolbar"
+                >
+                  <Unlink className="icon-sm" aria-hidden="true" />
+                  <span className="sticky-action-bar__label">Disconnect All</span>
+                </button>
+              </Tooltip>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Wires the shared `Tooltip` primitive onto the sticky toolbar's Connect and Disconnect All buttons on `LinkedAccounts`, which collapse to icon-only at narrow viewports (`max-width: 768px`, via `.sticky-action-bar__label { display: none }`).
- Enhances `AccessibleTooltip` to support `position` (`'top' | 'bottom'`), `hoverDelay`, `longPressDelay`, and `disabled` props — previously hardcoded/absent, even though several other components (`StatusBadge`, `OnboardingFlow`, `ConfirmationStep`, `RequestEvaluation`, `AffordabilityCalc`) already called it with these props, causing pre-existing type errors.
- When given a single interactive child (e.g. a `<button>`), the tooltip now attaches `aria-describedby` to that child once visible, merging with any existing `aria-describedby` rather than overwriting it — instead of the previous fixed-wrapper attribute.
- Adds Escape-to-dismiss (without `stopPropagation`, so an enclosing dialog's own handler still fires) and `touchmove` cancellation of a pending long-press.
- Adds a `position="bottom"` CSS variant to `AccessibleTooltip.css`.

## Notes
- `src/components/Tooltip.test.tsx` already contained a full behavioral spec for this work but was missing `fireEvent`/`act`/`vi` imports (and an unused `exec` import), so it couldn't run; fixed the imports and added fake-timer setup/teardown. All 9 tests in that file now pass against the new implementation.
- Added 2 focused tests to `LinkedAccounts.test.tsx` covering the toolbar tooltip wiring (hover-delay reveal, focus reveal, `aria-describedby` attachment). All 32 tests in that file pass, including the 30 pre-existing ones (unchanged).

## Test plan
- [x] `npx vitest run src/components/Tooltip.test.tsx` — 9/9 passing
- [x] `npx vitest run src/pages/LinkedAccounts.test.tsx` — 32/32 passing
- [x] `npx tsc --noEmit` scoped grep for `tooltip`/`linkedaccounts` — no errors (previously present pre-existing errors in consumer files are now resolved as a side effect)

Closes #842