### PR TITLE
fix: polish AmountInput layout for narrow mobile viewports (<=375px) (Closes #820)

### DIFF
--- a/src/components/AmountInput.mobile.test.tsx
+++ b/src/components/AmountInput.mobile.test.tsx
@@ -70,7 +70,7 @@ describe("AmountInput Narrow Mobile Viewport (<=375px) Layout", () => {
     const backBtn = screen.getByRole("button", { name: /back/i });
     const actionsContainer = backBtn.parentElement;
 
-    expect(actionsContainer?.className).toContain("flex-col-reverse");
-    expect(actionsContainer?.className).toContain("sm:flex-row");
+    expect(actionsContainer?.className).toContain("flex-col");
+    expect(actionsContainer?.className).toContain("xs:flex-row");
   });
 });

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -19,7 +19,7 @@ import { Skeleton } from "./Skeleton";
 const STEP_AMOUNT = 100;
 
 const stepClasses =
-  "flex items-center justify-center min-w-[44px] min-h-[44px] w-11 h-11 rounded-lg border border-border bg-background/60 text-foreground hover:bg-surface hover:border-accent/50 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:opacity-40 disabled:cursor-not-allowed shrink-0";
+  "flex items-center justify-center min-w-[44px] min-h-[44px] w-10 h-10 xs:w-11 xs:h-11 rounded-lg border border-border bg-background/60 text-foreground hover:bg-surface hover:border-accent/50 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:opacity-40 disabled:cursor-not-allowed shrink-0";
 
 const STEP_ICON_CLASS = "h-4 w-4 stroke-[2.5]";
 
@@ -86,7 +86,7 @@ export function AmountInputSkeleton() {
       {/* Quick amount presets skeleton */}
       <div>
         <Skeleton width="100px" height="1.25rem" className="rounded-md mb-3" />
-        <div className="grid grid-cols-4 gap-1.5 sm:gap-2">
+        <div className="grid grid-cols-2 xs:grid-cols-4 gap-1.5 sm:gap-2">
           {[25, 50, 75, 100].map((percent) => (
             <Skeleton key={percent} height="44px" className="rounded-lg min-h-[44px]" />
           ))}
@@ -110,9 +110,9 @@ export function AmountInputSkeleton() {
       </div>
 
       {/* Action buttons skeleton */}
-      <div className="flex flex-col-reverse sm:flex-row gap-2.5 sm:gap-3 pt-4">
-        <Skeleton height="44px" className="w-full sm:flex-1 rounded-lg min-h-[44px]" />
-        <Skeleton height="44px" className="w-full sm:flex-1 rounded-lg min-h-[44px]" />
+      <div className="flex flex-col xs:flex-row gap-2.5 sm:gap-3 pt-4">
+        <Skeleton height="44px" className="w-full xs:flex-1 rounded-lg min-h-[44px]" />
+        <Skeleton height="44px" className="w-full xs:flex-1 rounded-lg min-h-[44px]" />
       </div>
     </div>
   );
@@ -286,7 +286,7 @@ export function AmountInput({
 
         {/* Input field container polished for narrow (<=375px) mobile viewports */}
         <div
-          className={`flex flex-wrap sm:flex-nowrap items-center gap-1.5 sm:gap-3 bg-surface p-2.5 sm:p-4 rounded-xl border-2 overflow-hidden transition-colors ${inputStateClassName}`}
+          className={`flex flex-wrap xs:flex-nowrap items-center gap-1.5 sm:gap-3 bg-surface p-2.5 sm:p-4 rounded-xl border-2 overflow-hidden transition-colors ${inputStateClassName}`}
         >
           <div className="flex items-center gap-1 sm:gap-2 flex-1 min-w-[120px] max-w-full">
             <button
@@ -401,7 +401,7 @@ export function AmountInput({
         <p className="text-xs sm:text-sm font-semibold text-foreground mb-2 sm:mb-3 leading-[var(--lh-body)]">
           Quick amount
         </p>
-        <div className="grid grid-cols-4 gap-1.5 sm:gap-2">
+        <div className="grid grid-cols-2 xs:grid-cols-4 gap-1.5 sm:gap-2">
           {[25, 50, 75, 100].map((percent) => (
             <button
               key={percent}
@@ -445,10 +445,10 @@ export function AmountInput({
       </div>
 
       {/* Action buttons stacked vertically on <=375px mobile, horizontal on sm+ */}
-      <div className="flex flex-col-reverse sm:flex-row gap-2.5 sm:gap-3 pt-3 sm:pt-4">
+      <div className="flex flex-col xs:flex-row gap-2.5 sm:gap-3 pt-3 sm:pt-4">
         <button
           onClick={onBack}
-          className="w-full sm:flex-1 py-3 px-4 border-2 border-border text-foreground rounded-lg hover:bg-surface transition-colors font-semibold text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px] flex items-center justify-center"
+          className="w-full xs:w-auto py-3 px-4 border-2 border-border text-foreground rounded-lg hover:bg-surface transition-colors font-semibold text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px] flex items-center justify-center"
           type="button"
         >
           Back
@@ -456,7 +456,7 @@ export function AmountInput({
         <button
           onClick={() => onNext(numAmount)}
           disabled={!isValid}
-          className="w-full sm:flex-1 py-3 px-4 bg-accent text-background rounded-lg hover:bg-accent/90 transition-all font-semibold text-sm disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px] flex items-center justify-center"
+          className="w-full xs:w-auto py-3 px-4 bg-accent text-background rounded-lg hover:bg-accent/90 transition-all font-semibold text-sm disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px] flex items-center justify-center"
           type="button"
         >
           Continue

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 @import "./styles/typography.css";
+
+@theme {
+  --breakpoint-xs: 480px;
+}
 /* focus.css — WCAG 2.1 AA focus-ring tokens and utilities (FWC26) */
 @import "./styles/focus.css";
 @import "./styles/safe-area.css";


### PR DESCRIPTION
## Summary

Closes #820

Audits `AmountInput` on **<=375px** viewports and adjusts the responsive breakpoints from `sm` (640px) to `xs` (480px) so the mobile layout kicks in earlier.

## Changes

### New: `xs` breakpoint (480px) in Tailwind v4 theme
- Added `@theme { --breakpoint-xs: 480px; }` to `src/index.css`

### AmountInput responsive refinements
| Area | Before | After |
|:---|:---|:---|
| Quick amount presets | `grid-cols-4` at all sizes | `grid-cols-2` narrow → `xs:grid-cols-4` |
| Action buttons | `flex-col-reverse sm:flex-row` | `flex-col` narrow → `xs:flex-row` |
| Stepper buttons | `w-11 h-11` (44×44) at all sizes | `w-10 h-10` narrow → `xs:w-11 xs:h-11` |
| Action button width | `w-full sm:flex-1` | `w-full` narrow → `xs:w-auto` |
| Input container | `flex-wrap sm:flex-nowrap` | `flex-wrap` narrow → `xs:flex-nowrap` |

### Test updates
- Updated mobile test to reflect new `flex-col` / `xs:flex-row` behavior

## Testing
- ✅ 3 mobile tests pass (AmountInput.mobile.test.tsx)
- ✅ 5 responsive breakpoint tests pass (AmountInput.test.tsx — Responsive Breakpoints (v7) section)
- 30 pre-existing test failures in the main test file are unrelated to this change