### PR TITLE
feat(SmartPayCTA): add keyboard shortcut hint chip

### DIFF
--- a/src/pages/SmartPayCTA.css
+++ b/src/pages/SmartPayCTA.css
@@ -1,0 +1,32 @@
+/* SmartPayCTA.css
+ *
+ * Layout for the CTA action row and the subtle keyboard-shortcut hint
+ * chip shown next to the primary action. All colors/spacing come from
+ * design tokens in src/index.css (or KbdHint's own token-based styles).
+ */
+
+.smartpay-cta__action {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-3, 0.75rem);
+}
+
+.smartpay-cta__shortcut-hint {
+  /* Recedes visually behind the primary action — hinted, not competing. */
+  opacity: 0.75;
+}
+
+@media (max-width: 480px) {
+  /* Shortcut chips describe a physical keyboard; not useful on touch-only
+     viewports, and crowds the primary action at this width. */
+  .smartpay-cta__shortcut-hint {
+    display: none;
+  }
+}
+
+@media (prefers-contrast: high) {
+  .smartpay-cta__shortcut-hint {
+    opacity: 1;
+  }
+}

--- a/src/pages/SmartPayCTA.test.tsx
+++ b/src/pages/SmartPayCTA.test.tsx
@@ -57,4 +57,44 @@ describe('SmartPayCTA', () => {
     );
     expect(document.querySelector('picture')).not.toBeInTheDocument();
   });
+
+  it('omits the shortcut hint chip when shortcutKeys is not provided', () => {
+    render(
+      <SmartPayCTA
+        title="No Shortcut"
+        description="No hint here."
+        cta={<button>Ok</button>}
+      />,
+    );
+    expect(document.querySelector('.smartpay-cta__shortcut-hint')).not.toBeInTheDocument();
+  });
+
+  it('renders a shortcut hint chip next to the CTA when shortcutKeys is provided', () => {
+    render(
+      <SmartPayCTA
+        title="Pay Now"
+        description="Repay instantly."
+        cta={<button>Pay</button>}
+        shortcutKeys={['Ctrl', 'Enter']}
+        shortcutLabel="Pay now"
+      />,
+    );
+    const hint = document.querySelector('.smartpay-cta__shortcut-hint');
+    expect(hint).toBeInTheDocument();
+    expect(hint).toHaveAttribute('aria-label', 'Pay now (Ctrl Enter)');
+    expect(screen.getByText('Ctrl')).toBeInTheDocument();
+    expect(screen.getByText('Enter')).toBeInTheDocument();
+  });
+
+  it('accepts a single shortcut key as a string', () => {
+    render(
+      <SmartPayCTA
+        title="Confirm"
+        description="One key does it."
+        cta={<button>Confirm</button>}
+        shortcutKeys="Enter"
+      />,
+    );
+    expect(screen.getByText('Enter')).toBeInTheDocument();
+  });
 });

--- a/src/pages/SmartPayCTA.tsx
+++ b/src/pages/SmartPayCTA.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react';
+import { KbdHint } from '../components/KbdHint';
+import './SmartPayCTA.css';
 
 export interface SmartPayCTAProps {
   /** The heading for the CTA card. */
@@ -17,6 +19,13 @@ export interface SmartPayCTAProps {
   imageAlt?: string;
   /** Additional CSS class names. */
   className?: string;
+  /**
+   * Keyboard shortcut for the primary CTA (e.g. `['Ctrl', 'Enter']`).
+   * When provided, a subtle hint chip is rendered next to the action.
+   */
+  shortcutKeys?: string | string[];
+  /** Optional label shown alongside the shortcut hint chip. */
+  shortcutLabel?: string;
 }
 
 /**
@@ -39,6 +48,8 @@ export function SmartPayCTA({
   images,
   imageAlt = '',
   className = '',
+  shortcutKeys,
+  shortcutLabel,
 }: SmartPayCTAProps) {
   const classes = ['card', 'smartpay-cta', className].filter(Boolean).join(' ');
 
@@ -47,7 +58,17 @@ export function SmartPayCTA({
       <div className="smartpay-cta__body">
         <h2 className="smartpay-cta__title">{title}</h2>
         <p className="smartpay-cta__desc">{description}</p>
-        <div className="smartpay-cta__action">{cta}</div>
+        <div className="smartpay-cta__action">
+          {cta}
+          {shortcutKeys && (
+            <KbdHint
+              keys={shortcutKeys}
+              label={shortcutLabel}
+              variant="badge"
+              className="smartpay-cta__shortcut-hint"
+            />
+          )}
+        </div>
       </div>
 
       {images && images.length > 0 && (


### PR DESCRIPTION
## Summary
- Add an optional keyboard shortcut hint chip beside the SmartPayCTA primary action.
- Reuse the shared KbdHint component with accessible labeling, responsive layout, dark-mode tokens, and high-contrast support.
- Add focused tests for omitted, single-key, and multi-key shortcuts.

## Test plan
- [x] npm test -- --run src/pages/SmartPayCTA.test.tsx
- [ ] npm run lint -- --quiet (environment dependency missing: eslint command not found)

Closes #843