### PR TITLE
fix: ensure keyboard-only focus outlines on every interactive element in CreditLines (Closes #815)

### DIFF
--- a/src/components/CreditLineRowMenu.tsx
+++ b/src/components/CreditLineRowMenu.tsx
@@ -83,7 +83,7 @@ export function CreditLineRowMenu({
               setIsOpen(false);
               if (onRepay) onRepay();
             }}
-            className="flex w-full items-center gap-3 px-4 py-2 text-sm text-foreground hover:bg-accent/10 hover:text-accent transition-colors text-left"
+            className="focus-ring cl-row-menu-item flex w-full items-center gap-3 px-4 py-2 text-sm text-foreground hover:bg-accent/10 hover:text-accent transition-colors text-left"
             role="menuitem"
           >
             <ArrowUpCircle className="w-4 h-4" />
@@ -94,7 +94,7 @@ export function CreditLineRowMenu({
           <Link
             to={`/draw-credit?line=${lineId}`}
             onClick={() => setIsOpen(false)}
-            className="flex w-full items-center gap-3 px-4 py-2 text-sm text-foreground hover:bg-accent/10 hover:text-accent transition-colors"
+            className="focus-ring cl-row-menu-item flex w-full items-center gap-3 px-4 py-2 text-sm text-foreground hover:bg-accent/10 hover:text-accent transition-colors"
             role="menuitem"
           >
             <ArrowDownCircle className="w-4 h-4" />
@@ -109,7 +109,7 @@ export function CreditLineRowMenu({
                 if (frozen && onUnfreeze) onUnfreeze(lineId);
                 else if (!frozen && onFreeze) onFreeze(lineId);
               }}
-              className="flex w-full items-center gap-3 px-4 py-2 text-sm text-foreground hover:bg-accent/10 hover:text-accent transition-colors text-left"
+              className="focus-ring cl-row-menu-item flex w-full items-center gap-3 px-4 py-2 text-sm text-foreground hover:bg-accent/10 hover:text-accent transition-colors text-left"
               role="menuitem"
             >
               <Snowflake className="w-4 h-4" />
@@ -123,7 +123,7 @@ export function CreditLineRowMenu({
               setIsOpen(false);
               if (onSchedule) onSchedule(lineId);
             }}
-            className="flex w-full items-center gap-3 px-4 py-2 text-sm text-foreground hover:bg-accent/10 hover:text-accent transition-colors text-left"
+            className="focus-ring cl-row-menu-item flex w-full items-center gap-3 px-4 py-2 text-sm text-foreground hover:bg-accent/10 hover:text-accent transition-colors text-left"
             role="menuitem"
           >
             <Calendar className="w-4 h-4" />
@@ -136,7 +136,7 @@ export function CreditLineRowMenu({
               setIsOpen(false);
               if (onDetails) onDetails(lineId);
             }}
-            className="flex w-full items-center gap-3 px-4 py-2 text-sm text-foreground hover:bg-accent/10 hover:text-accent transition-colors text-left"
+            className="focus-ring cl-row-menu-item flex w-full items-center gap-3 px-4 py-2 text-sm text-foreground hover:bg-accent/10 hover:text-accent transition-colors text-left"
             role="menuitem"
           >
             <Info className="w-4 h-4" />

--- a/src/pages/__tests__/CreditLines.focusVisible.test.tsx
+++ b/src/pages/__tests__/CreditLines.focusVisible.test.tsx
@@ -63,6 +63,14 @@ describe('focus.css — CreditLines (#691) coverage', () => {
     expect(css).toContain('.cl-card [aria-haspopup="true"]:focus-visible');
   });
 
+  it('defines a focus-visible rule for the row-menu dropdown items', () => {
+    expect(css).toContain('.cl-row-menu-item:focus-visible');
+  });
+
+  it('defines a focus-within rule for the compare checkbox label', () => {
+    expect(css).toContain('.cl-row-select:focus-within');
+  });
+
   it('uses :focus-visible, never bare :focus, for these rules', () => {
     for (const selector of ['.cl-primary-btn', '.cl-sort-dir', '.cl-card']) {
       const bareFocus = new RegExp(`\\${selector}:focus(?!-visible)\\b`);

--- a/src/styles/focus.css
+++ b/src/styles/focus.css
@@ -284,6 +284,7 @@
     .cl-row-select input        — per-card compare checkboxes
     [aria-haspopup="true"]      — CreditLineRowMenu 3-dot trigger (belt-and-suspenders
                                   fallback in case Tailwind utilities aren't active)
+    .cl-row-menu-item           — CreditLineRowMenu dropdown action items
 */
 
 .cl-primary-btn:focus-visible,
@@ -291,7 +292,15 @@
 .cl-card:focus-visible,
 .cl-filters select:focus-visible,
 .cl-row-select input:focus-visible,
-.cl-card [aria-haspopup="true"]:focus-visible {
+.cl-card [aria-haspopup="true"]:focus-visible,
+.cl-row-menu-item:focus-visible {
+  outline: var(--focus-ring-width, 2px) solid var(--focus-ring-color, #58a6ff);
+  outline-offset: var(--focus-ring-offset, 3px);
+  border-radius: var(--focus-ring-radius, 6px);
+}
+
+/* Ensure the selected compare checkbox label gets a ring too */
+.cl-row-select:focus-within {
   outline: var(--focus-ring-width, 2px) solid var(--focus-ring-color, #58a6ff);
   outline-offset: var(--focus-ring-offset, 3px);
   border-radius: var(--focus-ring-radius, 6px);


### PR DESCRIPTION
## Summary

Ensures every interactive element on the CreditLines page has a visible keyboard focus outline (WCAG 2.1 AA 2.4.7 Focus Visible).

## Changes

### src/styles/focus.css
- Added `.cl-row-menu-item:focus-visible` rule for CreditLineRowMenu dropdown action items (Repay, Draw, Freeze, Schedule, Details)
- Added `.cl-row-select:focus-within` rule for the compare checkbox label wrapper

### src/components/CreditLineRowMenu.tsx
- Added `focus-ring` and `cl-row-menu-item` classes to all 5 dropdown menu items (Repay, Draw, Freeze/Unfreeze, Schedule, Details)

### src/pages/__tests__/CreditLines.focusVisible.test.tsx
- Added test for `.cl-row-menu-item:focus-visible` CSS rule
- Added test for `.cl-row-select:focus-within` CSS rule

## Testing
- All 16 tests in `CreditLines.focusVisible.test.tsx` pass
- Pre-existing test failures in `CreditLines.test.tsx` and `CreditLines.reduced-motion.test.tsx` are unrelated to these changes

Closes #815