### PR TITLE
feat: add hover-preview card on HealthMeter rows/cards (Closes #845)

### DIFF
--- a/src/pages/CreditLines.css
+++ b/src/pages/CreditLines.css
@@ -740,3 +740,111 @@
     }
 }
 
+/* ─── Health Factor Preview Card ──────────────────────────────────────────── */
+
+.hf-preview-card {
+    min-width: 200px;
+}
+
+.hf-preview-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.hf-preview-card__label {
+    font-size: var(--text-xs, 0.75rem);
+    font-weight: 600;
+    color: var(--muted, #8b949e);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.hf-preview-card__value {
+    font-size: var(--text-lg, 1.125rem);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+}
+
+.hf-preview-card__value--safe {
+    color: var(--success, #3fb950);
+}
+
+.hf-preview-card__value--caution {
+    color: var(--warning, #d29922);
+}
+
+.hf-preview-card__value--risk {
+    color: var(--danger, #f85149);
+}
+
+.hf-preview-card__band {
+    margin-bottom: 0.5rem;
+}
+
+.hf-preview-card__band-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.15rem 0.5rem;
+    border-radius: var(--radius-full, 9999px);
+    font-size: var(--text-xs, 0.75rem);
+    font-weight: 500;
+    line-height: 1;
+}
+
+.hf-preview-card__band-badge--safe {
+    background: rgba(63, 185, 80, 0.16);
+    color: var(--success, #3fb950);
+    border: 1px solid rgba(63, 185, 80, 0.35);
+}
+
+.hf-preview-card__band-badge--caution {
+    background: rgba(210, 153, 34, 0.16);
+    color: var(--warning, #d29922);
+    border: 1px solid rgba(210, 153, 34, 0.35);
+}
+
+.hf-preview-card__band-badge--risk {
+    background: rgba(248, 81, 73, 0.16);
+    color: var(--danger, #f85149);
+    border: 1px solid rgba(248, 81, 73, 0.35);
+}
+
+.hf-preview-card__divider {
+    height: 1px;
+    background: var(--border, #30363d);
+    margin: 0.5rem 0;
+}
+
+.hf-preview-card__metrics {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.hf-preview-card__metric {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: var(--text-xs, 0.75rem);
+}
+
+.hf-preview-card__metric-label {
+    color: var(--muted, #8b949e);
+}
+
+.hf-preview-card__metric-value {
+    color: var(--text, #e6edf3);
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+}
+
+.hf-preview-card__formula {
+    font-size: 0.7rem;
+    color: var(--muted, #8b949e);
+    line-height: 1.3;
+    font-variant-numeric: tabular-nums;
+}
+

--- a/src/pages/CreditLines.tsx
+++ b/src/pages/CreditLines.tsx
@@ -16,10 +16,13 @@ import type {
   SortDirection,
 } from "../types/creditLine";
 import type { CollateralAsset } from "../types/collateral";
+import { PreviewCard } from '../components/PreviewCard';
 import {
   HealthFactorChart,
   buildHealthHistory,
   deriveHealthFactor,
+  healthBand,
+  healthBandLabel,
 } from '../components/HealthFactorChart';
 import {
   COLOR,
@@ -80,7 +83,7 @@ function CreditLineCard({
 
   return (
     <div
-      className={`cl-card status-${line.status.toLowerCase()}${isDefaulted ? " cl-row--defaulted" : ""} focus-ring`}
+      className={`cl-card status-${line.status.toLowerCase()}${isDefaulted ? " cl-row--defaulted" : ""} preview-card-trigger focus-ring`}
       aria-label={
         isDefaulted ? `Credit line ${line.id} is defaulted` : undefined
       }
@@ -192,12 +195,51 @@ function CreditLineCard({
 
         {(() => {
           const hf = deriveHealthFactor(line.limit, line.utilized);
+          const band = healthBand(hf);
           return (
-            <HealthFactorChart
-              lineName={line.name}
-              current={hf}
-              data={buildHealthHistory(hf)}
-            />
+            <PreviewCard
+              preview={
+                <div className="hf-preview-card">
+                  <div className="hf-preview-card__header">
+                    <span className="hf-preview-card__label">Health Factor</span>
+                    <span className={`hf-preview-card__value hf-preview-card__value--${band}`}>
+                      {hf.toFixed(2)}
+                    </span>
+                  </div>
+                  <div className="hf-preview-card__band">
+                    <span className={`hf-preview-card__band-badge hf-preview-card__band-badge--${band}`}>
+                      {healthBandLabel(band)}
+                    </span>
+                  </div>
+                  <div className="hf-preview-card__divider" />
+                  <div className="hf-preview-card__metrics">
+                    <div className="hf-preview-card__metric">
+                      <span className="hf-preview-card__metric-label">Limit</span>
+                      <span className="hf-preview-card__metric-value">{fmt(line.limit)}</span>
+                    </div>
+                    <div className="hf-preview-card__metric">
+                      <span className="hf-preview-card__metric-label">Utilized</span>
+                      <span className="hf-preview-card__metric-value">{fmt(line.utilized)}</span>
+                    </div>
+                    <div className="hf-preview-card__metric">
+                      <span className="hf-preview-card__metric-label">Available</span>
+                      <span className="hf-preview-card__metric-value">{fmt(line.limit - line.utilized)}</span>
+                    </div>
+                  </div>
+                  <div className="hf-preview-card__divider" />
+                  <div className="hf-preview-card__formula">
+                    HF = Limit ÷ Utilized = {fmt(line.limit)} ÷ {fmt(line.utilized)} = {hf.toFixed(2)}
+                  </div>
+                </div>
+              }
+              ariaLabel={`Health factor preview for ${line.name}`}
+            >
+              <HealthFactorChart
+                lineName={line.name}
+                current={hf}
+                data={buildHealthHistory(hf)}
+              />
+            </PreviewCard>
           );
         })()}
 

--- a/src/pages/__tests__/CreditLines.test.tsx
+++ b/src/pages/__tests__/CreditLines.test.tsx
@@ -118,6 +118,24 @@ describe('CreditLines page', () => {
     expect(card?.textContent).toMatch(/Opened/);
   });
 
+  it('renders hover-preview card with health factor breakdown on each credit line card', () => {
+    renderPage();
+    // Each card should have a hidden health factor preview region
+    const previewRegions = screen.getAllByRole('region', { hidden: true });
+    const healthPreviews = previewRegions.filter((r) =>
+      r.getAttribute('aria-label')?.startsWith('Health factor preview for'),
+    );
+    expect(healthPreviews.length).toBeGreaterThanOrEqual(3);
+    // Each preview should contain health factor details
+    healthPreviews.forEach((preview) => {
+      expect(preview.textContent).toMatch(/Health Factor/);
+      expect(preview.textContent).toMatch(/Safe|Caution|At risk/);
+      expect(preview.textContent).toMatch(/Limit/);
+      expect(preview.textContent).toMatch(/Utilized/);
+      expect(preview.textContent).toMatch(/Available/);
+    });
+  });
+
   describe("skeleton loading state", () => {
     beforeEach(() => {
       vi.useFakeTimers();


### PR DESCRIPTION
## Summary

Adds a hover-triggered preview card (PreviewCard) to the HealthFactorChart on each credit line card, showing a detailed health factor breakdown.

## Changes

- **CreditLines.tsx**: Imported `PreviewCard`, `healthBand`, and `healthBandLabel`. Wrapped the `HealthFactorChart` in each `CreditLineCard` with a `PreviewCard` that shows:
  - Health factor value (color-coded: safe/green, caution/yellow, risk/red)
  - Band badge (Safe / Caution / At risk)
  - Credit line metrics: Limit, Utilized, Available
  - HF formula: `HF = Limit ÷ Utilized = value`
- Added `preview-card-trigger` class to the `CreditLineCard` root div for hover/focus activation
- **CreditLines.css**: Added styles for the health factor preview card (`.hf-preview-card` BEM classes)
- **CreditLines.test.tsx**: Added test verifying the preview card renders on each credit line with correct content

## Accessibility

- Preview region has `role="region"` and `aria-label` for screen readers
- WCAG 2.1 AA compliant via existing PreviewCard component
- Tabular-nums on metric values for numeric alignment

Closes #845