### PR TITLE
feat(AprBreakdown): add visible focus-visible outline on interactive elements

### DIFF
--- a/src/components/AprBreakdown.css
+++ b/src/components/AprBreakdown.css
@@ -54,10 +54,7 @@
   border-color: rgba(88, 166, 255, 0.5);
 }
 
-.apr-breakdown__toggle:focus-visible {
-  outline: 2px solid #58a6ff;
-  outline-offset: 2px;
-}
+
 
 .apr-breakdown__toggle:active {
   background-color: rgba(88, 166, 255, 0.25);
@@ -210,10 +207,7 @@
   color: #58a6ff;
 }
 
-.apr-breakdown__component-expand:focus-visible {
-  outline: 2px solid #58a6ff;
-  outline-offset: 1px;
-}
+
 
 .apr-breakdown__component-expand[aria-expanded="true"] {
   background-color: rgba(88, 166, 255, 0.12);

--- a/src/styles/focus.css
+++ b/src/styles/focus.css
@@ -341,6 +341,39 @@
   border-radius: var(--radius-sm, 4px);
 }
 
+/* ── AprBreakdown interactive elements ───────────────────────────────────── */
+/*
+  GrantFox FWC26 (Stellar Wave) — "Visible focus outline on keyboard-only
+  nav for AprBreakdown" requirement (issue #835).
+
+  Every interactive element inside the AprBreakdown component that is
+  reachable via Tab must show a visible focus ring on keyboard navigation
+  (:focus-visible).
+
+  Covered here:
+    .apr-breakdown__toggle              — "Explain APR" toggle button
+    .apr-breakdown__component-expand    — Per-component expand/collapse button
+
+  All rules use :focus-visible so mouse/touch interactions are unaffected.
+  All colours reference design tokens so they respond to [data-contrast="high"].
+*/
+
+.apr-breakdown__toggle:focus-visible,
+.apr-breakdown__component-expand:focus-visible {
+  outline: var(--focus-ring-width, 2px) solid
+    var(--focus-ring-color, var(--accent, #58a6ff)) !important;
+  outline-offset: var(--focus-ring-offset, 3px) !important;
+  box-shadow: none !important;
+}
+
+.apr-breakdown__toggle:focus-visible {
+  border-radius: var(--radius-md, 6px);
+}
+
+.apr-breakdown__component-expand:focus-visible {
+  border-radius: var(--radius-sm, 4px);
+}
+
 /* ── RepayPage interactive elements ──────────────────────────────────────── */
 /*
   GrantFox FWC26 (Stellar Wave) — "Visible focus outline on keyboard-only

--- a/src/styles/focus.test.tsx
+++ b/src/styles/focus.test.tsx
@@ -316,6 +316,36 @@ describe('OnboardingFlow — focus-visible rules (FWC26)', () => {
   });
 });
 
+describe('AprBreakdown — focus-visible rules (FWC26 / issue #835)', () => {
+  const cssPath = resolve(__dirname, '../styles/focus.css');
+  const css = readFileSync(cssPath, 'utf-8');
+
+  it('defines AprBreakdown-scoped toggle button focus rule', () => {
+    expect(css).toContain('.apr-breakdown__toggle:focus-visible');
+  });
+
+  it('defines AprBreakdown-scoped component expand button focus rule', () => {
+    expect(css).toContain('.apr-breakdown__component-expand:focus-visible');
+  });
+
+  it('uses shared focus-ring tokens in AprBreakdown rules', () => {
+    const abBlockStart = css.indexOf('AprBreakdown interactive elements');
+    expect(abBlockStart).toBeGreaterThan(-1);
+    const abBlock = css.slice(abBlockStart);
+    expect(abBlock).toContain('--focus-ring-width');
+    expect(abBlock).toContain('--focus-ring-color');
+    expect(abBlock).toContain('--focus-ring-offset');
+    expect(abBlock).toContain('!important');
+  });
+
+  it('defines toggle button border-radius', () => {
+    const abBlockStart = css.indexOf('AprBreakdown interactive elements');
+    expect(abBlockStart).toBeGreaterThan(-1);
+    const abBlock = css.slice(abBlockStart);
+    expect(abBlock).toContain('border-radius: var(--radius-md, 6px)');
+  });
+});
+
 describe('RepayPage — focus-visible rules (FWC26 / issue #512)', () => {
   const cssPath = resolve(__dirname, '../styles/focus.css');
   const css = readFileSync(cssPath, 'utf-8');


### PR DESCRIPTION
## Summary

Add visible focus-visible outline on every interactive element in the AprBreakdown component, using the project's shared focus-ring design tokens.

## Changes

- **focus.css**: Added AprBreakdown-scoped focus-visible rules for `.apr-breakdown__toggle` and `.apr-breakdown__component-expand`, using shared `--focus-ring-width`, `--focus-ring-color`, and `--focus-ring-offset` tokens
- **AprBreakdown.css**: Removed hardcoded `:focus-visible` rules (now handled by focus.css)
- **focus.test.tsx**: Added 4 tests verifying AprBreakdown focus rules exist, use shared tokens, and have correct border-radius

## Tests

- All 13 AprBreakdown tests pass
- All 4 new AprBreakdown focus tests pass
- All existing focus.css tests pass (4 pre-existing Dashboard test failures are unrelated)

Closes #835