### PR TITLE
Add accessible toast queue with role=status (#458)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ public `LandingPage` exist as components, ready to be wired into the route tree.
 | [`docs/UX_RATIONALE.md`](docs/UX_RATIONALE.md) | Why each major flow looks the way it does — alternatives considered |
 | [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md) | LCP/INP/CLS budgets, code-splitting, bundle budgets per route |
 | [`docs/TESTING.md`](docs/TESTING.md) | Test pyramid, coverage status, how to run each tier |
+| [`docs/TOAST_QUEUE.md`](docs/TOAST_QUEUE.md) | Centralized accessible toast queue: API, ARIA semantics, visible behaviour |
 | [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) | Conventional commits, branch model, review checklist |
 | [`Design System/`](Design%20System/) | Figma source-of-truth references for tokens, components, alerts, interaction |
 

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -331,7 +331,7 @@ The table below is updated on every accessibility-impacting PR. Status legend:
 | `CopyToClipboard` | Real `<button>`; Enter copies | Specific `aria-label`; polite live region announces "Copied" | AA | n/a | OK |
 | `AccessibleTooltip` | Trigger is keyboard-focusable | `role="tooltip"`, `aria-describedby` | AA | n/a | OK |
 | `RouteAnnouncer` | n/a (route observer) | Updates `document.title`, meta description, and a polite live region | AA | n/a | OK |
-| `NotificationBell` | Tab/Enter; counter is decorative | `aria-label="Notifications, N unread"` | AA | n/a | OK |
+| `NotificationBell` | Tab/Enter; counter is decorative | `aria-label="Notifications — N unread"` (custom `label` prop honored) | AA | n/a | OK |
 | `NotificationCenter` | Focus trap inside the panel; mobile Expand/Collapse snap controls for keyboard users | `role="dialog"`, category filters use `role="tab"` + `aria-selected`; iOS safe-area insets on bottom sheet | AA | reduced-motion disables snap transitions | OK |
 | `ToastContainer` | Tab/Esc to dismiss | `role="status"` / `role="alert"` per severity | AA | reduced-motion gated | OK |
 | `BannerAlert` | Tab/Enter on action & dismiss | `role="alert"` for warning/error | AA | n/a | OK |

--- a/docs/NOTIFICATION_CENTER.md
+++ b/docs/NOTIFICATION_CENTER.md
@@ -51,7 +51,7 @@ import { NotificationWidget } from './components/notifications/NotificationWidge
 
 ### `NotificationBell`
 
-`React.forwardRef<HTMLButtonElement>` — no props. Forwards its ref to the parent for the `triggerRef` handshake.
+`React.forwardRef<HTMLButtonElement, { label?: string }>` — forwards its ref to the parent for the `triggerRef` handshake. Optional `label` prop overrides the accessible name (default `"Notifications"`); when unread it becomes `"{label} — N unread"`. Plays a one-shot `.bell-pulse` ring when a new danger/error notification arrives (disabled under `prefers-reduced-motion: reduce`).
 
 ### `NotificationCenter`
 
@@ -134,7 +134,7 @@ npx vitest run src/components/__tests__/NotificationCenter.test.tsx
 | Suite | Tests |
 |---|---|
 | NotificationCenter | 27 |
-| NotificationBell | 7 |
+| NotificationBell | 9 |
 | NotificationWidget | 3 |
 
 **NotificationCenter** — panel visibility (open/closed aria-hidden), ARIA attrs, dismiss via ×/backdrop/Escape, "Mark all read" enabled/disabled state, "Clear all" presence, mark-all-read mutation, clear-all mutation, prefs panel show/hide, prefs aria-expanded, 6 filter tabs, default tab selection, tab click selection, empty state, article rendering, aria-label, unread dot, click-to-mark-read, action button callback, drag handle DOM presence.

--- a/docs/TOAST_QUEUE.md
+++ b/docs/TOAST_QUEUE.md
@@ -1,0 +1,145 @@
+# Accessible Toast Queue
+
+**Campaign:** GrantFox FWC26  ·  **Issue:** #458 — "Add accessible toast queue with role=status"
+
+A single, centralized toast queue for transient status messages. Mounted once in
+`App.tsx` inside `NotificationProvider`, it renders every active toast in a
+`role="status"` live region — WCAG 2.1 SC 4.1.3 (Status Messages).
+
+---
+
+## Overview
+
+| Concern | Implementation |
+|---|---|
+| Centralized queue | One `<ToastContainer />` mounted in `src/App.tsx` renders all toasts from `NotificationContext` |
+| Live-region semantics | Outer container: `role="status"` + `aria-live="polite"` + `aria-atomic="true"` + `aria-label="Notifications"` |
+| Per-toast semantics | success/info/warning → `role="status"` + `aria-live="polite"`; error/danger → `role="alert"` + `aria-live="assertive"` |
+| Auto-dismiss | 5 500 ms default (`duration` option), progress bar; `persistent: true` disables it |
+| Stack cap | 5 toasts max (enforced in `NotificationContext`) |
+| Safe areas | Mobile `--sat` / `--sar` / `--sal` offsets for notched devices |
+| Reduced motion | `prefers-reduced-motion: reduce` disables enter/leave transitions |
+
+---
+
+## Component API
+
+### `ToastContainer` (`src/components/ToastContainer.tsx`)
+
+```tsx
+import { ToastContainer } from './components/ToastContainer';
+
+// Mount once inside <NotificationProvider>:
+<NotificationProvider>
+  <ToastContainer />
+  <Routes>…</Routes>
+</NotificationProvider>
+```
+
+No props. Reads `toasts` + `dismissToast` from `useNotifications()`.
+
+### `useToast()` (`src/hooks/useToast.ts`)
+
+Convenience wrapper around `addToast`/`dismissToast`:
+
+```ts
+const toast = useToast();
+
+const id = toast.success('Repayment sent', 'Your payment is being processed.');
+toast.error('Connection failed', 'Could not reach the Stellar network.', {
+  persistent: true,
+});
+toast.info('New feature', 'Undo is now available.', {
+  action: { label: 'Learn more', onClick: () => navigate('/help') },
+});
+toast.dismiss(id); // programmatic dismissal
+```
+
+`ToastOptions`:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `category` | `NotificationCategory` | `'system'` | Governs per-category mute preferences |
+| `duration` | `number` | `5500` | Auto-dismiss delay in ms |
+| `persistent` | `boolean` | `false` | Keep until manually dismissed |
+| `action` | `{ label, onClick }` | — | Optional inline CTA button |
+
+### `addToast` (`src/context/NotificationContext.tsx`)
+
+```ts
+const { addToast } = useNotifications();
+const id = addToast({
+  type: 'success',
+  title: 'Connected',
+  message: 'Wallet connected successfully.',
+  saveToHistory: false, // default: also saves to the notification inbox
+});
+```
+
+Returns a stable id (empty string when the category is muted). Toasts are also
+saved to the persisted inbox by default (`saveToHistory`).
+
+---
+
+## Visible behaviour
+
+- Toasts appear **top-right**, stacking newest-first (capped at 5).
+- Each toast: severity icon badge, title, message, optional action button, and a
+  dismiss (×) button (44×44 px touch target, WCAG 2.5.5).
+- A thin progress bar shows time remaining; it disappears for persistent toasts.
+- Slide-in/fade enter animation and slide-out leave animation, disabled under
+  `prefers-reduced-motion: reduce`.
+
+---
+
+## Accessibility (WCAG 2.1 AA)
+
+| SC | Implementation |
+|---|---|
+| 4.1.3 Status Messages | `role="status"` container + per-item `role="status"` / `role="alert"` |
+| 1.4.1 Use of Color | Severity conveyed by icon + text + left accent bar, not color alone |
+| 1.4.3 Contrast | Title ≥ 4.5:1 on tinted surface; muted body ≥ 3:1 (see `ToastContainer.css` notes) |
+| 2.1.1 Keyboard | All controls are real `<button>`s (dismiss, action) |
+| 2.5.5 Target size | Dismiss + action buttons ≥ 44×44 px |
+| 2.4.7 Focus visible | `:focus-visible` rings on dismiss/action buttons |
+| Reduced motion | Transitions disabled under `prefers-reduced-motion: reduce` |
+| Forced colors | Patterns/colors mapped to system tokens where applicable |
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `src/components/ToastContainer.tsx` | Centralized queue component (mounted in `App.tsx`) |
+| `src/components/notifications/ToastContainer.tsx` | `ToastItem` presentational component + inner queue |
+| `src/components/notifications/ToastContainer.css` | Queue + item styles, safe-area & motion handling |
+| `src/components/notifications/notificationIcons.tsx` | Severity icon + color maps |
+| `src/context/NotificationContext.tsx` | `toasts` state, `addToast` / `dismissToast` dispatchers |
+| `src/hooks/useToast.ts` | Typed convenience helpers |
+| `src/types/notification.ts` | `Toast`, `NotificationType`, `NotificationCategory` types |
+
+---
+
+## Tests
+
+```bash
+npx vitest run src/components/ToastContainer.test.tsx
+npx vitest run src/components/notifications/ToastContainer.test.tsx
+npx vitest run src/components/notifications/UndoToast.test.tsx
+```
+
+Coverage: container ARIA attributes, per-severity roles, rendering all four
+types, dismiss (×) removal, auto-dismiss after duration, persistent toasts,
+stack cap (5), action buttons, empty queue, icon `aria-hidden`, severity theme
+colors, safe-area CSS tokens (`--sat`/`--sar` in `safe-area.test.ts`).
+
+---
+
+## Notes
+
+- The outer container intentionally does **not** set `aria-relevant="additions"`:
+  each child `ToastItem` already carries its own live-region role, and restricting
+  the parent causes inconsistent double-announcements across screen readers.
+- `NotificationCenter` (mark-all-read / clear-all) emits undo toasts through this
+  same queue — see `docs/NOTIFICATION_CENTER.md`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import { NetworkMismatchBanner } from "./components/notifications/NetworkMismatc
 import { Header } from "./layouts/Header";
 import CreditLineCompare from "./pages/CreditLineCompare";
 import { TermsBanner } from "./components/TermsBanner";
+import { ToastContainer } from "./components/ToastContainer";
 
 const isEditableTarget = (target: EventTarget | null) => {
   if (!(target instanceof HTMLElement)) return false;
@@ -274,6 +275,19 @@ function App() {
                         read useLocation().  Renders a sr-only polite status
                         region for screen-reader route announcements. */}
                     <RouteAnnouncer />
+
+                    {/*
+                     * Centralized accessible toast queue.
+                     * Fixed-position overlay at top-right of viewport.
+                     * Renders inside NotificationProvider so it can consume
+                     * useNotifications(). Does NOT need routing context, so it
+                     * lives here rather than inside <Routes>.
+                     *
+                     * WCAG: role="status" + aria-live="polite" on the outer
+                     * container, individual items use role="status" or
+                     * role="alert" per severity (SC 4.1.3 Status Messages).
+                     */}
+                    <ToastContainer />
                   </div>
                   </RouteHeadProvider>
                 </BrowserRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { KycDrawer, KycTriggerButton } from "./components/KycDrawer";
 import { NetworkMismatchBanner } from "./components/NetworkMismatchBanner";
 import { WalletReconnectBanner } from "./components/WalletReconnectBanner";
 import DrawCreditPage from "./pages/DrawCreditPage";
+import CollateralSwap from "./pages/CollateralSwap";
 import CreditLines from "./pages/CreditLines";
 import { TransactionHistory } from "./pages/TransactionHistory";
 import { RequestEvaluation } from "./pages/RequestEvaluation";

--- a/src/components/ToastContainer.test.tsx
+++ b/src/components/ToastContainer.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * Tests for the centralized accessible ToastContainer (`src/components/ToastContainer.tsx`).
+ *
+ * Coverage areas:
+ * - Renders inside NotificationProvider
+ * - Uses role="status" on the outer queue container
+ * - aria-live="polite", aria-atomic="true"
+ * - Renders individual toast items with correct severity roles
+ * - Dismissing a toast removes it from the DOM
+ * - Stack is capped at 5 items
+ * - Works with useToast helpers (success, error, warning, info)
+ * - Edge cases: empty queue, persistent toasts, action buttons
+ */
+
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { NotificationProvider } from '../context/NotificationContext';
+import { ToastContainer } from './ToastContainer';
+import { useToast } from '../hooks/useToast';
+
+// ── Test harness ──────────────────────────────────────────────────────────────
+
+function TestHarness({
+  onMount,
+}: {
+  onMount?: (toast: ReturnType<typeof useToast>) => void;
+}) {
+  const toast = useToast();
+  if (onMount) onMount(toast);
+  return <ToastContainer />;
+}
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(<NotificationProvider>{ui}</NotificationProvider>);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ToastContainer (centralized queue)', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.runAllTimers(); vi.useRealTimers(); });
+
+  // ─── Container ARIA ─────────────────────────────────────────────────────────
+
+  it('has role="status" on the outer queue container', () => {
+    renderWithProvider(<TestHarness />);
+    const container = document.querySelector('.toast-container');
+    expect(container).toHaveAttribute('role', 'status');
+  });
+
+  it('has aria-live="polite" on the outer container', () => {
+    renderWithProvider(<TestHarness />);
+    const container = document.querySelector('.toast-container');
+    expect(container).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('has aria-atomic="true" on the outer container', () => {
+    renderWithProvider(<TestHarness />);
+    const container = document.querySelector('.toast-container');
+    expect(container).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('has aria-label="Notifications" on the outer container', () => {
+    renderWithProvider(<TestHarness />);
+    const container = document.querySelector('.toast-container');
+    expect(container).toHaveAttribute('aria-label', 'Notifications');
+  });
+
+  // ─── Renders toasts ─────────────────────────────────────────────────────────
+
+  it('renders a toast when useToast().success is called', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+
+    act(() => { toastFns.success('Saved', 'Your changes are saved.'); });
+
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+    expect(screen.getByText('Your changes are saved.')).toBeInTheDocument();
+  });
+
+  it('renders a toast when useToast().error is called', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+
+    act(() => { toastFns.error('Failed', 'Could not connect.'); });
+
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+
+  it('renders all four severity types', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+
+    act(() => {
+      toastFns.success('S', 'success msg');
+      toastFns.error('E', 'error msg');
+      toastFns.warning('W', 'warning msg');
+      toastFns.info('I', 'info msg');
+    });
+
+    expect(screen.getByText('S')).toBeInTheDocument();
+    expect(screen.getByText('E')).toBeInTheDocument();
+    expect(screen.getByText('W')).toBeInTheDocument();
+    expect(screen.getByText('I')).toBeInTheDocument();
+  });
+
+  // ─── Individual toast roles (re-exported from notifications/ToastContainer) ─
+
+  it('gives success toasts role="status" and aria-live="polite"', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.success('Done', 'All good.'); });
+
+    const toast = document.querySelector('.toast-item');
+    expect(toast).toHaveAttribute('role', 'status');
+    expect(toast).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('gives error toasts role="alert" and aria-live="assertive"', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.error('Failed', 'Broke.'); });
+
+    const toast = document.querySelector('.toast-item');
+    expect(toast).toHaveAttribute('role', 'alert');
+    expect(toast).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  // ─── Dismiss ────────────────────────────────────────────────────────────────
+
+  it('removes the toast after clicking the dismiss button', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.info('Dismiss me', 'Click ×.'); });
+
+    expect(screen.getByText('Dismiss me')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss notification/i }));
+    act(() => { vi.advanceTimersByTime(400); });
+
+    expect(screen.queryByText('Dismiss me')).not.toBeInTheDocument();
+  });
+
+  // ─── Stack cap ──────────────────────────────────────────────────────────────
+
+  it('caps the toast stack at 5 items', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => {
+      for (let i = 0; i < 7; i++) {
+        toastFns.info(`Toast ${i}`, 'msg');
+      }
+    });
+
+    const items = document.querySelectorAll('.toast-item');
+    expect(items.length).toBeLessThanOrEqual(5);
+  });
+
+  // ─── Action buttons ─────────────────────────────────────────────────────────
+
+  it('renders an action button when an action is provided', () => {
+    const onAction = vi.fn();
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => {
+      toastFns.info('With action', 'Click below.', {
+        action: { label: 'View details', onClick: onAction },
+      });
+    });
+
+    expect(screen.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+  });
+
+  it('fires the action callback when the action button is clicked', () => {
+    const onAction = vi.fn();
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => {
+      toastFns.info('Action test', 'Perform action.', {
+        action: { label: 'Do it', onClick: onAction },
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /do it/i }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── Persistent toasts ─────────────────────────────────────────────────────
+
+  it('keeps persistent toasts visible beyond the default duration', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => {
+      toastFns.info('Persistent', 'Stays forever.', { persistent: true });
+    });
+
+    act(() => { vi.advanceTimersByTime(10000); });
+
+    expect(screen.getByText('Persistent')).toBeInTheDocument();
+  });
+
+  // ─── Auto-dismiss after duration ────────────────────────────────────────────
+
+  it('auto-dismisses non-persistent toasts after the default duration', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.info('Auto', 'Will vanish.'); });
+
+    act(() => { vi.advanceTimersByTime(5500); });
+    act(() => { vi.advanceTimersByTime(400); });
+
+    expect(screen.queryByText('Auto')).not.toBeInTheDocument();
+  });
+
+  // ─── Empty state ───────────────────────────────────────────────────────────
+
+  it('renders an empty container when there are no toasts', () => {
+    renderWithProvider(<TestHarness />);
+    const container = document.querySelector('.toast-container');
+    expect(container).toBeInTheDocument();
+    expect(container!.childElementCount).toBe(0);
+  });
+
+  // ─── Icon accessibility ─────────────────────────────────────────────────────
+
+  it('marks the icon badge as aria-hidden', () => {
+    let toastFns!: ReturnType<typeof useToast>;
+    renderWithProvider(<TestHarness onMount={(t) => { toastFns = t; }} />);
+    act(() => { toastFns.success('Icon test', 'Check icon.'); });
+
+    const badge = document.querySelector('.toast-type-icon');
+    expect(badge).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -1,0 +1,92 @@
+/**
+ * Centralized accessible toast queue for the application.
+ *
+ * Mount this component once in the app root (e.g. inside
+ * `<NotificationProvider>`) to render all active toasts in a
+ * `role="status"` live region.
+ *
+ * ## Accessibility (WCAG 2.1 AA)
+ *
+ * - The outer container carries `role="status"` so screen readers can
+ *   identify this region as a status landmark (SC 4.1.3 – Status Messages).
+ * - `aria-live="polite"` ensures new toasts are announced when the AT
+ *   is idle, without interrupting the user's current task.
+ * - `aria-atomic="true"` tells AT to read the region as a whole unit.
+ * - Each individual toast item carries its own `role="status"` (for
+ *   success / info / warning) or `role="alert"` (for error / danger),
+ *   which drives the actual per-toast announcement — see `ToastItem` in
+ *   `./notifications/ToastContainer.tsx`.
+ * - The container has `aria-label="Notifications"` so AT users can
+ *   identify the region when navigating by landmark.
+ *
+ * The container does NOT set `aria-relevant="additions"` because each
+ * child ToastItem already has its own live-region role; restricting the
+ * parent to only additions would cause unpredictable behaviour across
+ * different screen readers (some would double-announce, others would
+ * defer to the child and behave correctly).
+ *
+ * ## Usage
+ *
+ * ```tsx
+ * import { ToastContainer } from './components/ToastContainer';
+ *
+ * function App() {
+ *   return (
+ *     <NotificationProvider>
+ *       <ToastContainer />
+ *       <Routes>…</Routes>
+ *     </NotificationProvider>
+ *   );
+ * }
+ * ```
+ *
+ * ## Responsive behaviour
+ *
+ * - The queue is fixed-positioned at the top-right of the viewport.
+ * - On mobile (≤ 640 px) it respects safe-area insets (`--sat`, `--sar`)
+ *   for notched devices.
+ * - `max-width` is constrained to `calc(100vw - 2.5rem)` so it never
+ *   overflows the viewport.
+ * - Stack is capped at 5 toasts (enforced by `NotificationContext`).
+ *
+ * ## Future enhancements
+ *
+ * - Add a `position` prop to support bottom-left or bottom-right
+ *   placement.
+ * - Support toast stacking direction (top-to-bottom vs bottom-to-top).
+ */
+
+import { ToastItem } from "./notifications/ToastContainer";
+import { useNotifications } from "../context/NotificationContext";
+import "./notifications/ToastContainer.css";
+
+export function ToastContainer() {
+  const { toasts, dismissToast } = useNotifications();
+
+  return (
+    /*
+     * role="status" + aria-live="polite" = WCAG 4.1.3 Status Message.
+     * The region politely announces new content when the AT is idle,
+     * without interrupting the user's current task.
+     *
+     * aria-atomic="true" provides a hint that the region should be read
+     * as a complete unit.
+     *
+     * Each individual ToastItem carries its own role/aria-live for
+     * per-toast announcements. This container serves as a labelled
+     * landmark region that AT users can navigate to, and as a fallback
+     * live region for aggregate changes.
+     */
+    <div
+      className="toast-container"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      aria-label="Notifications"
+    >
+      {toasts.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} onDismiss={dismissToast} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/notifications/NotificationBell.css
+++ b/src/components/notifications/NotificationBell.css
@@ -49,3 +49,24 @@
   from { transform: scale(0.5); opacity: 0; }
   to   { transform: scale(1); opacity: 1; }
 }
+
+/* One-shot pulse ring when a new high-priority notification arrives
+   (danger/error — issue #219). Purely decorative: the unread badge and
+   live-region announcements carry the meaning (WCAG 1.4.1 safe). */
+.bell-pulse {
+  animation: bellPulse 0.6s ease-out;
+}
+
+@keyframes bellPulse {
+  0%   { box-shadow: 0 0 0 0 rgba(248, 81, 73, 0.5); }
+  70%  { box-shadow: 0 0 0 10px rgba(248, 81, 73, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(248, 81, 73, 0); }
+}
+
+/* Reduced motion: no animation — brief static accent border instead. */
+@media (prefers-reduced-motion: reduce) {
+  .bell-pulse {
+    animation: none;
+    border-color: #f85149;
+  }
+}

--- a/src/components/notifications/NotificationBell.test.tsx
+++ b/src/components/notifications/NotificationBell.test.tsx
@@ -83,7 +83,7 @@ describe('NotificationBell', () => {
 
   // 3
   it('applies bell-pulse class when a new high-priority notification arrives', () => {
-    const { rerender } = renderBell([high('hp-1')]);
+    renderBell([high('hp-1')]);
     const btn = screen.getByRole('button');
     expect(btn).toHaveClass('bell-pulse');
   });
@@ -100,6 +100,39 @@ describe('NotificationBell', () => {
     const btn = screen.getByRole('button');
     expect(btn).toHaveClass('bell-pulse');
 
+    await act(async () => vi.advanceTimersByTime(700));
+    expect(btn).not.toHaveClass('bell-pulse');
+  });
+
+  // 5b — regression: a notifications mutation mid-animation (e.g. markAsRead
+  // or another arrival) must NOT cancel the in-flight pulse timer, or
+  // `.bell-pulse` would stick on forever.
+  it('clears the pulse even when notifications change mid-animation (sticky-pulse regression)', async () => {
+    let addToast!: ReturnType<typeof useNotifications>['addToast'];
+    function Harness() {
+      addToast = useNotifications().addToast;
+      return <NotificationBell />;
+    }
+    render(
+      <NotificationProvider>
+        <Seeder notifications={[high('hp-1')]} />
+        <Harness />
+      </NotificationProvider>,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveClass('bell-pulse');
+
+    // Trigger a `notifications` array change while the pulse is active.
+    act(() => {
+      addToast({
+        type: 'info',
+        title: 'Info',
+        message: 'Another arrival.',
+        saveToHistory: true,
+      });
+    });
+
+    // The original 650 ms timer must still fire and clear the pulse.
     await act(async () => vi.advanceTimersByTime(700));
     expect(btn).not.toHaveClass('bell-pulse');
   });

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -4,14 +4,33 @@
  * Exposes its internal button ref via React.forwardRef so the parent
  * NotificationWidget can pass it to NotificationCenter as `triggerRef`,
  * enabling correct return-focus when the panel closes.
+ *
+ * Plays a one-shot pulse ring when a NEW high-priority (danger/error)
+ * notification arrives (issue #219). The pulse is purely visual — the
+ * unread badge + live-region announcements carry the meaning, so it is
+ * WCAG 1.4.1 (Use of Color) safe. Under `prefers-reduced-motion: reduce`
+ * the animation is replaced by a brief static border flash.
  */
-import { forwardRef, useEffect, useRef } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 import { useNotifications } from "../../context/NotificationContext";
 import "./NotificationBell.css";
 
-export const NotificationBell = forwardRef<HTMLButtonElement>(
-  function NotificationBell(_props, ref) {
-    const { unreadCount, isPanelOpen, openPanel } = useNotifications();
+interface NotificationBellProps {
+  /** Accessible label for the button (defaults to "Notifications"). */
+  label?: string;
+}
+
+export const NotificationBell = forwardRef<HTMLButtonElement, NotificationBellProps>(
+  function NotificationBell({ label = "Notifications" }, ref) {
+    const { unreadCount, isPanelOpen, openPanel, notifications } = useNotifications();
+
+    // One-shot pulse state — set true on a new high-priority arrival,
+    // cleared after the 650 ms animation so the next arrival re-triggers.
+    const [isPulsing, setIsPulsing] = useState(false);
+    const lastPulsedIdRef = useRef<string | null>(null);
+    // Timer kept in a ref (NOT coupled to the effect cleanup below) so a
+    // mid-animation `notifications` change can't cancel the pulse early.
+    const pulseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     // Internal fallback ref used only for the return-focus side-effect below.
     // When a forwarded ref is provided the parent manages focus return instead.
@@ -33,13 +52,42 @@ export const NotificationBell = forwardRef<HTMLButtonElement>(
       }
     }, [isPanelOpen, ref, buttonRef]);
 
+    // ── Pulse trigger ──────────────────────────────────────────────────────
+    useEffect(() => {
+      // `notifications` is newest-first, so find() returns the most recent
+      // high-priority item. Pulse once per ARRIVAL id, not per render.
+      const latest = notifications.find(
+        (n) => n.type === "danger" || n.type === "error",
+      );
+      if (!latest || latest.id === lastPulsedIdRef.current) return;
+
+      lastPulsedIdRef.current = latest.id;
+      setIsPulsing(true);
+
+      // Remove the class after the animation completes (650 ms) so another
+      // high-priority arrival can pulse again. Managed via a ref so the
+      // cleanup below only clears it on unmount — re-runs of this effect
+      // (e.g. markAsRead mutating `notifications`) must NOT kill an active
+      // pulse, or `.bell-pulse` would stick on forever.
+      if (pulseTimerRef.current) clearTimeout(pulseTimerRef.current);
+      pulseTimerRef.current = setTimeout(() => setIsPulsing(false), 650);
+    }, [notifications]);
+
+    // Clear the pulse timer on unmount only.
+    useEffect(
+      () => () => {
+        if (pulseTimerRef.current) clearTimeout(pulseTimerRef.current);
+      },
+      [],
+    );
+
     return (
       <button
         ref={buttonRef}
-        className="notif-bell"
+        className={isPulsing ? "notif-bell bell-pulse" : "notif-bell"}
         type="button"
         onClick={openPanel}
-        aria-label={`Notifications${unreadCount > 0 ? `, ${unreadCount} unread` : ""}`}
+        aria-label={`${label}${unreadCount > 0 ? ` — ${unreadCount} unread` : ""}`}
         aria-haspopup="dialog"
         aria-expanded={isPanelOpen}
         aria-controls="notification-center"

--- a/src/components/notifications/NotificationCenter.tsx
+++ b/src/components/notifications/NotificationCenter.tsx
@@ -217,7 +217,9 @@ export function NotificationCenter({ triggerRef }: NotificationCenterProps = {})
     if (!isPanelOpen) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.shiftKey && e.key === 'r' && unreadCount > 0) {
+      // Shift+R produces e.key === 'R' (uppercase) — normalise so the
+      // shortcut works regardless of caps-lock / shift-modifier casing.
+      if (e.shiftKey && e.key.toLowerCase() === 'r' && unreadCount > 0) {
         e.preventDefault();
         handleMarkAllAsRead();
       }

--- a/src/components/notifications/NotificationCenter.tsx
+++ b/src/components/notifications/NotificationCenter.tsx
@@ -133,21 +133,6 @@ export function NotificationCenter({ triggerRef }: NotificationCenterProps = {})
     };
   }, []);
 
-  // Keyboard shortcut: Shift+R to mark all as read when panel is open
-  useEffect(() => {
-    if (!isPanelOpen) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.shiftKey && e.key === 'r' && unreadCount > 0) {
-        e.preventDefault();
-        handleMarkAllAsRead();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isPanelOpen, unreadCount, handleMarkAllAsRead]);
-
   const filtered = filterByCategory(activeFilter);
   const dragStartY = useRef<number | null>(null);
   const panelElRef = useRef<HTMLDivElement | null>(null);
@@ -222,6 +207,25 @@ export function NotificationCenter({ triggerRef }: NotificationCenterProps = {})
     markAllAsRead();
     announce(count);
   }, [notifications, unreadCount, addToast, dismissToast, undoRead, markAllAsRead, announce]);
+
+  // Keyboard shortcut: Shift+R to mark all as read when panel is open.
+  // Declared after handleMarkAllAsRead so the dependency array below can
+  // reference it without hitting the temporal-dead-zone ReferenceError
+  // (the callback is a const useCallback, so it must be initialized before
+  // this effect's deps are evaluated during render).
+  useEffect(() => {
+    if (!isPanelOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.shiftKey && e.key === 'r' && unreadCount > 0) {
+        e.preventDefault();
+        handleMarkAllAsRead();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isPanelOpen, unreadCount, handleMarkAllAsRead]);
 
   const handleClearAll = useCallback(() => {
     const prior = [...notifications];

--- a/src/components/notifications/ToastContainer.tsx
+++ b/src/components/notifications/ToastContainer.tsx
@@ -4,7 +4,7 @@ import type { Toast } from "../../types/notification";
 import { TYPE_COLOR, TYPE_ICON } from "./notificationIcons";
 import "./ToastContainer.css";
 
-function ToastItem({
+export function ToastItem({
   toast,
   onDismiss,
 }: {

--- a/src/components/notifications/UndoToast.test.tsx
+++ b/src/components/notifications/UndoToast.test.tsx
@@ -48,7 +48,7 @@ function renderWithUndo() {
     <NotificationProvider>
       <ToastContainer />
       <div>
-        <button type="button" aria-label="Open panel">Dummy opener</button>
+        <OpenPanelHarness />
         <NotificationCenter />
       </div>
     </NotificationProvider>,


### PR DESCRIPTION
## Summary

Closes **#458** — Add accessible toast queue with `role=status`.

A single, centralized toast queue for transient status messages. Mounted once in `App.tsx` inside `NotificationProvider`, it renders every active toast in a `role="status"` live region — WCAG 2.1 SC 4.1.3 (Status Messages).

### What's included

- **`src/components/ToastContainer.tsx`** (new) — centralized queue component mounted in `App.tsx`; outer container uses `role="status"` + `aria-live="polite"` + `aria-atomic="true"` + `aria-label="Notifications"`
- **`src/components/notifications/ToastContainer.tsx`** — `ToastItem` presentational component with per-severity semantics: success/info/warning → `role="status"` + `aria-live="polite"`; error/danger → `role="alert"` + `aria-live="assertive"`
- **`src/hooks/useToast.ts`** — typed convenience helpers (`success`, `error`, `warning`, `info`, `dismiss`)
- **`docs/TOAST_QUEUE.md`** (new) — API, ARIA semantics, visible behaviour, files, and test coverage; linked from the README

### Fixes included on this branch

- **NotificationCenter TDZ crash** — the Shift+R shortcut effect referenced a `const useCallback` before initialization (ReferenceError on every render); moved below `handleMarkAllAsRead` so the dep array can reference it safely
- **Shift+R case-sensitivity** — handler compared `e.key === 'r'` but Shift+R reports `'R'`; normalized with `toLowerCase()` so the shortcut actually works
- **NotificationBell** — restored the `label` prop and one-shot `bell-pulse` on danger/error arrivals (feature dropped in an earlier rewrite but still covered by tests); pulse timer held in a ref and cleared on unmount only, so a mid-animation `notifications` change can't stick the pulse; `prefers-reduced-motion: reduce` fallback added
- **CollateralSwap import** — restored `import CollateralSwap from "./pages/CollateralSwap"` in `App.tsx` (dropped accidentally while wiring in `ToastContainer`, breaking the `/collateral-swap` route)
- **Tests** — added `ToastContainer` suite (17 tests), per-severity role tests, sticky-pulse regression test, contrast tests; removed an unused binding

### Validation

- Toast/notification suite: **164 tests passing** across repeated runs (`ToastContainer`, `notifications/ToastContainer`, `UndoToast`, `NotificationCenter`, `NotificationBell`, `__tests__/NotificationCenter`, `safe-area`)
- `tsc -b` introduces no new errors in touched files

> **Note (pre-existing, not from this branch):** `App.test.tsx` / `App.credit-lines-route.test.tsx` have failures on the base commit `afcb629` and on `upstream/main` too (duplicate `WalletReconnectBanner`/`NetworkMismatchBanner` imports and missing props in `App.tsx` from an earlier merge). They are unrelated to this branch and identical at the merge-base.

## Accessibility Checklist
- [x] Keyboard navigation works (Tab, Shift+Tab, Enter, Escape)
- [x] Focus indicators are clearly visible (2px outline, 2px offset)
- [x] Contrast ratios meet WCAG AA (4.5:1 text, 3:1 large text/icons) — see `ToastContainer.contrast.test.ts`
- [x] Touch targets are at least 44×44 px
- [x] Semantic HTML and ARIA roles/labels are used (`role="status"` / `role="alert"`, `aria-live`, `aria-atomic`, `aria-label`)
- [x] `prefers-reduced-motion` is respected
