### PR TITLE
feat: add contextual help popover on DrawCreditPage explaining main metrics for first-time users (Closes #850)

### DIFF
--- a/src/components/CreditLineSelector.tsx
+++ b/src/components/CreditLineSelector.tsx
@@ -20,6 +20,7 @@
 import { CreditLine } from "@/types/draw-credit.types";
 import { AlertCircle, ChevronRight } from "lucide-react";
 import { formatMoney } from "@/utils/amountValidation";
+import { HelpPopover } from "@/components/HelpPopover";
 
 interface CreditLineSelectorProps {
   /** Credit lines the user is eligible to draw from. */
@@ -92,6 +93,11 @@ export function CreditLineSelector({
                       <div>
                         <span className="dc-credit-line-item__label">
                           Available:
+                          <HelpPopover
+                            term="Available"
+                            definition="The amount you can currently draw from this credit line. It equals your total credit limit minus any outstanding balance and pending transactions."
+                            placement="top"
+                          />
                         </span>
                         <span className="dc-credit-line-item__value tabular-nums">
                           ${line.available.toLocaleString()}
@@ -101,6 +107,11 @@ export function CreditLineSelector({
                       <div>
                         <span className="dc-credit-line-item__label">
                           Utilization:
+                          <HelpPopover
+                            term="Utilization"
+                            definition="The percentage of your total credit limit currently in use. Lower utilization (under 30%) is generally better for your credit health and may lead to better rates."
+                            placement="top"
+                          />
                         </span>
                         <span
                           className={`num-tabular ${

--- a/src/components/HelpPopover.css
+++ b/src/components/HelpPopover.css
@@ -1,0 +1,133 @@
+/* ── HelpPopover ────────────────────────────────────────────────────────── */
+
+.help-popover-wrapper {
+  position: relative;
+  display: inline-flex;
+  vertical-align: middle;
+  margin-left: 0.35rem;
+}
+
+.help-popover__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+  line-height: 0;
+}
+
+.help-popover__trigger:hover,
+.help-popover__trigger[aria-expanded="true"] {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-tint);
+}
+
+.help-popover__trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ── Popover content ──────────────────────────────────────────────────── */
+
+.help-popover__content {
+  position: absolute;
+  left: 50%;
+  z-index: 30;
+  width: max(220px, min(320px, calc(100vw - 2rem)));
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  text-align: left;
+  pointer-events: auto;
+  /* Entrance animation (disabled for reduced motion) */
+  animation: help-popover-enter 140ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .help-popover__content {
+    animation: none;
+  }
+}
+
+@keyframes help-popover-enter {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 4px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+/* ── Placement: top ──────────────────────────────────────────────────── */
+
+.help-popover__content--top {
+  bottom: calc(100% + 10px);
+  transform: translate(-50%, 0);
+}
+
+.help-popover__content--top::after {
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  width: 8px;
+  height: 8px;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  content: "";
+  transform: translate(-50%, -4px) rotate(45deg);
+}
+
+/* ── Placement: bottom ───────────────────────────────────────────────── */
+
+.help-popover__content--bottom {
+  top: calc(100% + 10px);
+  transform: translate(-50%, 0);
+}
+
+.help-popover__content--bottom::after {
+  position: absolute;
+  left: 50%;
+  bottom: 100%;
+  width: 8px;
+  height: 8px;
+  border-left: 1px solid var(--border);
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  content: "";
+  transform: translate(-50%, 4px) rotate(45deg);
+}
+
+/* ── Typography ──────────────────────────────────────────────────────── */
+
+.help-popover__term {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.help-popover__definition {
+  margin: 0;
+  color: var(--text);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}

--- a/src/components/HelpPopover.test.tsx
+++ b/src/components/HelpPopover.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * HelpPopover.test.tsx
+ *
+ * Tests for the HelpPopover component:
+ *  - Renders the info trigger button
+ *  - Clicking toggles the popover content
+ *  - Escape key closes the popover
+ *  - Clicking outside closes the popover
+ *  - Renders term and definition text
+ *  - Supports top and bottom placement
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HelpPopover } from "./HelpPopover";
+
+describe("HelpPopover", () => {
+  const defaultProps = {
+    term: "Available",
+    definition: "Your available balance is the amount you can draw.",
+  };
+
+  it("renders the info trigger button", () => {
+    render(<HelpPopover {...defaultProps} />);
+    const button = screen.getByRole("button", { name: /Help: Available/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("shows the popover content when clicked", async () => {
+    const user = userEvent.setup();
+    render(<HelpPopover {...defaultProps} />);
+
+    const button = screen.getByRole("button", { name: /Help: Available/i });
+    await user.click(button);
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Available")).toBeInTheDocument();
+    expect(
+      screen.getByText("Your available balance is the amount you can draw."),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the popover on second click", async () => {
+    const user = userEvent.setup();
+    render(<HelpPopover {...defaultProps} />);
+
+    const button = screen.getByRole("button", { name: /Help: Available/i });
+    await user.click(button);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    await user.click(button);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("closes the popover with Escape key", async () => {
+    const user = userEvent.setup();
+    render(<HelpPopover {...defaultProps} />);
+
+    const button = screen.getByRole("button", { name: /Help: Available/i });
+    await user.click(button);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    // Focus returns to the trigger
+    expect(button).toHaveFocus();
+  });
+
+  it("closes the popover when clicking outside", async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <HelpPopover {...defaultProps} />
+        <div data-testid="outside">Outside</div>
+      </div>,
+    );
+
+    const button = screen.getByRole("button", { name: /Help: Available/i });
+    await user.click(button);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    const outside = screen.getByTestId("outside");
+    await user.click(outside);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("renders with bottom placement", () => {
+    render(
+      <HelpPopover
+        term="Utilization"
+        definition="The percentage of credit in use."
+        placement="bottom"
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /Help: Utilization/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("restores focus to the trigger after closing", async () => {
+    const user = userEvent.setup();
+    render(<HelpPopover {...defaultProps} />);
+
+    const button = screen.getByRole("button", { name: /Help: Available/i });
+    await user.click(button);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(button).toHaveFocus();
+  });
+});

--- a/src/components/HelpPopover.tsx
+++ b/src/components/HelpPopover.tsx
@@ -1,0 +1,100 @@
+import { useId, useRef, useState, useEffect, useCallback } from "react";
+import { Info } from "lucide-react";
+import "./HelpPopover.css";
+
+interface HelpPopoverProps {
+  /** The label or term being explained. */
+  term: string;
+  /** The explanation/definition shown inside the popover. */
+  definition: string | React.ReactNode;
+  /** Optional placement — defaults to top. */
+  placement?: "top" | "bottom";
+}
+
+/**
+ * A click-to-open popover that shows contextual help for a term or metric.
+ *
+ * - Clicking the info icon toggles the popover.
+ * - Pressing Escape closes it.
+ * - Clicking outside closes it.
+ * - Uses `aria-expanded` and `aria-describedby` for screen-reader support.
+ * - Respects `prefers-reduced-motion` by disabling the entrance animation.
+ */
+export function HelpPopover({
+  term,
+  definition,
+  placement = "top",
+}: HelpPopoverProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const popoverId = useId();
+
+  const handleToggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        handleClose();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, handleClose]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!isOpen) return;
+    const onClickOutside = (e: MouseEvent) => {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(e.target as Node) &&
+        triggerRef.current &&
+        !triggerRef.current.contains(e.target as Node)
+      ) {
+        handleClose();
+      }
+    };
+    // Use mousedown to close before the trigger's click fires
+    document.addEventListener("mousedown", onClickOutside);
+    return () => document.removeEventListener("mousedown", onClickOutside);
+  }, [isOpen, handleClose]);
+
+  return (
+    <span className="help-popover-wrapper">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="help-popover__trigger"
+        onClick={handleToggle}
+        aria-expanded={isOpen}
+        aria-describedby={isOpen ? popoverId : undefined}
+        aria-label={`Help: ${term}`}
+      >
+        <Info size={14} aria-hidden="true" />
+      </button>
+      {isOpen && (
+        <div
+          ref={popoverRef}
+          id={popoverId}
+          role="tooltip"
+          className={`help-popover__content help-popover__content--${placement}`}
+          data-placement={placement}
+        >
+          <strong className="help-popover__term">{term}</strong>
+          <p className="help-popover__definition">{definition}</p>
+        </div>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a contextual **HelpPopover** component with info icons next to the **Available** and **Utilization** labels on the DrawCreditPage credit line selector. First-time users can click the info icon to learn what each metric means.

## Changes

### New files
- **`src/components/HelpPopover.tsx`** — Click-to-open popover component with:
  - Info icon trigger button with `aria-expanded` and `aria-label`
  - Popover content with role=\tooltip\ 
  - Closes on Escape key, click outside, or re-clicking the trigger
  - Focus restoration on close
  - Supports `top` and `bottom` placement
- **`src/components/HelpPopover.css`** — Styled popover with:
  - Entrance animation (disabled for `prefers-reduced-motion`)
  - CSS custom property based theming (dark mode compatible)
  - Arrow indicator matching placement
  - Responsive width: `min(320px, calc(100vw - 2rem))`
- **`src/components/HelpPopover.test.tsx`** — 7 tests covering:
  - Renders trigger button with correct aria attributes
  - Click toggles popover content
  - Second click hides popover
  - Escape key closes popover
  - Click outside closes popover
  - Bottom placement renders correctly
  - Focus restoration on close

### Modified files
- **`src/components/CreditLineSelector.tsx`** — Integrated HelpPopover next to \"Available:\" and \"Utilization:\" labels with contextual explanations

## Testing
```
✓ src/components/HelpPopover.test.tsx (7 tests) 630ms
```

Closes #850