### PR TITLE
feat(AmountConfirm): add aria-live region for screen-reader announcements (Closes #839)

### DIFF
--- a/src/pages/AmountConfirm.test.tsx
+++ b/src/pages/AmountConfirm.test.tsx
@@ -66,4 +66,34 @@ describe('AmountConfirm', () => {
     );
     expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument();
   });
+
+  // ─── LiveRegion tests ────────────────────────────────────────────────────
+
+  it('renders a LiveRegion with sr-only class for SR announcements', () => {
+    render(<AmountConfirm amount={5000} onConfirm={vi.fn()} />);
+    const liveRegion = document.querySelector('[role="status"]');
+    expect(liveRegion).toBeInTheDocument();
+    expect(liveRegion).toHaveClass('sr-only');
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('announces confirmation message when amount matches', () => {
+    render(<AmountConfirm amount={5000} onConfirm={vi.fn()} />);
+    const input = screen.getByLabelText(/Type the amount to confirm/i);
+    fireEvent.change(input, { target: { value: '5000' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    const liveRegion = document.querySelector('[role="status"]');
+    expect(liveRegion).toHaveTextContent('Amount confirmed: $5,000');
+  });
+
+  it('announces error message when amount does not match', () => {
+    render(<AmountConfirm amount={5000} onConfirm={vi.fn()} />);
+    const input = screen.getByLabelText(/Type the amount to confirm/i);
+    fireEvent.change(input, { target: { value: '4999' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    const liveRegion = document.querySelector('[role="status"]');
+    expect(liveRegion).toHaveTextContent(
+      /Amount does not match.*type exactly 5000/i,
+    );
+  });
 });

--- a/src/pages/AmountConfirm.tsx
+++ b/src/pages/AmountConfirm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { LiveRegion } from '../components/LiveRegion';
 
 export interface AmountConfirmProps {
   /** The monetary amount to confirm (USD). */
@@ -48,6 +49,7 @@ export function AmountConfirm({
 }: AmountConfirmProps) {
   const [typed, setTyped] = useState('');
   const [error, setError] = useState('');
+  const [srAnnouncement, setSrAnnouncement] = useState('');
   const formattedAmount = `$${amount.toLocaleString()}`;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -58,9 +60,11 @@ export function AmountConfirm({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (typed.trim() === String(amount)) {
+      setSrAnnouncement(`Amount confirmed: ${formattedAmount}`);
       onConfirm();
     } else {
       setError(`Please type exactly "${amount}" to confirm.`);
+      setSrAnnouncement(`Amount does not match. Please type exactly ${amount} to confirm.`);
     }
   };
 
@@ -123,6 +127,7 @@ export function AmountConfirm({
           {confirmLabel}
         </button>
       </div>
+      <LiveRegion message={srAnnouncement} politeness="polite" />
     </form>
   );
 }


### PR DESCRIPTION
## Summary

Adds a polite `aria-live` region (via the project's existing `LiveRegion` component) to `AmountConfirm` so screen-reader users are notified of status changes.

## Changes

- **`src/pages/AmountConfirm.tsx`**: Imported `LiveRegion` component and added `srAnnouncement` state. On successful confirmation, announces `"Amount confirmed: $"`; on mismatch, announces the expected amount.
- **`src/pages/AmountConfirm.test.tsx`**: Added 3 tests:
  - Verifies LiveRegion renders with `sr-only` class and `aria-live="polite"`
  - Verifies confirmation announcement on match
  - Verifies error announcement on mismatch

## Acceptance Criteria

- [x] LiveRegion with `sr-only` class is rendered inside the form
- [x] `aria-live="polite"` ensures SR announcements don't interrupt the user
- [x] Confirmation success announces the confirmed amount
- [x] Error state announces the mismatch and expected amount
- [x] All 10 tests pass (7 existing + 3 new)

Closes #839