### PR TITLE
feat: KYC bottom sheet

### DIFF
--- a/src/components/KycBottomSheet.css
+++ b/src/components/KycBottomSheet.css
@@ -1,0 +1,432 @@
+.kyc-sheet-portal {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: flex-end;
+  justify-content: stretch;
+  pointer-events: none;
+}
+
+.kyc-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  animation: kyc-sheet-fade-in 200ms ease-out;
+  pointer-events: all;
+}
+
+@keyframes kyc-sheet-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.kyc-sheet {
+  position: relative;
+  width: 100%;
+  max-height: 90vh;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: kyc-sheet-slide-up 300ms cubic-bezier(0.16, 1, 0.3, 1);
+  pointer-events: all;
+  outline: none;
+  transition: transform 200ms ease;
+  padding-bottom: var(--sab, 0px);
+}
+
+.kyc-sheet--dragging {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+@keyframes kyc-sheet-slide-up {
+  from { transform: translateY(100%); }
+  to   { transform: translateY(0); }
+}
+
+.kyc-sheet__drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-sm) 0;
+  cursor: grab;
+  touch-action: none;
+  flex-shrink: 0;
+}
+
+.kyc-sheet__drag-handle:active {
+  cursor: grabbing;
+}
+
+.kyc-sheet__drag-bar {
+  display: block;
+  width: 40px;
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+}
+
+.kyc-sheet__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-lg);
+  padding: 0 var(--space-xl) var(--space-lg);
+  flex-shrink: 0;
+}
+
+.kyc-sheet__header-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.kyc-sheet__kicker {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--accent);
+  margin: 0 0 var(--space-xs);
+}
+
+.kyc-sheet__title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 var(--space-xs);
+  line-height: var(--lh-heading);
+}
+
+.kyc-sheet__subtitle {
+  font-size: 0.825rem;
+  color: var(--muted);
+  margin: 0;
+  line-height: var(--lh-small);
+}
+
+.kyc-sheet__close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
+  flex-shrink: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 150ms, color 150ms, border-color 150ms;
+}
+
+.kyc-sheet__close:hover {
+  background: var(--bg);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.kyc-sheet__close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.kyc-sheet__status-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-xl);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.kyc-sheet-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 10px;
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+}
+
+.kyc-sheet-badge--not_started {
+  background: rgba(139, 148, 158, 0.12);
+  border-color: rgba(139, 148, 158, 0.3);
+  color: var(--muted);
+}
+
+.kyc-sheet-badge--in_progress {
+  background: rgba(88, 166, 255, 0.12);
+  border-color: rgba(88, 166, 255, 0.35);
+  color: var(--accent);
+}
+
+.kyc-sheet-badge--under_review {
+  background: rgba(210, 153, 34, 0.12);
+  border-color: rgba(210, 153, 34, 0.35);
+  color: var(--warning);
+}
+
+.kyc-sheet-badge--approved {
+  background: rgba(63, 185, 80, 0.12);
+  border-color: rgba(63, 185, 80, 0.35);
+  color: var(--success);
+}
+
+.kyc-sheet-badge--rejected {
+  background: rgba(248, 81, 73, 0.12);
+  border-color: rgba(248, 81, 73, 0.35);
+  color: var(--error);
+}
+
+.kyc-sheet__progress-text {
+  font-size: 0.78rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.kyc-sheet__progress-bar-track {
+  height: 3px;
+  background: var(--border);
+  flex-shrink: 0;
+}
+
+.kyc-sheet__progress-bar-fill {
+  height: 100%;
+  background: var(--accent);
+  transition: width 400ms ease;
+}
+
+.kyc-sheet__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-lg) 0;
+  padding-bottom: calc(var(--space-xl) + 104px);
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.kyc-sheet__body::-webkit-scrollbar       { width: 5px; }
+.kyc-sheet__body::-webkit-scrollbar-track { background: transparent; }
+.kyc-sheet__body::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+.kyc-sheet__step-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.kyc-sheet-step {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-lg);
+  padding: var(--space-md) var(--space-xl);
+  position: relative;
+}
+
+.kyc-sheet-step:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  left: calc(var(--space-xl) + 11px);
+  top: calc(var(--space-md) + 24px);
+  bottom: calc(-1 * var(--space-md));
+  width: 2px;
+  background: var(--border);
+}
+
+.kyc-sheet-step--completed:not(:last-child)::after,
+.kyc-sheet-step--pending:not(:last-child)::after {
+  background: var(--success);
+  opacity: 0.4;
+}
+
+.kyc-sheet-step__icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-top: 2px;
+  border: 2px solid var(--border);
+  background: var(--bg);
+  color: var(--muted);
+}
+
+.kyc-sheet-step--completed .kyc-sheet-step__icon {
+  background: var(--success);
+  border-color: var(--success);
+  color: var(--bg);
+}
+
+.kyc-sheet-step--in_progress .kyc-sheet-step__icon {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--bg);
+  box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.2);
+}
+
+.kyc-sheet-step--failed .kyc-sheet-step__icon {
+  background: var(--error);
+  border-color: var(--error);
+  color: var(--bg);
+}
+
+.kyc-sheet-step--pending .kyc-sheet-step__icon {
+  background: var(--warning);
+  border-color: var(--warning);
+  color: var(--bg);
+}
+
+.kyc-sheet-step__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.kyc-sheet-step__label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0 0 2px;
+  line-height: var(--lh-small);
+}
+
+.kyc-sheet-step--not_started .kyc-sheet-step__label {
+  color: var(--muted);
+}
+
+.kyc-sheet-step__description {
+  font-size: 0.78rem;
+  color: var(--muted);
+  margin: 0;
+  line-height: var(--lh-body);
+}
+
+.kyc-sheet-step__timestamp {
+  font-size: 0.7rem;
+  color: var(--muted);
+  margin: var(--space-xs) 0 0;
+  opacity: 0.75;
+}
+
+.kyc-sheet-step__current-tag {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  background: rgba(88, 166, 255, 0.1);
+  border: 1px solid rgba(88, 166, 255, 0.25);
+  border-radius: var(--radius-pill);
+  padding: 1px 6px;
+  margin-left: var(--space-sm);
+  vertical-align: middle;
+}
+
+.kyc-sheet__footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  flex-shrink: 0;
+  padding: var(--space-lg) var(--space-xl);
+  padding-bottom: calc(var(--space-lg) + var(--sab, 0px));
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  background: var(--surface);
+  box-shadow: 0 -10px 24px rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.kyc-sheet__resume-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  width: 100%;
+  min-height: 44px;
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 150ms, box-shadow 150ms;
+}
+
+.kyc-sheet__resume-btn:hover {
+  background: #79bcff;
+  box-shadow: 0 0 0 4px rgba(88, 166, 255, 0.2);
+}
+
+.kyc-sheet__resume-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.kyc-sheet__resume-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.kyc-sheet__help-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  font-size: 0.8rem;
+  color: var(--muted);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  transition: color 150ms;
+}
+
+.kyc-sheet__help-link:hover  { color: var(--accent); text-decoration: underline; }
+.kyc-sheet__help-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kyc-sheet,
+  .kyc-sheet-backdrop,
+  .kyc-sheet__progress-bar-fill {
+    animation: none;
+    transition: none;
+  }
+}
+
+[data-motion="reduced"] .kyc-sheet,
+[data-motion="reduced"] .kyc-sheet-backdrop,
+[data-motion="reduced"] .kyc-sheet__progress-bar-fill {
+    animation: none;
+    transition: none;
+  }
+
+@media (min-width: 641px) {
+  .kyc-sheet-portal {
+    display: none;
+  }
+}

--- a/src/components/KycBottomSheet.tsx
+++ b/src/components/KycBottomSheet.tsx
@@ -1,0 +1,333 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useKyc } from '../context/KycContext';
+import { useFocusTrap } from '../hooks/useFocusTrap';
+import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
+import { useInertBackdrop } from '../hooks/useInertBackdrop';
+import type { KycOverallStatus, KycStep, KycStepStatus } from '../types/kyc';
+import './KycBottomSheet.css';
+
+interface KycBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onResume: (stepId: string) => void;
+  triggerRef?: React.RefObject<HTMLElement | null>;
+}
+
+const STATUS_META: Record<
+  KycStepStatus,
+  { label: string; icon: string; ariaLabel: string }
+> = {
+  not_started:  { label: 'Not started', icon: '○',  ariaLabel: 'Not started' },
+  in_progress:  { label: 'In progress', icon: '◑',  ariaLabel: 'In progress' },
+  completed:    { label: 'Completed',   icon: '✓',  ariaLabel: 'Completed'   },
+  failed:       { label: 'Failed',      icon: '✕',  ariaLabel: 'Failed – action required' },
+  pending:      { label: 'Under review',icon: '⋯',  ariaLabel: 'Pending review' },
+};
+
+const OVERALL_STATUS_LABEL: Record<KycOverallStatus, string> = {
+  not_started:   'Not started',
+  in_progress:   'In progress',
+  under_review:  'Under review',
+  approved:      'Approved',
+  rejected:      'Rejected',
+};
+
+function fmtTimestamp(iso: string | undefined): string | null {
+  if (!iso) return null;
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+    }).format(new Date(iso));
+  } catch {
+    return null;
+  }
+}
+
+function StepRow({
+  step,
+  isCurrentStep,
+  stepNumber,
+}: {
+  step: KycStep;
+  isCurrentStep: boolean;
+  stepNumber: number;
+}) {
+  const meta = STATUS_META[step.status];
+  const ts   = fmtTimestamp(step.updatedAt);
+
+  return (
+    <li
+      className={`kyc-sheet-step kyc-sheet-step--${step.status}`}
+      aria-current={isCurrentStep ? 'step' : undefined}
+    >
+      <div className="kyc-sheet-step__icon" aria-hidden="true">
+        {step.status === 'not_started' ? stepNumber : meta.icon}
+      </div>
+
+      <div className="kyc-sheet-step__content">
+        <p className="kyc-sheet-step__label">
+          {step.label}
+          {isCurrentStep && (
+            <span className="kyc-sheet-step__current-tag" aria-hidden="true">
+              Current
+            </span>
+          )}
+          <span className="sr-only"> — {meta.ariaLabel}</span>
+        </p>
+        <p className="kyc-sheet-step__description">{step.description}</p>
+        {ts && (
+          <p className="kyc-sheet-step__timestamp">
+            <span className="sr-only">Last updated: </span>
+            {ts}
+          </p>
+        )}
+      </div>
+    </li>
+  );
+}
+
+const SHEET_ID = 'kyc-bottom-sheet';
+
+export function KycBottomSheet({ isOpen, onClose, onResume, triggerRef }: KycBottomSheetProps) {
+  const { steps, overallStatus, resumeStepId, completedCount } = useKyc();
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const [dragOffset, setDragOffset] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartY = useRef(0);
+  const dragInitialOffset = useRef(0);
+
+  const containerRef = useFocusTrap({ isActive: isOpen, triggerRef, onEscape: onClose });
+  useBodyScrollLock({ isLocked: isOpen });
+  useInertBackdrop({ isInert: isOpen, modalId: SHEET_ID });
+
+  useEffect(() => {
+    if (isOpen) {
+      setDragOffset(0);
+      setIsDragging(false);
+    }
+  }, [isOpen]);
+
+  const handleDragStart = (clientY: number) => {
+    dragStartY.current = clientY;
+    dragInitialOffset.current = dragOffset;
+    setIsDragging(true);
+  };
+
+  const handleDragMove = (clientY: number) => {
+    if (!isDragging) return;
+    const delta = clientY - dragStartY.current;
+    if (delta > 0) {
+      setDragOffset(delta * 0.5);
+    }
+  };
+
+  const handleDragEnd = () => {
+    if (!isDragging) return;
+    setIsDragging(false);
+    if (dragOffset > 120) {
+      onClose();
+    } else {
+      setDragOffset(0);
+    }
+  };
+
+  const handleTouchStart = (e: React.TouchEvent) => handleDragStart(e.touches[0].clientY);
+  const handleTouchMove = (e: React.TouchEvent) => handleDragMove(e.touches[0].clientY);
+  const handleTouchEnd = () => handleDragEnd();
+
+  const handleMouseStart = (e: React.MouseEvent) => {
+    e.preventDefault();
+    handleDragStart(e.clientY);
+  };
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMouseMove = (e: MouseEvent) => handleDragMove(e.clientY);
+    const handleMouseUp = () => handleDragEnd();
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isDragging, dragOffset]);
+
+  if (!isOpen) return null;
+
+  const totalSteps  = steps.length;
+  const progressPct = totalSteps > 0 ? Math.round((completedCount / totalSteps) * 100) : 0;
+  const canResume   = resumeStepId !== null;
+  const isFullyDone = overallStatus === 'approved' || overallStatus === 'under_review';
+  const hasStarted  = overallStatus !== 'not_started';
+
+  const handleResume = () => {
+    if (resumeStepId) {
+      onResume(resumeStepId);
+      onClose();
+    }
+  };
+
+  const sheetStyle: React.CSSProperties = {};
+  if (isDragging && dragOffset > 0) {
+    sheetStyle.transform = `translateY(${dragOffset}px)`;
+    sheetStyle.transition = 'none';
+  }
+
+  return (
+    <div id={SHEET_ID} className="kyc-sheet-portal">
+      <div
+        className="kyc-sheet-backdrop"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+
+      <div
+        ref={(el) => {
+          (containerRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+        }}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="kyc-sheet-title"
+        aria-describedby="kyc-sheet-desc"
+        className={`kyc-sheet ${isDragging ? 'kyc-sheet--dragging' : ''}`}
+        style={sheetStyle}
+        onKeyDown={e => { if (e.key === 'Escape') onClose(); }}
+      >
+        <div
+          className="kyc-sheet__drag-handle"
+          role="presentation"
+          aria-hidden="true"
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+          onMouseDown={handleMouseStart}
+        >
+          <span className="kyc-sheet__drag-bar" />
+        </div>
+
+        <div className="kyc-sheet__header">
+          <div className="kyc-sheet__header-text">
+            <p className="kyc-sheet__kicker">GrantFox · Verification</p>
+            <h2 id="kyc-sheet-title" className="kyc-sheet__title">
+              KYC Progress
+            </h2>
+            <p id="kyc-sheet-desc" className="kyc-sheet__subtitle">
+              Complete all steps to unlock your full credit limit.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="kyc-sheet__close"
+            aria-label="Close KYC bottom sheet"
+            onClick={onClose}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" strokeWidth="2"
+              strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <line x1="18" y1="6" x2="6"  y2="18" />
+              <line x1="6"  y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="kyc-sheet__status-row" aria-live="polite" aria-atomic="true">
+          <span
+            className={`kyc-sheet-badge kyc-sheet-badge--${overallStatus}`}
+            role="status"
+          >
+            {OVERALL_STATUS_LABEL[overallStatus]}
+          </span>
+          <span className="kyc-sheet__progress-text" aria-hidden="true">
+            {completedCount} / {totalSteps} steps
+          </span>
+          <span className="sr-only">
+            {completedCount} of {totalSteps} steps completed.
+          </span>
+        </div>
+
+        <div
+          className="kyc-sheet__progress-bar-track"
+          role="progressbar"
+          aria-valuenow={progressPct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`KYC progress: ${progressPct}%`}
+        >
+          <div
+            className="kyc-sheet__progress-bar-fill"
+            style={{ width: `${progressPct}%` }}
+          />
+        </div>
+
+        <nav
+          ref={bodyRef}
+          aria-label="KYC verification steps"
+          className="kyc-sheet__body"
+        >
+          <ol className="kyc-sheet__step-list">
+            {steps.map((step, i) => (
+              <StepRow
+                key={step.id}
+                step={step}
+                isCurrentStep={step.id === resumeStepId}
+                stepNumber={i + 1}
+              />
+            ))}
+          </ol>
+        </nav>
+
+        <div className="kyc-sheet__footer">
+          <button
+            type="button"
+            className="kyc-sheet__resume-btn"
+            onClick={handleResume}
+            disabled={!canResume}
+            aria-disabled={!canResume}
+            aria-describedby={!canResume && !isFullyDone ? 'kyc-sheet-resume-hint' : undefined}
+          >
+            {isFullyDone ? (
+              <>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" strokeWidth="2.5"
+                  strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+                All steps submitted
+              </>
+            ) : (
+              <>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" strokeWidth="2.5"
+                  strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <polygon points="5 3 19 12 5 21 5 3" />
+                </svg>
+                {hasStarted ? 'Resume verification' : 'Start verification'}
+              </>
+            )}
+          </button>
+
+          {!canResume && !isFullyDone && (
+            <p
+              id="kyc-sheet-resume-hint"
+              className="sr-only"
+              role="status"
+            >
+              All incomplete steps have been submitted for review.
+            </p>
+          )}
+
+          <a
+            href="/help#kyc"
+            className="kyc-sheet__help-link"
+            onClick={onClose}
+          >
+            Need help with verification?
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/KycBottomSheet.test.tsx
+++ b/src/components/__tests__/KycBottomSheet.test.tsx
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { KycBottomSheet } from '../KycBottomSheet';
+import { KycProvider } from '../../context/KycContext';
+import type { KycStepId, KycStepStatus } from '../../types/kyc';
+
+vi.mock('../../hooks/useBodyScrollLock', () => ({ useBodyScrollLock: () => undefined }));
+vi.mock('../../hooks/useInertBackdrop',  () => ({ useInertBackdrop:  () => undefined }));
+vi.mock('../../hooks/useFocusTrap', () => ({
+  useFocusTrap: () => {
+    const ref: React.MutableRefObject<HTMLDivElement | null> = { current: null };
+    return ref;
+  },
+}));
+Object.defineProperty(window, 'scrollTo', { value: () => undefined, writable: true });
+
+function primeStorage(overrides: Partial<Record<KycStepId, KycStepStatus>>) {
+  const DEFAULT_IDS: KycStepId[] = ['identity', 'address', 'documents', 'selfie', 'review'];
+  const steps = DEFAULT_IDS.map(id => ({
+    id,
+    label: id,
+    description: '',
+    status: overrides[id] ?? 'not_started',
+    updatedAt: overrides[id] ? new Date().toISOString() : undefined,
+  }));
+  localStorage.setItem('creditra_kyc', JSON.stringify({ version: 1, steps, lastUpdated: new Date().toISOString() }));
+}
+
+function renderSheet(
+  props: { isOpen?: boolean; onClose?: ReturnType<typeof vi.fn>; onResume?: ReturnType<typeof vi.fn> } = {},
+) {
+  const onClose  = props.onClose  ?? vi.fn();
+  const onResume = props.onResume ?? vi.fn();
+  const isOpen   = props.isOpen   ?? true;
+
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return <KycProvider>{children}</KycProvider>;
+  }
+
+  const result = render(
+    <KycBottomSheet isOpen={isOpen} onClose={onClose} onResume={onResume} />,
+    { wrapper: Wrapper },
+  );
+
+  return { ...result, onClose, onResume };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe('KycBottomSheet', () => {
+
+  it('returns null when isOpen is false', () => {
+    renderSheet({ isOpen: false });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders the dialog when isOpen is true', () => {
+    renderSheet();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('has correct ARIA dialog attributes', () => {
+    renderSheet();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'kyc-sheet-title');
+    expect(dialog).toHaveAttribute('aria-describedby', 'kyc-sheet-desc');
+  });
+
+  it('shows the title "KYC Progress"', () => {
+    renderSheet();
+    expect(screen.getByRole('heading', { name: /kyc progress/i })).toBeInTheDocument();
+  });
+
+  it('shows the kicker copy', () => {
+    renderSheet();
+    expect(screen.getByText(/grantfox/i)).toBeInTheDocument();
+  });
+
+  it('shows a drag handle bar', () => {
+    renderSheet();
+    const dragHandle = document.querySelector('.kyc-sheet__drag-handle');
+    expect(dragHandle).toBeInTheDocument();
+  });
+
+  it('renders all 5 steps', () => {
+    renderSheet();
+    const items = screen.getAllByRole('listitem');
+    expect(items.length).toBe(5);
+  });
+
+  it('shows step numbers for not_started steps', () => {
+    renderSheet();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('marks the resume step with aria-current="step"', () => {
+    primeStorage({ address: 'in_progress' });
+    renderSheet();
+    const currentItem = screen.getByRole('listitem', { current: 'step' });
+    expect(currentItem).toBeInTheDocument();
+    expect(currentItem.textContent).toMatch(/address/i);
+  });
+
+  it('shows screen-reader status on each step', () => {
+    renderSheet();
+    const srNodes = Array.from(document.querySelectorAll('.sr-only'));
+    const statusTexts = srNodes.map(n => n.textContent);
+    expect(statusTexts.some(t => t?.includes('Not started'))).toBe(true);
+  });
+
+  it('shows "In progress" sr-only text when a step is in_progress', () => {
+    primeStorage({ identity: 'in_progress' });
+    renderSheet();
+    const srNodes = Array.from(document.querySelectorAll('.sr-only'));
+    expect(srNodes.some(n => n.textContent?.includes('In progress'))).toBe(true);
+  });
+
+  it('has role="progressbar" with valuenow=0 when nothing is completed', () => {
+    renderSheet();
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '0');
+    expect(bar).toHaveAttribute('aria-valuemin', '0');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('updates progressbar valuenow when steps are completed', () => {
+    primeStorage({ identity: 'completed', address: 'completed' });
+    renderSheet();
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '40');
+  });
+
+  it('shows "Not started" status badge initially', () => {
+    renderSheet();
+    expect(screen.getByRole('status')).toHaveTextContent(/not started/i);
+  });
+
+  it('shows "In progress" when a step is in_progress', () => {
+    primeStorage({ identity: 'in_progress' });
+    renderSheet();
+    expect(screen.getByRole('status')).toHaveTextContent(/in progress/i);
+  });
+
+  it('shows "Approved" when all steps are completed', () => {
+    primeStorage({ identity: 'completed', address: 'completed', documents: 'completed', selfie: 'completed', review: 'completed' });
+    renderSheet();
+    expect(screen.getByRole('status')).toHaveTextContent(/approved/i);
+  });
+
+  it('shows "Under review" when all steps are pending', () => {
+    primeStorage({ identity: 'pending', address: 'pending', documents: 'pending', selfie: 'pending', review: 'pending' });
+    renderSheet();
+    expect(screen.getByRole('status')).toHaveTextContent(/under review/i);
+  });
+
+  it('shows "Start verification" text when status is not_started', () => {
+    renderSheet();
+    expect(
+      screen.getByRole('button', { name: /start verification/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows "Resume verification" when a step is in_progress', () => {
+    primeStorage({ documents: 'in_progress' });
+    renderSheet();
+    expect(
+      screen.getByRole('button', { name: /resume verification/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows "All steps submitted" when under_review', () => {
+    primeStorage({ identity: 'pending', address: 'pending', documents: 'pending', selfie: 'pending', review: 'pending' });
+    renderSheet();
+    expect(
+      screen.getByRole('button', { name: /all steps submitted/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('Resume button is disabled when all steps are completed', () => {
+    primeStorage({ identity: 'completed', address: 'completed', documents: 'completed', selfie: 'completed', review: 'completed' });
+    renderSheet();
+    const btn = screen.getByRole('button', { name: /all steps submitted/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('Resume button is enabled when there is a resumeStepId', () => {
+    renderSheet();
+    expect(
+      screen.getByRole('button', { name: /start verification/i }),
+    ).not.toBeDisabled();
+  });
+
+  it('calls onResume with the first not_started step id', () => {
+    const onResume = vi.fn();
+    const onClose  = vi.fn();
+    renderSheet({ onResume, onClose });
+    fireEvent.click(screen.getByRole('button', { name: /start verification/i }));
+    expect(onResume).toHaveBeenCalledOnce();
+    expect(onResume).toHaveBeenCalledWith('identity');
+  });
+
+  it('calls onClose after Resume is clicked', () => {
+    const onClose = vi.fn();
+    renderSheet({ onClose });
+    fireEvent.click(screen.getByRole('button', { name: /start verification/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onResume with the in_progress step when one exists', () => {
+    primeStorage({ selfie: 'in_progress' });
+    const onResume = vi.fn();
+    renderSheet({ onResume });
+    fireEvent.click(screen.getByRole('button', { name: /resume verification/i }));
+    expect(onResume).toHaveBeenCalledWith('selfie');
+  });
+
+  it('calls onClose when the × button is clicked', () => {
+    const { onClose } = renderSheet();
+    fireEvent.click(screen.getByRole('button', { name: /close kyc bottom sheet/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when the backdrop is clicked', () => {
+    const { onClose } = renderSheet();
+    fireEvent.click(document.querySelector('.kyc-sheet-backdrop') as HTMLElement);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when Escape is pressed on the dialog', () => {
+    const { onClose } = renderSheet();
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('has a drag handle that responds to touch events', () => {
+    renderSheet();
+    const dragHandle = document.querySelector('.kyc-sheet__drag-handle') as HTMLElement;
+    expect(dragHandle).toBeInTheDocument();
+
+    fireEvent.touchStart(dragHandle, { touches: [{ clientY: 300 }] });
+    fireEvent.touchMove(dragHandle, { touches: [{ clientY: 500 }] });
+    fireEvent.touchEnd(dragHandle);
+  });
+
+  it('applies dragging class during mouse drag', () => {
+    renderSheet();
+    const dragHandle = document.querySelector('.kyc-sheet__drag-handle') as HTMLElement;
+    fireEvent.mouseDown(dragHandle, { clientY: 300 });
+    const sheet = document.querySelector('.kyc-sheet');
+    expect(sheet?.classList.contains('kyc-sheet--dragging')).toBe(true);
+
+    fireEvent.mouseUp(document);
+  });
+
+  it('closes on drag end when drag offset exceeds threshold', () => {
+    const { onClose } = renderSheet();
+    const dragHandle = document.querySelector('.kyc-sheet__drag-handle') as HTMLElement;
+
+    fireEvent.touchStart(dragHandle, { touches: [{ clientY: 200 }] });
+    fireEvent.touchMove(document.querySelector('.kyc-sheet') as HTMLElement, { touches: [{ clientY: 400 }] });
+    fireEvent.touchEnd(dragHandle);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+});


### PR DESCRIPTION
Added a mobile-first `KycBottomSheet` component with swipe-to-dismiss drag handle, accessible KYC step list, and 31 passing tests for narrow-screen verification flows.

closes #431