### PR TITLE
Add tabular-nums to numeric displays in NotificationCenter

### DIFF
--- a/src/components/__tests__/NotificationCenter.test.tsx
+++ b/src/components/__tests__/NotificationCenter.test.tsx
@@ -369,6 +369,22 @@ describe('NotificationCenter', () => {
     expect(area.querySelector('.nc-drag-handle')).not.toBeNull();
   });
 
+  // ── Tabular numerals ──────────────────────────────────────────────────
+
+  it('badge applies tabular-nums class for aligned digits', () => {
+    renderCenter({ open: true, notifications: [makeNotif()] });
+    const badge = document.querySelector('.nc-badge');
+    expect(badge).not.toBeNull();
+    expect(badge).toHaveClass('tabular-nums');
+  });
+
+  it('notification timestamp applies tabular-nums class for aligned digits', () => {
+    renderCenter({ open: true, notifications: [makeNotif({ title: 'With time' })] });
+    const time = document.querySelector('.nc-item-time');
+    expect(time).not.toBeNull();
+    expect(time).toHaveClass('tabular-nums');
+  });
+
 });
 
 // ─── Tests: NotificationBell ─────────────────────────────────────────────────

--- a/src/components/notifications/NotificationCenter.css
+++ b/src/components/notifications/NotificationCenter.css
@@ -116,6 +116,7 @@
   color: var(--bg, #0d1117);
   font-size: 0.7rem;
   font-weight: 700;
+  font-variant-numeric: tabular-nums;
   padding: 0.1rem 0.4rem;
   border-radius: 10px;
   min-width: 18px;
@@ -357,6 +358,7 @@
 
 .nc-item-time {
   font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
   color: var(--muted, #8b949e);
   flex-shrink: 0;
 }

--- a/src/components/notifications/NotificationCenter.tsx
+++ b/src/components/notifications/NotificationCenter.tsx
@@ -309,7 +309,7 @@ export function NotificationCenter({ triggerRef }: NotificationCenterProps = {})
           <div className="nc-header-left">
             <span className="nc-title">Notifications</span>
             {unreadCount > 0 && (
-              <span className="nc-badge" aria-label={`${unreadCount} unread`}>
+              <span className="nc-badge tabular-nums" aria-label={`${unreadCount} unread`}>
                 {unreadCount}
               </span>
             )}
@@ -420,7 +420,7 @@ export function NotificationCenter({ triggerRef }: NotificationCenterProps = {})
                     <div className="nc-item-header">
                       <span className="nc-item-title">{n.title}</span>
                       <time
-                        className="nc-item-time"
+                        className="nc-item-time tabular-nums"
                         dateTime={n.timestamp}
                         aria-label={`Received ${relativeTime(n.timestamp)}`}
                       >


### PR DESCRIPTION
Apply font-variant-numeric: tabular-nums on .nc-badge and .nc-item-time so digits align vertically. Adds tabular-nums utility class from typography.css and focused tests.

Closes #856