### PR TITLE
feat(LandingHero): add tabular-nums to title and subtitle for numeric alignment

### DIFF
--- a/src/pages/LandingHero.test.tsx
+++ b/src/pages/LandingHero.test.tsx
@@ -49,4 +49,12 @@ describe('LandingHero', () => {
     );
     expect(container.querySelector('header')).toBeInTheDocument();
   });
+
+  it('applies tabular-nums to title and subtitle for numeric alignment', () => {
+    render(<LandingHero title="$1,234.56" subtitle="0% APR — 5.0% fee" />);
+    const title = screen.getByRole('heading', { level: 1 });
+    const subtitle = document.querySelector('.landing-hero__subtitle');
+    expect(title.className).toMatch(/tabular-nums/);
+    expect(subtitle?.className).toMatch(/tabular-nums/);
+  });
 });

--- a/src/pages/LandingHero.tsx
+++ b/src/pages/LandingHero.tsx
@@ -54,8 +54,8 @@ export function LandingHero({
       </div>
 
       <div className="landing-hero__content">
-        <h1 className="landing-hero__title">{title}</h1>
-        <p className="landing-hero__subtitle">{subtitle}</p>
+        <h1 className="landing-hero__title tabular-nums">{title}</h1>
+        <p className="landing-hero__subtitle tabular-nums">{subtitle}</p>
         {(cta || secondaryCta) && (
           <div className="landing-hero__actions">
             {cta && <div className="landing-hero__cta">{cta}</div>}


### PR DESCRIPTION
## Summary

Adds `font-variant-numeric: tabular-nums` to the LandingHero title and subtitle elements so that any numeric digits align vertically, preventing digit-width wobble when the displayed content changes.

## Changes

- **LandingHero.tsx**: Added `tabular-nums` class to both `landing-hero__title` and `landing-hero__subtitle` elements
- **LandingHero.test.tsx**: Added test verifying both elements have the `tabular-nums` class

Closes #836