### PR TITLE
feat: add optimistic UI on AmountInput primary action (Closes #853)

### DIFF
--- a/src/components/AmountInput.test.tsx
+++ b/src/components/AmountInput.test.tsx
@@ -717,4 +717,106 @@ describe("AmountInput", () => {
     expect(screen.getByText("↑ / ↓")).toBeInTheDocument();
     expect(screen.getByText("Adjust amount")).toBeInTheDocument();
   });
+
+  describe("Optimistic UI (isSubmitting)", () => {
+    it("shows a spinner and 'Processing…' label on the Continue button when isSubmitting is true", () => {
+      render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+          isSubmitting={true}
+        />,
+      );
+
+      // Enter a valid amount so Continue is enabled
+      const input = screen.getByRole("spinbutton", { name: /draw amount/i });
+      fireEvent.change(input, { target: { value: "10000" } });
+
+      const continueBtn = screen.getByRole("button", { name: /processing/i });
+      expect(continueBtn).toBeInTheDocument();
+      expect(continueBtn).toBeDisabled();
+      expect(continueBtn).toHaveAttribute("aria-busy", "true");
+      expect(continueBtn.querySelector(".pending-btn__spinner")).toBeInTheDocument();
+    });
+
+    it("shows normal Continue label when not submitting", () => {
+      render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+          isSubmitting={false}
+        />,
+      );
+
+      const input = screen.getByRole("spinbutton", { name: /draw amount/i });
+      fireEvent.change(input, { target: { value: "10000" } });
+
+      expect(screen.getByRole("button", { name: /continue/i })).toBeInTheDocument();
+      expect(screen.queryByText(/processing/i)).not.toBeInTheDocument();
+    });
+
+    it("disables all interactive elements when isSubmitting is true", () => {
+      render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+          isSubmitting={true}
+        />,
+      );
+
+      const input = screen.getByRole("spinbutton", { name: /draw amount/i });
+      expect(input).toBeDisabled();
+
+      const decreaseBtn = screen.getByRole("button", { name: /decrease amount/i });
+      expect(decreaseBtn).toBeDisabled();
+
+      const increaseBtn = screen.getByRole("button", { name: /increase amount/i });
+      expect(increaseBtn).toBeDisabled();
+
+      const maxBtn = screen.getByRole("button", { name: /set amount to maximum/i });
+      expect(maxBtn).toBeDisabled();
+
+      const backBtn = screen.getByRole("button", { name: /back/i });
+      expect(backBtn).toBeDisabled();
+
+      const presetBtns = screen.getAllByRole("button", { name: /percent/i });
+      presetBtns.forEach((btn) => expect(btn).toBeDisabled());
+    });
+
+    it("sets aria-busy on the root container when isSubmitting is true", () => {
+      const { container } = render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+          isSubmitting={true}
+        />,
+      );
+
+      const root = container.querySelector("div[aria-busy='true']");
+      expect(root).toBeInTheDocument();
+    });
+
+    it("omits aria-busy on root container when isSubmitting is false", () => {
+      const { container } = render(
+        <AmountInput
+          creditLine={creditLine}
+          onAmountChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+          isSubmitting={false}
+        />,
+      );
+
+      const root = container.querySelector("div[aria-busy='true']");
+      expect(root).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -14,6 +14,7 @@ import {
 } from "../utils/amountValidation";
 import { FormMessage } from "./FormMessage";
 import { KbdHint } from "./KbdHint";
+import { PendingButton } from "./PendingButton";
 import { Skeleton } from "./Skeleton";
 
 const STEP_AMOUNT = 100;
@@ -29,6 +30,8 @@ export interface AmountInputProps {
   onNext?: (amount: number) => void;
   onBack?: () => void;
   isLoading?: boolean;
+  /** When true, the Continue button shows a spinner and all inputs are disabled. */
+  isSubmitting?: boolean;
 }
 
 export function AmountInputSkeleton() {
@@ -124,6 +127,7 @@ export function AmountInput({
   onNext,
   onBack,
   isLoading = false,
+  isSubmitting = false,
 }: AmountInputProps) {
   const [amount, setAmount] = useState("");
   const [pasteAnnouncement, setPasteAnnouncement] = useState("");
@@ -245,7 +249,7 @@ export function AmountInput({
   const describedBy = `${helperId} ${constraintsId} ${statusId}${hasError ? ` ${errorId}` : ""}`;
 
   return (
-    <div className="space-y-6 sm:space-y-8 max-w-full overflow-hidden">
+    <div className="space-y-6 sm:space-y-8 max-w-full overflow-hidden" aria-busy={isSubmitting || undefined}>
       <div>
         <h2 className="text-xl sm:text-3xl font-bold text-foreground leading-[var(--lh-heading)] tracking-tight">
           Enter Amount
@@ -291,7 +295,7 @@ export function AmountInput({
           <div className="flex items-center gap-1 sm:gap-2 flex-1 min-w-[120px] max-w-full">
             <button
               onClick={() => handleStep("down")}
-              disabled={numAmount <= 0}
+              disabled={numAmount <= 0 || isSubmitting}
               className={stepClasses}
               aria-label="Decrease amount"
               aria-controls={inputId}
@@ -314,7 +318,8 @@ export function AmountInput({
               onPaste={handlePaste}
               onKeyDown={handleKeyDown}
               ref={inputRef}
-              className="text-base sm:text-2xl font-bold bg-transparent outline-none flex-1 text-foreground placeholder:text-muted/50 min-w-0 tabular-nums amount leading-[var(--lh-display)]"
+              disabled={isSubmitting}
+              className="text-base sm:text-2xl font-bold bg-transparent outline-none flex-1 text-foreground placeholder:text-muted/50 min-w-0 tabular-nums amount leading-[var(--lh-display)] disabled:opacity-40"
               min={validation.minAmount}
               max={creditLine.available}
               step={STEP_AMOUNT}
@@ -325,7 +330,7 @@ export function AmountInput({
             />
             <button
               onClick={() => handleStep("up")}
-              disabled={numAmount >= creditLine.available}
+              disabled={numAmount >= creditLine.available || isSubmitting}
               className={stepClasses}
               aria-label="Increase amount"
               aria-controls={inputId}
@@ -338,7 +343,8 @@ export function AmountInput({
           {/* Max button for quick-fill with 44x44px minimum tap target */}
           <button
             onClick={handleMaxClick}
-            className="px-2.5 sm:px-3 py-2 text-xs sm:text-sm font-semibold text-accent hover:bg-accent/10 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center self-center"
+            disabled={isSubmitting}
+            className="px-2.5 sm:px-3 py-2 text-xs sm:text-sm font-semibold text-accent hover:bg-accent/10 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center self-center disabled:opacity-40 disabled:cursor-not-allowed"
             aria-label="Set amount to maximum available credit"
             type="button"
           >
@@ -410,7 +416,8 @@ export function AmountInput({
                   Math.floor((creditLine.available * percent) / 100).toString(),
                 )
               }
-              className="py-2 px-1.5 sm:px-3 border-2 border-border rounded-lg hover:border-accent hover:bg-surface transition-all text-foreground font-medium text-xs sm:text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px] flex items-center justify-center"
+              disabled={isSubmitting}
+              className="py-2 px-1.5 sm:px-3 border-2 border-border rounded-lg hover:border-accent hover:bg-surface transition-all text-foreground font-medium text-xs sm:text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px] flex items-center justify-center disabled:opacity-40 disabled:cursor-not-allowed"
               aria-label={`Set amount to ${percent} percent of available credit`}
               type="button"
             >
@@ -448,19 +455,22 @@ export function AmountInput({
       <div className="flex flex-col-reverse sm:flex-row gap-2.5 sm:gap-3 pt-3 sm:pt-4">
         <button
           onClick={onBack}
-          className="w-full sm:flex-1 py-3 px-4 border-2 border-border text-foreground rounded-lg hover:bg-surface transition-colors font-semibold text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px] flex items-center justify-center"
+          disabled={isSubmitting}
+          className="w-full sm:flex-1 py-3 px-4 border-2 border-border text-foreground rounded-lg hover:bg-surface transition-colors font-semibold text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px] flex items-center justify-center disabled:opacity-40 disabled:cursor-not-allowed"
           type="button"
         >
           Back
         </button>
-        <button
+        <PendingButton
+          pending={isSubmitting}
+          pendingLabel="Processing…"
           onClick={() => onNext(numAmount)}
           disabled={!isValid}
           className="w-full sm:flex-1 py-3 px-4 bg-accent text-background rounded-lg hover:bg-accent/90 transition-all font-semibold text-sm disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background min-h-[44px] flex items-center justify-center"
           type="button"
         >
           Continue
-        </button>
+        </PendingButton>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Adds optimistic UI feedback to the AmountInput primary action (Continue button). When `isSubmitting` is true:

- **Continue button** shows an inline spinner and "Processing…" label via the existing `PendingButton` component
- **All interactive elements** are disabled (stepper buttons, number input, Max button, preset chips, Back button)
- **Root container** gets `aria-busy="true"` for screen reader announcements
- **Disabled styling** (`disabled:opacity-40 disabled:cursor-not-allowed`) applied consistently

The revert-on-failure pattern is handled by the parent component — the parent sets `isSubmitting=false` on error, which restores the normal Continue button and re-enables all inputs.

## Changes
- `AmountInput.tsx`: Added `isSubmitting` prop, integrated `PendingButton`, disabled all interactive elements when submitting
- `AmountInput.test.tsx`: Added 5 tests covering spinner display, label swap, disabled state, and `aria-busy` behavior

Closes #853