### PR TITLE
feat: add print stylesheet section for SettingsAccount [b#011] [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,8 @@
 @import "./styles/patterns.css";
 @import "./components/FormField.css";
 @import "./styles/themes/high-contrast.css"; // High‑contrast overrides
+@import "./styles/print.css";        // Print media — hides chrome, expands collapsibles, formats for paper
+@import "./styles/print-settings.css"; // Print media — SettingsAccount-specific print styles
 :root,
 .theme-default {
   --bg: #0d1117;

--- a/src/pages/SettingsAccount.css
+++ b/src/pages/SettingsAccount.css
@@ -168,3 +168,45 @@
 [data-motion="reduced"] .settings-account__panel {
   transition: none !important;
 }
+
+/* ── Print media ─────────────────────────────────────────────────────────── */
+
+@media print {
+  /* Hide interactive chrome */
+  .settings-account__toggle {
+    display: none !important;
+  }
+
+  .settings-account__chevron {
+    display: none !important;
+  }
+
+  /* Expand all collapsible panels so their content is fully visible on paper */
+  .settings-account__panel,
+  .settings-account__panel--expanded {
+    max-height: none !important;
+    height: auto !important;
+    overflow: visible !important;
+    transition: none !important;
+  }
+
+  /* Keep the panel-inner visible without padding issues */
+  .settings-account__panel-inner {
+    padding: 0 var(--space-5) var(--space-5) var(--space-5);
+    display: block !important;
+  }
+
+  /* Ensure section headings and labels print in dark ink */
+  .settings-account__title,
+  .settings-account__description,
+  .settings-account__toggle-label {
+    color: #000 !important;
+  }
+
+  /* Clean up card borders and backgrounds for paper */
+  .settings-account__collapsible {
+    border: 1px solid #ccc !important;
+    background: #fff !important;
+    break-inside: avoid;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a dedicated print stylesheet section for the SettingsAccount page, ensuring a clean, readable printed output.

## Changes

### `src/index.css`
- **Import `print.css`**: Restores the missing import for the general print stylesheet (covers AmountConfirm and other pages)
- **Import `print-settings.css`: Restores the missing import for the SettingsAccount-specific print stylesheet

### `src/pages/SettingsAccount.css`
- **Hide interactive chrome**: Toggle buttons and chevrons are hidden in print mode
- **Expand collapsible panels**: All `.settings-account__panel` and `.settings-account__panel--expanded` elements are fully expanded (`max-height: none`, `height: auto`, `overflow: visible`)
- **Dark ink on white paper**: Section headings, descriptions, and toggle labels print in `#000` on white background
- **Clean card borders**: Collapsible containers get a light `#ccc` border and `#fff` background for paper output
- **Page continuity**: `break-inside: avoid` prevents awkward page breaks within collapsible sections

## Testing

- Existing `print-settings.test.ts` (6 tests) — ✅ all pass
- The pre-existing `resolve is not defined` error in `SettingsAccount.test.tsx` is unrelated to this change (missing import in the test file's parent scope)

Closes #824