### PR TITLE
fix(ui): audit KycDrawer responsive breakpoints, tap targets, and wra…

### DIFF
--- a/src/components/KycDrawer.css
+++ b/src/components/KycDrawer.css
@@ -396,7 +396,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 36px;
+  min-height: 44px;
   font-size: 0.8rem;
   color: var(--muted);
   text-decoration: none;
@@ -486,6 +486,42 @@
     background: var(--border);
     border-radius: 2px;
     margin: var(--space-md) auto 0;
+  }
+}
+
+/* ── Narrow screens (<=375px) ──────────────────────────────────────────── */
+@media (max-width: 375px) {
+  .kyc-drawer__header {
+    padding: var(--space-lg) var(--space-md);
+  }
+
+  .kyc-drawer__title {
+    font-size: 1rem;
+  }
+
+  .kyc-drawer__subtitle {
+    font-size: 0.75rem;
+  }
+
+  .kyc-drawer__status-row {
+    padding: var(--space-md);
+  }
+
+  .kyc-step {
+    padding: var(--space-md);
+  }
+
+  .kyc-step:not(:last-child)::after {
+    left: calc(var(--space-md) + 11px);
+  }
+
+  .kyc-drawer__body {
+    padding-left: var(--space-md);
+    padding-right: var(--space-md);
+  }
+
+  .kyc-drawer__footer {
+    padding: var(--space-lg) var(--space-md);
   }
 }
 

--- a/src/components/__tests__/KycDrawer.test.tsx
+++ b/src/components/__tests__/KycDrawer.test.tsx
@@ -33,6 +33,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import { KycDrawer, KycTriggerButton } from '../KycDrawer';
 import { KycProvider } from '../../context/KycContext';
 import type { KycStepId, KycStepStatus } from '../../types/kyc';
@@ -373,5 +375,66 @@ describe('KycTriggerButton', () => {
     const { onClick } = renderTrigger();
     await user.click(screen.getByRole('button', { name: /kyc/i }));
     expect(onClick).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── Responsive audit ────────────────────────────────────────────────────
+
+describe('KycDrawer responsive audit (<=375px)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders without error at 375px viewport', () => {
+    vi.spyOn(window, 'matchMedia').mockImplementation(
+      (query: string) =>
+        ({
+          matches: query === '(max-width: 375px)',
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as unknown as MediaQueryList,
+    );
+    expect(() => renderDrawer()).not.toThrow();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem').length).toBe(5);
+  });
+
+  it('help link renders as an accessible anchor', () => {
+    renderDrawer();
+    const helpLink = screen.getByText(/Need help with verification/i);
+    expect(helpLink).toBeInTheDocument();
+    expect(helpLink.tagName).toBe('A');
+    expect(helpLink).toHaveAttribute('href', '/help#kyc');
+  });
+});
+
+// ─── CSS content audit ───────────────────────────────────────────────────
+
+describe('KycDrawer CSS — breakpoint & tap-target audit', () => {
+  it('contains a narrow-screen breakpoint at 375px', () => {
+    const css = readFileSync(resolve(__dirname, '../KycDrawer.css'), 'utf-8');
+    expect(css).toContain('@media (max-width: 375px)');
+    const start = css.indexOf('@media (max-width: 375px)');
+    const block = css.slice(start, css.indexOf('/* ── Reduced motion', start));
+    expect(block).toContain('--space-md');
+    expect(block).toContain('--space-lg');
+  });
+
+  it('sets min-height 44px on .kyc-drawer__help-link', () => {
+    const css = readFileSync(resolve(__dirname, '../KycDrawer.css'), 'utf-8');
+    const ruleStart = css.indexOf('.kyc-drawer__help-link');
+    const rule = css.slice(ruleStart, css.indexOf('}', ruleStart) + 1);
+    expect(rule).toContain('min-height: 44px');
+  });
+
+  it('does not use 36px tap target on help link', () => {
+    const css = readFileSync(resolve(__dirname, '../KycDrawer.css'), 'utf-8');
+    expect(css).not.toMatch(/\.kyc-drawer__help-link[^}]*min-height:\s*36px/);
   });
 });


### PR DESCRIPTION
…pping at <=375px

- Add @media (max-width: 375px) breakpoint with tighter padding tokens
- Increase help link min-height from 36px to 44px for WCAG 2.2 AA
- Add focused responsive and CSS-content tests
closes #860