### PR TITLE
feat: add sticky action bar on Dashboard while scrolling (Closes #847)

### DIFF
--- a/src/components/DashboardActionBar.test.tsx
+++ b/src/components/DashboardActionBar.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * DashboardActionBar.test.tsx
+ *
+ * Focused test suite for the DashboardActionBar component.
+ *
+ * Coverage areas:
+ *   1. Rendering — bar is hidden by default, visible on scroll
+ *   2. Content   — correct buttons shown based on hasLines/hasUtilized
+ *   3. Accessibility — toolbar role, ARIA labels
+ *   4. Reduced motion — no motion class when reduced motion is active
+ *   5. Scroll threshold — configurable scroll threshold
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BrowserRouter } from 'react-router-dom';
+import { DashboardActionBar } from './DashboardActionBar';
+import { ReducedMotionProvider } from '../context/ReducedMotionContext';
+
+// ─── Mock scrollTo ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  // jsdom doesn't support scrollY, so we stub it
+  Object.defineProperty(window, 'scrollY', { value: 0, writable: true, configurable: true });
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const MOCK_CREDIT_LINES = [
+  { id: 'cl-1', name: 'Line 1', status: 'Active' as const, limit: 10000, utilized: 3000, riskScore: 650, updatedAt: '2025-01-01T00:00:00Z', apr: 8.5, openedAt: '2024-06-01T00:00:00Z', transactions: [], statusHistory: [] },
+  { id: 'cl-2', name: 'Line 2', status: 'Active' as const, limit: 20000, utilized: 8000, riskScore: 720, updatedAt: '2025-01-01T00:00:00Z', apr: 7.2, openedAt: '2024-06-01T00:00:00Z', transactions: [], statusHistory: [] },
+];
+
+function renderBar(props: Partial<Parameters<typeof DashboardActionBar>[0]> = {}) {
+  return render(
+    <BrowserRouter>
+      <ReducedMotionProvider>
+        <DashboardActionBar
+          hasLines={true}
+          hasUtilized={true}
+          activeLinesOnly={MOCK_CREDIT_LINES}
+          totalAvailable={15000}
+          totalUtilized={11000}
+          creditLines={MOCK_CREDIT_LINES}
+          {...props}
+        />
+      </ReducedMotionProvider>
+    </BrowserRouter>
+  );
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('DashboardActionBar visibility', () => {
+  it('is hidden when scrollY is below threshold', () => {
+    window.scrollY = 0;
+    renderBar();
+    const bar = screen.getByRole('toolbar', { hidden: true });
+    expect(bar).toHaveAttribute('hidden');
+    expect(bar).not.toHaveClass('dashboard-action-bar--visible');
+  });
+
+  it('is visible when scrollY exceeds threshold', () => {
+    window.scrollY = 400;
+    renderBar();
+    const bar = screen.getByRole('toolbar');
+    expect(bar).not.toHaveAttribute('hidden');
+    expect(bar).toHaveClass('dashboard-action-bar--visible');
+  });
+
+  it('respects custom scrollThreshold', () => {
+    window.scrollY = 200;
+    renderBar({ scrollThreshold: 100 });
+    const bar = screen.getByRole('toolbar');
+    expect(bar).not.toHaveAttribute('hidden');
+    expect(bar).toHaveClass('dashboard-action-bar--visible');
+  });
+});
+
+describe('DashboardActionBar content', () => {
+  it('shows Draw Credit button when hasLines and active lines exist', () => {
+    window.scrollY = 400;
+    renderBar();
+    expect(screen.getByText('Draw Credit')).toBeInTheDocument();
+    expect(screen.getByText('15.0K')).toBeInTheDocument(); // totalAvailable formatted
+  });
+
+  it('shows Repay button when hasUtilized', () => {
+    window.scrollY = 400;
+    renderBar();
+    expect(screen.getByText('Repay')).toBeInTheDocument();
+    expect(screen.getByText('11.0K')).toBeInTheDocument(); // totalUtilized formatted
+  });
+
+  it('shows Open Credit Line when no lines exist', () => {
+    window.scrollY = 400;
+    renderBar({ hasLines: false, hasUtilized: false, activeLinesOnly: [], totalAvailable: 0, totalUtilized: 0, creditLines: [] });
+    expect(screen.getByText('Open Credit Line')).toBeInTheDocument();
+    expect(screen.queryByText('Draw Credit')).not.toBeInTheDocument();
+  });
+
+  it('always shows View Credit Lines', () => {
+    window.scrollY = 400;
+    renderBar();
+    expect(screen.getByText('View Credit Lines')).toBeInTheDocument();
+  });
+
+  it('shows CopyLoanButton when hasLines', () => {
+    window.scrollY = 400;
+    renderBar();
+    // CopyLoanButton renders a button with "Copy" text
+    expect(screen.getByRole('toolbar').querySelectorAll('a').length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('DashboardActionBar accessibility', () => {
+  it('has toolbar role and aria-label', () => {
+    window.scrollY = 400;
+    renderBar();
+    const bar = screen.getByRole('toolbar');
+    expect(bar).toHaveAttribute('aria-label', 'Quick actions');
+  });
+
+  it('has data-visible attribute', () => {
+    window.scrollY = 400;
+    renderBar();
+    const bar = screen.getByRole('toolbar');
+    expect(bar.getAttribute('data-visible')).toBe('true');
+  });
+});
+
+describe('DashboardActionBar reduced motion', () => {
+  it('adds no-motion class when reduced motion is active', () => {
+    // Mock matchMedia for reduced motion
+    const original = window.matchMedia;
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    window.scrollY = 400;
+    renderBar();
+    const bar = screen.getByRole('toolbar');
+    expect(bar).toHaveClass('dashboard-action-bar--no-motion');
+
+    window.matchMedia = original;
+  });
+});

--- a/src/components/DashboardActionBar.tsx
+++ b/src/components/DashboardActionBar.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { useReducedMotion } from "../context/ReducedMotionContext";
+import { CopyLoanButton } from "./CopyLoanButton";
+import type { CreditLine } from "../types/creditLine";
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+
+interface DashboardActionBarProps {
+  hasLines: boolean;
+  hasUtilized: boolean;
+  activeLinesOnly: CreditLine[];
+  totalAvailable: number;
+  totalUtilized: number;
+  /** Offset from the top of the document (pixels) before the bar appears. */
+  scrollThreshold?: number;
+  /** All credit lines (passed through to CopyLoanButton). */
+  creditLines: CreditLine[];
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const fmt = (n: number): string => {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function DashboardActionBar({
+  hasLines,
+  hasUtilized,
+  activeLinesOnly,
+  totalAvailable,
+  totalUtilized,
+  scrollThreshold = 300,
+  creditLines,
+}: DashboardActionBarProps) {
+  const [visible, setVisible] = useState(false);
+  const { isReducedMotionActive } = useReducedMotion();
+  const barRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > scrollThreshold);
+    };
+
+    // Check initial state
+    handleScroll();
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [scrollThreshold]);
+
+  return (
+    <div
+      ref={barRef}
+      role="toolbar"
+      aria-label="Quick actions"
+      className={`dashboard-action-bar${visible ? " dashboard-action-bar--visible" : ""}${
+        isReducedMotionActive ? " dashboard-action-bar--no-motion" : ""
+      }`}
+      data-visible={visible}
+      hidden={!visible}
+    >
+      <div className="dashboard-action-bar__inner">
+        {!hasLines && (
+          <Link
+            to="/open-credit"
+            className="dashboard-action-bar__btn dashboard-action-bar__btn--primary"
+          >
+            <span aria-hidden="true">🆕</span>
+            <span className="dashboard-action-bar__label">Open Credit Line</span>
+          </Link>
+        )}
+
+        {hasLines && activeLinesOnly.length > 0 && (
+          <Link
+            to="/draw"
+            className="dashboard-action-bar__btn dashboard-action-bar__btn--primary"
+          >
+            <span aria-hidden="true">↗</span>
+            <span className="dashboard-action-bar__label">Draw Credit</span>
+            <span className="dashboard-action-bar__meta num-tabular">
+              {fmt(totalAvailable)}
+            </span>
+          </Link>
+        )}
+
+        {hasUtilized && (
+          <Link
+            to="/repay"
+            className="dashboard-action-bar__btn dashboard-action-bar__btn--secondary"
+          >
+            <span aria-hidden="true">↙</span>
+            <span className="dashboard-action-bar__label">Repay</span>
+            <span className="dashboard-action-bar__meta num-tabular">
+              {fmt(totalUtilized)}
+            </span>
+          </Link>
+        )}
+
+        <Link
+          to="/credit-lines"
+          className="dashboard-action-bar__btn dashboard-action-bar__btn--tertiary"
+        >
+          <span aria-hidden="true">📋</span>
+          <span className="dashboard-action-bar__label">View Credit Lines</span>
+        </Link>
+
+        {hasLines && (
+          <CopyLoanButton creditLines={creditLines} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default DashboardActionBar;

--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -996,3 +996,142 @@
   display: block;
 }
 
+/* ─── Dashboard Action Bar (sticky bottom bar) ─────────────────────────────── */
+
+.dashboard-action-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  padding: var(--space-3) var(--space-4);
+  transform: translateY(100%);
+  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.18);
+}
+
+.dashboard-action-bar--visible {
+  transform: translateY(0);
+}
+
+.dashboard-action-bar--no-motion {
+  transition: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dashboard-action-bar {
+    transition: none !important;
+  }
+}
+
+.dashboard-action-bar__inner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 1200px;
+  margin: 0 auto;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.dashboard-action-bar__inner::-webkit-scrollbar {
+  display: none;
+}
+
+.dashboard-action-bar__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  line-height: var(--lh-heading);
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  transition: all 0.15s;
+  min-height: 44px;
+}
+
+.dashboard-action-bar__btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.dashboard-action-bar__btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.dashboard-action-bar__btn--primary {
+  background: var(--accent);
+  color: #0d1117;
+  border-color: var(--accent);
+}
+
+.dashboard-action-bar__btn--primary:hover {
+  filter: brightness(1.1);
+}
+
+.dashboard-action-bar__btn--secondary {
+  background: rgba(63, 185, 80, 0.12);
+  color: var(--success);
+  border-color: rgba(63, 185, 80, 0.3);
+}
+
+.dashboard-action-bar__btn--secondary:hover {
+  background: rgba(63, 185, 80, 0.2);
+}
+
+.dashboard-action-bar__btn--tertiary {
+  background: transparent;
+  color: var(--muted);
+  border-color: transparent;
+}
+
+.dashboard-action-bar__btn--tertiary:hover {
+  background: rgba(139, 148, 158, 0.12);
+  color: var(--text);
+}
+
+.dashboard-action-bar__label {
+  flex: 1;
+}
+
+.dashboard-action-bar__meta {
+  font-size: var(--text-xs);
+  color: inherit;
+  opacity: 0.7;
+}
+
+/* ─── Dashboard Action Bar: responsive ─────────────────────────────────────── */
+
+@media (min-width: 769px) {
+  .dashboard-action-bar {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .dashboard-action-bar {
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .dashboard-action-bar__btn {
+    padding: var(--space-2);
+    font-size: var(--text-xs);
+    min-height: 40px;
+  }
+
+  .dashboard-action-bar__meta {
+    display: none;
+  }
+}
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -37,6 +37,7 @@ import { LiveRegion } from "../components/LiveRegion";
 import { useReducedMotion } from "../context/ReducedMotionContext";
 import { HealthTipsPanel } from "../components/HealthTipsPanel";
 import { SyncIndicator } from "@/components/SyncIndicator";
+import { DashboardActionBar } from "../components/DashboardActionBar";
 
 export { RiskGauge };
 
@@ -1103,6 +1104,16 @@ export function Dashboard() {
         isOpen={isExplainOpen}
         onClose={() => setIsExplainOpen(false)}
         triggerRef={explainTriggerRef}
+      />
+
+      {/* Sticky action bar — appears on scroll with primary actions */}
+      <DashboardActionBar
+        hasLines={hasLines}
+        hasUtilized={hasUtilized}
+        activeLinesOnly={activeLinesOnly}
+        totalAvailable={totalAvailable}
+        totalUtilized={totalUtilized}
+        creditLines={creditLines}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Adds a sticky bottom action bar on the Dashboard that appears when the user scrolls past a configurable threshold (default 300px). The bar provides quick access to primary actions (Draw Credit, Repay, View Credit Lines, Copy Loan) without requiring the user to scroll back to the top.

## Changes

### New component: `DashboardActionBar`
- `src/components/DashboardActionBar.tsx` — Scroll-aware fixed bottom bar with toolbar role
- `src/components/DashboardActionBar.test.tsx` — 11 focused tests

### Integration
- `src/pages/Dashboard.tsx` — Imported and rendered `DashboardActionBar` with current state props
- `src/pages/Dashboard.css` — Added styles for fixed positioning, slide-up animation, responsive breakpoints

## Features

- **Scroll detection**: Appears after scrolling past 300px (configurable via `scrollThreshold` prop)
- **Context-aware buttons**: Shows appropriate actions based on `hasLines`/`hasUtilized` state
- **Responsive**: Hidden on desktop (≥769px), compact on mobile (≤768px)
- **Accessibility**: `role=toolbar`, `aria-label`, `hidden` attribute, `focus-visible` outlines, 44px touch targets
- **Reduced motion**: Respects `prefers-reduced-motion` via existing `useReducedMotion` hook
- **Smooth animation**: Slide-up transition with cubic-bezier easing

## Testing

```
✓ src/components/DashboardActionBar.test.tsx (11 tests)
```

Coverage includes: visibility (hidden/visible, custom threshold), content (correct buttons per state), accessibility (toolbar role, aria-label, data-visible), reduced motion class.

Closes #847