### PR TITLE
feat(RepaymentVisualizer): add ErrorBoundary wrapper with retry action (Closes #852)

### DIFF
--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import { vi } from "vitest";
 import { ErrorBoundary } from "./ErrorBoundary";
@@ -7,6 +7,8 @@ import { ErrorBoundary } from "./ErrorBoundary";
 const ThrowError = () => {
   throw new Error("Test error");
 };
+
+const SafeChild = () => <div>Recovered content</div>;
 
 describe("ErrorBoundary", () => {
   const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -57,6 +59,9 @@ describe("ErrorBoundary", () => {
     );
 
     expect(
+      screen.getByRole("button", { name: /try again/i }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("button", { name: /go back/i }),
     ).toBeInTheDocument();
     expect(
@@ -66,5 +71,38 @@ describe("ErrorBoundary", () => {
     expect(
       screen.getByRole("link", { name: /contact support/i }),
     ).toBeInTheDocument();
+  });
+
+  it("resets error state and re-renders children on Try Again", () => {
+    // Use a mutable ref to control whether the component should throw
+    // after the error boundary has been reset.
+    let shouldThrow = true;
+
+    const ConditionalThrow = () => {
+      if (shouldThrow) {
+        throw new Error("Render error");
+      }
+      return <SafeChild />;
+    };
+
+    render(
+      <BrowserRouter>
+        <ErrorBoundary>
+          <ConditionalThrow />
+        </ErrorBoundary>
+      </BrowserRouter>,
+    );
+
+    // First render catches the error
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+    // Stop throwing and reset the error boundary
+    shouldThrow = false;
+
+    // Click "Try Again"
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    // After reset, the child re-renders and no longer throws
+    expect(screen.getByText("Recovered content")).toBeInTheDocument();
   });
 });

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -44,9 +44,18 @@ export class ErrorBoundary extends Component<Props, State> {
     console.error("Uncaught error:", error, errorInfo);
   }
 
+  /**
+   * Resets the error state so the boundary re-renders its children.
+   * Useful for "Try Again" / retry actions that should attempt to
+   * recover without a full page reload.
+   */
+  public resetError = (): void => {
+    this.setState({ hasError: false, error: undefined });
+  };
+
   public render() {
     if (this.state.hasError) {
-      return <ErrorPage error={this.state.error} />;
+      return <ErrorPage error={this.state.error} onRetry={this.resetError} />;
     }
 
     return this.props.children;
@@ -55,9 +64,12 @@ export class ErrorBoundary extends Component<Props, State> {
 
 interface ErrorPageProps {
   error?: Error;
+  /** Called when the user clicks "Try Again" — resets the error boundary
+   *  so the component subtree re-renders without a full page reload. */
+  onRetry?: () => void;
 }
 
-function ErrorPage({ error }: ErrorPageProps) {
+function ErrorPage({ error, onRetry }: ErrorPageProps) {
   const handleGoBack = () => {
     window.history.back();
   };
@@ -83,8 +95,17 @@ function ErrorPage({ error }: ErrorPageProps) {
           </p>
         )}
         <div className="error-actions">
+          {onRetry && (
+            <button
+              className="error-btn error-btn-primary"
+              onClick={onRetry}
+              aria-label="Try again to render the content"
+            >
+              Try Again
+            </button>
+          )}
           <button
-            className="error-btn error-btn-primary"
+            className="error-btn error-btn-secondary"
             onClick={handleGoBack}
             aria-label="Go back to previous page"
           >

--- a/src/pages/RepaymentVisualizer.tsx
+++ b/src/pages/RepaymentVisualizer.tsx
@@ -28,6 +28,7 @@ import type {
   ScheduleRow,
 } from "@/components/RepaymentVisualizer";
 import { LiveRegion } from "@/components/LiveRegion";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 /**
  * Derives the SR announcement text from a loading-state transition.
@@ -64,7 +65,9 @@ export default function RepaymentVisualizerPage(props: RepaymentVisualizerProps)
   return (
     <>
       <LiveRegion message={pageAnnouncement} politeness="polite" />
-      <RepaymentVisualizer {...props} />
+      <ErrorBoundary>
+        <RepaymentVisualizer {...props} />
+      </ErrorBoundary>
     </>
   );
 }


### PR DESCRIPTION
## Summary

Adds a component-level ErrorBoundary around the RepaymentVisualizer chart with a **Try Again** button that resets the error boundary state and re-renders the component without a full page reload.

## Changes

### ErrorBoundary (src/components/ErrorBoundary.tsx)
- Added `resetError()` method to the class component — sets `hasError: false` and `error: undefined` so the boundary re-renders its children
- Added `onRetry` callback prop to the `ErrorPage` fallback UI
- Added **Try Again** button (primary action) that calls `resetError()`
- Moved **Go Back** to secondary button style

### RepaymentVisualizer page (src/pages/RepaymentVisualizer.tsx)
- Wrapped the `RepaymentVisualizer` component in a dedicated `<ErrorBoundary>` so render errors in the chart are caught locally with a retry-able fallback

### Tests (src/components/ErrorBoundary.test.tsx)
- Added `resets error state and re-renders children on Try Again` test covering the retry recovery flow

Closes #852