### PR TITLE
fix(print): format BalanceChart reports

### DIFF
--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -47,6 +47,19 @@
     display: none !important;
   }
 
+  /* BalanceChart print view keeps report data while removing controls used
+     only for interactive exploration on screen. */
+  .balance-chart .balance-chart__chrome,
+  .balance-chart .balance-chart__toolbar,
+  .balance-chart .balance-chart__filters,
+  .balance-chart .balance-chart__actions,
+  .balance-chart .balance-chart__close,
+  .balance-chart button:not(.print-preserve),
+  .balance-chart input,
+  .balance-chart select {
+    display: none !important;
+  }
+
   /* Hide toggle icons, chevrons, and expansion trigger buttons */
   .amount-confirm__chevron,
   .amount-confirm__toggle-icon,
@@ -115,6 +128,29 @@
     clip-path: none !important;
     transition: none !important;
     animation: none !important;
+  }
+
+  /* Scope the same expansion behavior to BalanceChart custom panels. */
+  .balance-chart details,
+  .balance-chart .balance-chart__collapsible,
+  .balance-chart .balance-chart__panel,
+  .balance-chart .balance-chart__legend,
+  .balance-chart [role="region"] {
+    display: block !important;
+    max-height: none !important;
+    height: auto !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+    overflow: visible !important;
+    clip: auto !important;
+    clip-path: none !important;
+    transition: none !important;
+    animation: none !important;
+  }
+
+  .balance-chart .balance-chart__toggle,
+  .balance-chart .balance-chart__chevron {
+    display: none !important;
   }
 
   /* Ensure collapsible titles remain bold and prominent on paper */
@@ -198,6 +234,14 @@
   .amount-confirm__collapsible,
   .amount-confirm__summary-row,
   section {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .balance-chart,
+  .balance-chart__card,
+  .balance-chart__panel,
+  .balance-chart__legend {
     break-inside: avoid;
     page-break-inside: avoid;
   }

--- a/src/styles/print.test.ts
+++ b/src/styles/print.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const printCss = readFileSync(resolve(__dirname, 'print.css'), 'utf8');
 
 function injectPrintStylesheet(): void {
   const link = document.createElement('link');
@@ -25,6 +29,21 @@ describe('print.css', () => {
     const el = document.getElementById('print-test-stylesheet');
     expect(el).toBeInTheDocument();
     expect(el?.getAttribute('rel')).toBe('stylesheet');
+  });
+
+  it('scopes BalanceChart controls to the non-printing chrome', () => {
+    expect(printCss).toContain('.balance-chart .balance-chart__toolbar');
+    expect(printCss).toContain('.balance-chart .balance-chart__filters');
+    expect(printCss).toContain('.balance-chart button:not(.print-preserve)');
+    expect(printCss).toMatch(/\.balance-chart[\s\S]*display: none !important/);
+  });
+
+  it('expands BalanceChart panels and preserves page continuity', () => {
+    expect(printCss).toContain('.balance-chart .balance-chart__collapsible');
+    expect(printCss).toContain('.balance-chart [role="region"]');
+    expect(printCss).toContain('.balance-chart__legend');
+    expect(printCss).toMatch(/\.balance-chart[\s\S]*max-height: none !important/);
+    expect(printCss).toMatch(/\.balance-chart__[^{]+\{[\s\S]*break-inside: avoid/);
   });
 
   it('contains media print rules hiding UI chrome and header elements', () => {


### PR DESCRIPTION
## Summary
- Hide BalanceChart toolbar, filters, close controls, and form inputs in print output.
- Expand BalanceChart collapsible panels and ARIA regions so all report data is printed.
- Keep chart cards and legends together across page breaks, with focused stylesheet assertions.

## Test plan
- [x] New BalanceChart print assertions pass
- [ ] npm test -- --run src/styles/print.test.ts (one pre-existing card-color assertion expects browser-normalized rgb while its inline fixture remains hex)

Closes #844